### PR TITLE
Removed translations for existing gas_from_middle_east share

### DIFF
--- a/config/locales/en_input_elements.yml
+++ b/config/locales/en_input_elements.yml
@@ -72,7 +72,6 @@ en:
     employment_local_fraction: "Local production labor"
     energy_cokesoven_transformation_coal_share: "% of cokes locally produced"
     gas_from_algeria_share: "Algeria"
-    gas_from_middle_east_share: "Middle East"
     gas_from_nederlands_share: "Netherlands"
     gas_from_norway_share: "Norway"
     gas_from_russia_share: "Russia"

--- a/config/locales/nl_input_elements.yml
+++ b/config/locales/nl_input_elements.yml
@@ -72,7 +72,6 @@ nl:
     employment_local_fraction: "Binnenlandse arbeid (productiefase)"
     energy_cokesoven_transformation_coal_share: "% van cokes lokaal geproduceerd"
     gas_from_algeria_share: "Algerije"
-    gas_from_middle_east_share: "Midden-Oosten"
     gas_from_nederlands_share: "Nederland"
     gas_from_norway_share: "Noorwegen"
     gas_from_russia_share: "Rusland"


### PR DESCRIPTION
As decided in quintel/etmodel#1953 , the FCE gas_from_middle_east_share will be deleted (done in https://github.com/quintel/etsource/pull/1007) and this PR deletes the translations for that input statement.