### PR TITLE
Simplify permit!

### DIFF
--- a/app/controllers/admin/constraints_controller.rb
+++ b/app/controllers/admin/constraints_controller.rb
@@ -65,12 +65,7 @@ module Admin
     end
 
     def constraint_parameters
-      params.require(:constraint).permit(:key,
-                                         :group,
-                                         :gquery_key,
-                                         :disabled,
-                                         :description_attributes,
-                                         :area_dependency_attributes)
+      params.require(:constraint).permit!
     end
   end
 end

--- a/app/controllers/admin/general_user_notifications_controller.rb
+++ b/app/controllers/admin/general_user_notifications_controller.rb
@@ -51,10 +51,8 @@ module Admin
     #######
 
     def general_user_notification_parameters
-      params.require(:general_user_notification).permit(:key,
-                                                        :notification_nl,
-                                                        :notification_en,
-                                                        :active)
+      params.require(:general_user_notification).permit!
+
     end
     def find_notification
       @notification = GeneralUserNotification.find params[:id]

--- a/app/controllers/admin/input_elements_controller.rb
+++ b/app/controllers/admin/input_elements_controller.rb
@@ -19,7 +19,7 @@ module Admin
     end
 
     def create
-      @input_element = InputElement.new(params[:input_element])
+      @input_element = InputElement.new(input_element_parameters)
 
       if @input_element.save
         flash[:notice] = "InputElement saved"
@@ -32,7 +32,7 @@ module Admin
     def update
       @input_element = InputElement.find(params[:id])
 
-      if @input_element.update_attributes(params[:input_element])
+      if @input_element.update_attributes(input_element_parameters)
         ["nl","en"].each do |l|
           expire_fragment("slider_#{@input_element.id}_#{l}")
         end
@@ -61,16 +61,23 @@ module Admin
       @input_element.build_area_dependency unless @input_element.area_dependency
     end
 
+    #######
     private
+    #######
 
-      def find_model
-        if params[:version_id]
-          @version = Version.find(params[:version_id])
-          @input_element = @version.reify
-          flash[:notice] = "Revision"
-        else
-          @input_element = InputElement.find(params[:id])
-        end
+    def input_element_parameters
+      params.require(:input_element).permit!
+    end
+
+    def find_model
+      if params[:version_id]
+        @version = Version.find(params[:version_id])
+        @input_element = @version.reify
+        flash[:notice] = "Revision"
+      else
+        @input_element = InputElement.find(params[:id])
       end
+    end
+
   end
 end

--- a/app/controllers/admin/output_element_series_controller.rb
+++ b/app/controllers/admin/output_element_series_controller.rb
@@ -70,17 +70,7 @@ module Admin
 
     def oes_parameters
       if params[:output_element_serie]
-        params.require(:output_element_serie).permit(:label,
-                                                     :color,
-                                                     :order_by,
-                                                     :group,
-                                                     :show_at_first,
-                                                     :is_target_line,
-                                                     :target_line_position,
-                                                     :gquery,
-                                                     :output_element_id,
-                                                     :area_dependency_attributes,
-                                                     :description_attributes)
+        params.require(:output_element_serie).permit!
       end
     end
 

--- a/app/controllers/admin/output_elements_controller.rb
+++ b/app/controllers/admin/output_elements_controller.rb
@@ -63,17 +63,7 @@ module Admin
 
     def oe_attributes
       if params[:output_element]
-        params.require(:output_element).permit(:output_element_type_id,
-                                               :under_construction,
-                                               :unit,
-                                               :percentage,
-                                               :group,
-                                               :show_point_label,
-                                               :growth_chart,
-                                               :key,
-                                               :max_axis_value,
-                                               :min_axis_value,
-                                               :hidden)
+        params.require(:output_element).permit!
       end
     end
 

--- a/app/controllers/admin/sidebar_items_controller.rb
+++ b/app/controllers/admin/sidebar_items_controller.rb
@@ -53,9 +53,7 @@ module Admin
     #######
 
     def sidebar_item_parameters
-      params(:sidebar_item).require(:key, :section, :percentage_bar_query,
-                                    :nl_vimeo_id, :en_vimeo_id, :tab_id,
-                                    :position, :parent_id)
+      params.require(:sidebar_item).permit!
     end
 
     def find_model

--- a/app/controllers/admin/slides_controller.rb
+++ b/app/controllers/admin/slides_controller.rb
@@ -53,15 +53,7 @@ module Admin
 
     def slide_parameters
       if params[:slide]
-        params.require(:slide).permit(:image,
-                                      :general_sub_header,
-                                      :group_sub_header,
-                                      :subheader_image,
-                                      :key,
-                                      :position,
-                                      :sidebar_item_id,
-                                      :output_element_id,
-                                      :alt_output_element_id)
+        params.require(:slide).permit!
       end
     end
 

--- a/app/controllers/admin/tabs_controller.rb
+++ b/app/controllers/admin/tabs_controller.rb
@@ -54,7 +54,7 @@ module Admin
     end
 
     def tab_parameters
-      params.require(:tab).permit(:key, :nl_vimeo_id, :en_vimeo_id, :position)
+      params.require(:tab).permit!
     end
   end
 end

--- a/app/controllers/admin/texts_controller.rb
+++ b/app/controllers/admin/texts_controller.rb
@@ -40,13 +40,7 @@ module Admin
 
     def text_parameters
       if params[:text]
-        params.require(:text).permit(:key,
-                                     :content_en,
-                                     :content_nl,
-                                     :title_en,
-                                     :title_nl,
-                                     :short_content_en,
-                                     :short_content_nl)
+        params.require(:text).permit!
       end
     end
 

--- a/app/models/slide.rb
+++ b/app/models/slide.rb
@@ -19,8 +19,6 @@
 class Slide < ActiveRecord::Base
   include AreaDependent
 
-  
-
   belongs_to :sidebar_item
   has_one :description, :as => :describable
   has_many :sliders, :dependent => :nullify, :class_name => 'InputElement'


### PR DESCRIPTION
We can replace all the strong parameters for admins with `permit` to make it easier.
