### PR TITLE
Added translations for the Fce and Merit categories in the chart picker.

### DIFF
--- a/config/locales/en_output_elements.yml
+++ b/config/locales/en_output_elements.yml
@@ -7,6 +7,8 @@ en:
     supply: "Supply"
     demand: "Demand"
     cost: "Costs"
+    fce: "Fuel chain emissions"
+    merit: "Merit order"
   output_elements:
     common:
       old_browser: "Sorry! This chart is not supported by your browser. Please use Google Chrome, Firefox or Safari or Internet Explorer version 9 or higher."

--- a/config/locales/nl_output_elements.yml
+++ b/config/locales/nl_output_elements.yml
@@ -5,6 +5,8 @@ nl:
     supply: "Aanbod"
     demand: "Vraag"
     cost: "Kosten"
+    fce: "Ketenanalyse"
+    merit: "Merit order"
   output_elements:
     common:
       old_browser: "Sorry! Deze grafiek werkt niet in uw browser. Gebruik a.u.b. Google Chrome, Firefox, Safari of Internet Explorer versie 9 of nieuwer."


### PR DESCRIPTION
See https://github.com/quintel/etmodel/issues/1616 (comments).
