### PR TITLE
Added translations for supply_transport_trains, updated supply_transport_road_transport. Closes #1393.

### DIFF
--- a/config/locales/en_slides.yml
+++ b/config/locales/en_slides.yml
@@ -117,4 +117,5 @@ en:
     supply_transport_gasoline: "Gasoline for road transport"
     supply_transport_marine_fuels: "Domestic navigation"
     supply_transport_public_transport_technologies: "Public transport fuels"
-    supply_transport_road_transport: "Road"
+    supply_transport_road_transport: "Road transport"
+    supply_transport_trains: "Rail transport"

--- a/config/locales/nl_slides.yml
+++ b/config/locales/nl_slides.yml
@@ -118,4 +118,4 @@ nl:
     supply_transport_marine_fuels: "Binnenlandse scheepvaart"
     supply_transport_public_transport_technologies: "Energiedragers openbaar vervoer"
     supply_transport_road_transport: "Wegverkeer"
-
+    supply_transport_trains: "Treinverkeer"


### PR DESCRIPTION
I added a Dutch and English translation for supply_transport_trains. In addition, I changed the English translation for the key supply_transport_road_transport to be more consistent with the other slides in this page.
