### PR TITLE
LNG FCE slide merge with Natural gas FCE slide

### DIFF
--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -228,6 +228,8 @@ en:
     grid_composition: "gas composition in national network"
     grid_greengas: "composition greengas"
     grid_natural_gas: "composition natural gas"
+    pipeline_natural_gas: "pipeline natural gas"
+    liquefied_natural_gas: "liquefied natural gas"
     demand_percentage: "% of total demand"
     bio_ethanol_group: "Bio-ethanol"
     biodiesel_group: "Biodiesel"

--- a/config/locales/en_slides.yml
+++ b/config/locales/en_slides.yml
@@ -76,7 +76,6 @@ en:
     fce_coal: "Coal"
     fce_gas: "Natural gas"
     fce_greengas: "Green gas"
-    fce_lng: "Liquefied Natural Gas (LNG)"
     fce_settings: "FCE settings"
     fce_oil: "Mineral oil"
     fce_uranium: "Uranium"

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -228,6 +228,8 @@ nl:
     grid_composition: "gas samenstelling in nationale netwerk"
     grid_greengas: "samenstelling groengas"
     grid_natural_gas: "samenstelling aardgas"
+    pipeline_natural_gas: "pipeline natural gas"
+    liquefied_natural_gas: "liquefied natural gas"
     lng_road_mix: "samenstelling vloeibaar aardgas (LNG)"
     demand_percentage: "% van totale vraag"
     bio_feedstock: "bio grondstof"

--- a/config/locales/nl_slides.yml
+++ b/config/locales/nl_slides.yml
@@ -73,7 +73,6 @@ nl:
     fce_coal: "Kolen"
     fce_gas: "Aardgas"
     fce_greengas: "Groengas"
-    fce_lng: "Vloeibaar aardgas (LNG)"
     fce_settings: "FCE Opties"
     fce_oil: "Aardolie"
     fce_uranium: "Uranium"


### PR DESCRIPTION
As discussed and agreed in https://github.com/quintel/etmodel/issues/1953 , the two FCE slides for LNG and natural gas will be merged into the latter. In that slide, there will be a distinction between the (interface) group `pipeline natural gas` and `liquefied natural gas`. The old LNG FCE slide will be deleted.

This pull request adds translations for the new interface groups and removes the old fce_lng slide's translations.