### PR TITLE
Style flexibility order

### DIFF
--- a/app/assets/javascripts/lib/views/base_chart_view.coffee
+++ b/app/assets/javascripts/lib/views/base_chart_view.coffee
@@ -110,19 +110,21 @@ class @BaseChartView extends Backbone.View
       base_url = "#{ App.scenario.url_path() }/flexibility_order/"
 
       $.ajax
-        url: "#{ base_url}get",
+        url: "#{ base_url }get",
         type: 'GET',
         success: (data) ->
           Sortable.create sortable_el,
-            filter: '.ignore',
-            ghostClass: 'ghost',
-            animation: 150,
+            ghostClass: 'ghost'
+            animation: 150
             store:
               get: (sortable) ->
                 data.order.concat(['curtailment'])
 
               set: (sortable) ->
-                self.update_flexibility_order("#{ base_url }set", sortable.toArray())
+                self.update_flexibility_order(
+                  "#{ base_url }set",
+                  sortable.toArray().concat(['curtailment'])
+                )
 
   update_lock_icon: =>
     icon = @$el.find('a.lock_chart')

--- a/app/assets/stylesheets/sortable.sass
+++ b/app/assets/stylesheets/sortable.sass
@@ -1,37 +1,89 @@
+.sortable-container
+  background: #eee
+  border-radius: 4px
+  margin-bottom: 10px
+  padding: 4px
+  counter-reset: section
+
 ul.sortable
   padding-left: 0
-  border: 1px solid #eee
 
-  li
-    list-style-type: none
-    padding: 10px 14px
-    border-bottom: 1px solid #eee
+ul.sortable li, #flexibility-options .curtailment
+  background: white
+  border: 1px solid #ddd
+  list-style-type: none
+  margin-bottom: -1px
+  overflow: hidden
+  padding: 10px 14px 10px 50px
+  position: relative
 
-    span.fa-bars
-      float: right
-      line-height: 18px
-      color: #BBB
-      -webkit-transform: scale(1.5, 1.0)
-      -moz-transform: scale(1.5, 1.0)
-      -ms-transform: scale(1.5, 1.0)
-      -o-transform: scale(1.5, 1.0)
-      transform: scale(1.5, 1.0)
+  &:before
+    bottom: 0px
+    background: linear-gradient(white, #fafafa)
+    border-right: 1px solid #ddd
+    color: #999
+    counter-increment: section
+    content: counter(section)
+    display: inline-block
+    left: 0px
+    padding: 10px 14px 0
+    position: absolute
+    right: 0px
+    text-align: center
+    top: 0px
+    width: 10px
 
-    &.ignore
-      color: #999
+  span.fa
+    color: #BBB
+    float: right
+    line-height: 18px
+    margin-top: 2px
 
-    &.ghost
-      opacity: 0.1
-      background: #ddd
+ul.sortable li
+  cursor: grab
+  cursor: -webkit-grab
 
-    &:last-child
-      border-bottom: none
+  &:first-child
+    border-top-left-radius: 3px
+    border-top-right-radius: 3px
 
-    &:not(.ignore)
-      cursor: grab
-      cursor: -webkit-grab
+  &:last-child
+    border-bottom-left-radius: 3px
+    border-bottom-right-radius: 3px
 
-      &.sortable-chosen
-        cursor: grabbing
-        cursor: -webkit-grabbing
-        background-color: lighten(#DFE8F3, 5%)
+  .fa
+    -webkit-transform: scale(1.5, 1.0)
+    -moz-transform: scale(1.5, 1.0)
+    -ms-transform: scale(1.5, 1.0)
+    -o-transform: scale(1.5, 1.0)
+    transform: scale(1.5, 1.0)
+
+  &.sortable-chosen
+    &:before
+      content: '-'
+    cursor: grabbing
+    cursor: -webkit-grabbing
+    background-color: lighten(#DFE8F3, 5%)
+
+  &.ghost
+    opacity: 0.2
+    background: #ddd
+    &:before
+      content: counter(section)
+
+#flexibility-options
+  .curtailment
+    border-radius: 3px
+    color: #999
+    cursor: default
+    margin-top: 4px
+    margin-bottom: 0
+
+    .fa
+      color: #ccc
+      font-size: 17px
+      margin-right: 1px
+
+  .curtailment, .sortable li:last-child
+    border-bottom-color: #ccc
+    box-shadow: 0 1px 0 #ddd

--- a/app/views/scenarios/slides/_flexibility_order.html.haml
+++ b/app/views/scenarios/slides/_flexibility_order.html.haml
@@ -1,8 +1,10 @@
-%ul.sortable
-  - %w(power_to_power electric_vehicle power_to_heat power_to_gas export).each do |flexibility_option|
-    %li{data: { id: flexibility_option }}
-      = t("output_elements.flexibility_options.#{ flexibility_option }")
-      %span.fa.fa-bars
+#flexibility-options.sortable-container
+  %ul.sortable
+    - %w(power_to_power electric_vehicle power_to_heat power_to_gas export).each do |flexibility_option|
+      %li{data: { id: flexibility_option }}
+        = t("output_elements.flexibility_options.#{ flexibility_option }")
+        %span.fa.fa-bars
 
-  %li.ignore{data: {id: 'curtailment'}}
+  .curtailment
     = t('output_elements.flexibility_options.curtailment')
+    %span.fa.fa-lock


### PR DESCRIPTION
Changes the style of the flexibility order "sortable" to better fit with other input elements in the application. I wanted to make it more obvious that the technologies are in order of preference and not just a list of technologies. I also wanted to make it clear to users that curtailment is not a sortable option, and is always the final technology.

Also fixed is a problem whereby technologies could be moved beneath curtailment, even though curtailment itself is not supposed to be sortable.

<img width="469" alt="screen shot 2016-02-10 at 10 23 50" src="https://cloud.githubusercontent.com/assets/4383/12944687/abe430ca-cfe0-11e5-9d34-2e991161ad62.png">

--

I tested in Chrome, Firefox and IE11. I don't have an IE9 or 10 to test with right now, but I don't expect any problems (except perhaps for them not showing the subtle background gradient behind the numbers).

Pinging @dennisschoenmakers @ChaelKruip @jorisberkhout @grdw for feedback. :grinning: 