### PR TITLE
Fix calculating the mean line of the price curve in a loop

### DIFF
--- a/app/assets/javascripts/d3/merit_order_hourly_flexibility.coffee
+++ b/app/assets/javascripts/d3/merit_order_hourly_flexibility.coffee
@@ -23,7 +23,7 @@ D3.merit_order_hourly_flexibility =
       @drawChart()
       @dateSelect.setVal(1)
 
-      @drawLegend(@series)
+      @drawLegend(@series.concat(@model.target_series()))
 
       defs = @svg.append('defs')
       defs.append('clipPath')

--- a/app/assets/javascripts/d3/merit_order_price_curve.coffee
+++ b/app/assets/javascripts/d3/merit_order_price_curve.coffee
@@ -19,12 +19,13 @@ D3.merit_order_price_curve =
 
     averageData: ->
       values  = @prices[0].values.slice()
+      mean    = d3.mean(values.map((price) -> price.y))
 
       color:  @average.attributes.color,
       label:  @average.attributes.label,
       key:    'average',
       values: values.map((price) ->
-        x: price.x, y: d3.mean(values.map((price) -> price.y))
+        x: price.x, y: mean
       )
 
     dataForChart: ->


### PR DESCRIPTION
Patch fixes for related issues.

These are not groundbreaking changes but merely serve to make it a bit faster. It does improve the speed of the price curve a lot. 