### PR TITLE
Make scaling of scenario more obvious

### DIFF
--- a/app/views/layouts/etm/_settings_menu.html.haml
+++ b/app/views/layouts/etm/_settings_menu.html.haml
@@ -29,6 +29,9 @@
         %a#reset_scenario{:href => scenario_reset_path}= t("header.reset_scenario")
     - if controller_name != 'pages' && has_active_scenario?
       %li.sep
+      %li.scenario_option
+        = link_to t('header.scale_scenario'), scaled_path
+      %li.sep
 
       - if Current.setting.use_peak_load
         %li.scenario_option

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -45,6 +45,7 @@ en:
     feedback: "Feedback"
     information: "Information"
     load_scenario: "Load scenario"
+    scale_scenario: 'Create testing ground'
     merit_order_check: "Enable merit order"
     notify_of_grid_investments: "Grid investment notification"
     overview: "Overview"

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -44,6 +44,7 @@ nl:
     feedback: "Reacties"
     information: "Informatie"
     load_scenario: "Scenario laden"
+    scale_scenario: 'Converteer naar proeftuin'
     merit_order_check: "Gebruik merit order"
     notify_of_grid_investments: "Melding netwerkkosten"
     overview: "Overview"


### PR DESCRIPTION
I've added an item to the menu

#### To consider:

- [ ] What if this is an already scaled scenario?
- [ ] Can we do this for all Areas?
- [ ] The flow is not logical now: you still have to save the scenario first. Could we add an option to the select list of the **Current* scenario?

