### PR TITLE
Removed has_energy_import from area.rb

### DIFF
--- a/app/models/api/area.rb
+++ b/app/models/api/area.rb
@@ -12,7 +12,6 @@ class Api::Area < ActiveResource::Base
     :has_cold_network,
     :has_employment,
     :has_fce,
-    :has_heat_import,
     :has_industry,
     :has_lignite,
     :has_merit_order,


### PR DESCRIPTION
See also https://github.com/quintel/etsource/pull/756.
Closes https://github.com/quintel/etsource/issues/748.
