### PR TITLE
Makes it possible to put multiple merit charts below each-other

### DIFF
--- a/app/assets/stylesheets/chart.sass
+++ b/app/assets/stylesheets/chart.sass
@@ -45,7 +45,7 @@
     position: relative
     .chart_canvas
       // zoomed charts and dashboard popups redefine the height
-      height: 350px
+      min-height: 350px
       background-color: #fff
 
       select.d3-chart-date-select


### PR DESCRIPTION
Fixes: #2114 

I don't think this will break any other tables/chart though but I just want to know why the height is statically defined?