### PR TITLE
Hide Accordion`s H3 when there is only one

### DIFF
--- a/app/views/scenarios/_slide.html.haml
+++ b/app/views/scenarios/_slide.html.haml
@@ -3,7 +3,8 @@
   %h3{:class               => item_class,
       'data-slide'         => slide.url,
       'data-default_chart' => slide.output_element_id,
-      'data-alt_chart'     => slide.alt_output_element_id}
+      'data-alt_chart'     => slide.alt_output_element_id,
+      'style'              => @interface.slides.size == 1 ? 'display:none;' : ''}
     = link_to t("slides.#{slide.key}").html_safe, slide.url
   .slide
     %p


### PR DESCRIPTION
I removed the header from the accordion when there is only one, but it feel too much like it is breaking the design.

![image](https://cloud.githubusercontent.com/assets/104830/4918261/59227eee-64ef-11e4-9705-061f9fb55eec.png)


Not yet ready to be merged yet! What do you think @antw and @ChaelKruip ?