### PR TITLE
Adding output element id to constraints

### DIFF
--- a/app/models/constraint.rb
+++ b/app/models/constraint.rb
@@ -44,6 +44,7 @@ class Constraint < ActiveRecord::Base
 
   validates :group, :presence => true, :inclusion => GROUPS
 
+  belongs_to :output_element
   has_one :description, :as => :describable, :dependent => :destroy
   has_one :area_dependency, :as => :dependable, :dependent => :destroy
 

--- a/app/views/constraints/_bio_footprint.html.haml
+++ b/app/views/constraints/_bio_footprint.html.haml
@@ -4,8 +4,6 @@
   map      = "/assets/maps/#{country}_map.png"
   map_grey = "/assets/maps/#{country}_map_gray.png"
 
-.description= @constraint.description.try :short_content
-
 .item
   .present{:style => "background: url(#{map_grey}) repeat-x;"}
     %h3.tal= Current.setting.start_year

--- a/app/views/constraints/_co2_reduction.html.haml
+++ b/app/views/constraints/_co2_reduction.html.haml
@@ -1,3 +1,0 @@
-.description= @constraint.description.try :short_content
-#charts
-  .chart{:'data-chart_id' => 46}

--- a/app/views/constraints/_costs_fte.html.haml
+++ b/app/views/constraints/_costs_fte.html.haml
@@ -1,1 +1,0 @@
-.description= @constraint.description.try :short_content

--- a/app/views/constraints/_employment.html.haml
+++ b/app/views/constraints/_employment.html.haml
@@ -1,3 +1,0 @@
-.description= @constraint.description.try :short_content
-#charts
-  .chart{:'data-chart_id' => 118}

--- a/app/views/constraints/_household_energy_cost.html.haml
+++ b/app/views/constraints/_household_energy_cost.html.haml
@@ -1,3 +1,0 @@
-.description= @constraint.description.try :short_content
-#charts
-  .chart{:'data-chart_id' => 113}

--- a/app/views/constraints/_local_co2_reduction.html.haml
+++ b/app/views/constraints/_local_co2_reduction.html.haml
@@ -1,3 +1,0 @@
-.description= @constraint.description.try :short_content
-#charts
-  .chart{:'data-chart_id' => 46}

--- a/app/views/constraints/_loss_of_load.html.haml
+++ b/app/views/constraints/_loss_of_load.html.haml
@@ -1,3 +1,0 @@
-.description= @constraint.description.try :short_content
-#charts
-  .chart{:'data-chart_id' => 111}

--- a/app/views/constraints/_net_energy_import.html.haml
+++ b/app/views/constraints/_net_energy_import.html.haml
@@ -1,5 +1,3 @@
-.description= @constraint.description.try :short_content
-
 %table.energy_imports
   %thead
     %tr

--- a/app/views/constraints/_profitability.html.haml
+++ b/app/views/constraints/_profitability.html.haml
@@ -1,3 +1,0 @@
-.description= @constraint.description.try :content
-#charts
-  .chart{:'data-chart_id' => 140}

--- a/app/views/constraints/_renewable_electricity_percentage.html.haml
+++ b/app/views/constraints/_renewable_electricity_percentage.html.haml
@@ -1,4 +1,0 @@
-.description= @constraint.description.try :short_content
-#charts
-  .chart{:'data-chart_id' => 112}
-

--- a/app/views/constraints/_renewable_percentage.html.haml
+++ b/app/views/constraints/_renewable_percentage.html.haml
@@ -1,3 +1,0 @@
-.description= @constraint.description.try :short_content
-#charts
-  .chart{:'data-chart_id' => 49}

--- a/app/views/constraints/_score.html.haml
+++ b/app/views/constraints/_score.html.haml
@@ -1,3 +1,0 @@
-.description= @constraint.description.try :short_content
-#charts
-  Nothing here yet.

--- a/app/views/constraints/_security_of_supply.html.haml
+++ b/app/views/constraints/_security_of_supply.html.haml
@@ -1,3 +1,0 @@
-.description= @constraint.description.try :short_content
-#charts
-  Nothing here yet.

--- a/app/views/constraints/_total_energy_cost.html.haml
+++ b/app/views/constraints/_total_energy_cost.html.haml
@@ -1,3 +1,0 @@
-.description= @constraint.description.try :short_content
-#charts
-  .chart{:'data-chart_id' => 48}

--- a/app/views/constraints/_total_primary_energy.html.haml
+++ b/app/views/constraints/_total_primary_energy.html.haml
@@ -1,3 +1,0 @@
-.description= @constraint.description.try :short_content
-#charts
-  .chart{:'data-chart_id' => 45}

--- a/app/views/constraints/show.html.haml
+++ b/app/views/constraints/show.html.haml
@@ -1,6 +1,18 @@
 #dashboard_popup{class: @constraint.key}
-  %h2= t("constraints.#{@constraint.key}.title").html_safe
-  = render :partial => @constraint.key
+  %h2
+    - if @constraint.output_element
+      = t("output_elements.#{@constraint.output_element.key}").html_safe
+    - else
+      = t("constraints.#{@constraint.key}.title").html_safe
+
+  - if @constraint.description
+    .description= @constraint.description.try :short_content
+
+  - if @constraint.chart_number
+    #charts
+      .chart{:'data-chart_id' => @constraint.chart_number}
+
+  = render partial: @constraint.key rescue nil
 
   = render 'output_elements/chart_template'
   :javascript

--- a/db/migrate/20160122125506_add_output_element_id_to_constraints.rb
+++ b/db/migrate/20160122125506_add_output_element_id_to_constraints.rb
@@ -1,0 +1,24 @@
+class AddOutputElementIdToConstraints < ActiveRecord::Migration
+  def change
+    add_column :constraints, :output_element_id, :integer
+    add_column :constraints, :chart_number, :integer
+
+    chart_numbers = {
+      'co2_reduction' => 46,
+      'employment' => 118,
+      'household_energy_cost' => 113,
+      'local_co2_reduction' => 46,
+      'loss_of_load' => 111,
+      'profitability' => 140,
+      'renewable_electricity_percentage' => 112,
+      'renewable_percentage' => 49,
+      'total_energy_cost' => 48,
+      'total_primary_energy' => 45
+    }
+
+    chart_numbers.each_pair do |key, chart_number|
+      Constraint.find_by_key(key)
+        .update_attribute(:chart_number, chart_number)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141128142852) do
+ActiveRecord::Schema.define(version: 20160122125506) do
 
   create_table "area_dependencies", force: true do |t|
     t.string  "dependent_on"
@@ -27,9 +27,11 @@ ActiveRecord::Schema.define(version: 20141128142852) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "gquery_key"
-    t.string   "group",      limit: 25,                 null: false
+    t.string   "group",             limit: 25,                 null: false
     t.integer  "position"
-    t.boolean  "disabled",              default: false
+    t.boolean  "disabled",                     default: false
+    t.integer  "output_element_id"
+    t.integer  "chart_number"
   end
 
   add_index "constraints", ["disabled"], name: "index_constraints_on_disabled", using: :btree


### PR DESCRIPTION
Includes cleaning up the constraints.

Next to the now obsolete partials of constraints that existed in the database. I found two placeholder partials (`security_of_supply` and `score`) which I throwed away considering that they weren't rendered anyway. 

Fixes: #1847 