### PR TITLE
Added slider names and chart names for ICT additions

### DIFF
--- a/config/locales/en_input_elements.yml
+++ b/config/locales/en_input_elements.yml
@@ -177,6 +177,8 @@ en:
     industry_useful_demand_for_other_aggregated_industry_other_efficiency: "Efficiency improvement"
     industry_useful_demand_for_other_food: "Size"
     industry_useful_demand_for_other_food_efficiency: "Efficiency improvement"
+    industry_useful_demand_for_other_ict: "Size"
+    industry_useful_demand_for_other_ict_efficiency: "Efficiency improvement"
     industry_useful_demand_for_other_other: "Size"
     industry_useful_demand_for_other_other_efficiency: "Efficiency improvement"
     industry_useful_demand_for_other_paper: "Size"

--- a/config/locales/en_output_element_series.yml
+++ b/config/locales/en_output_element_series.yml
@@ -19,6 +19,7 @@ en:
       gas: "Gas"
       geothermal: "Geothermal"
       households: "Households"
+      ict: "Central ICT"
       industry: "Industry"
       metal: "Metal"
       nuclear: "Nuclear"

--- a/config/locales/en_output_elements.yml
+++ b/config/locales/en_output_elements.yml
@@ -317,6 +317,7 @@ en:
     use_of_final_demand_in_industry_chemical_fertilizers: "Final energy demand in the fertilizer industry"
     use_of_final_demand_in_industry_chemical_other: "Final energy demand in the other chemical industry"
     use_of_final_demand_in_industry_other_food: "Final energy demand in the food industry"
+    use_of_final_demand_in_industry_other_ict: "Final electricity demand in the central ICT industry"
     use_of_final_demand_in_industry_other: "Final energy demand in the other industry"
     use_of_final_demand_in_industry_other_paper: "Final energy demand in the paper industry"
     use_of_final_demand_in_industry_other_detailed: "Final energy demand in the other industry"

--- a/config/locales/en_slides.yml
+++ b/config/locales/en_slides.yml
@@ -60,6 +60,7 @@ en:
     demand_industry_chemical_other: "Chemicals"
     demand_industry_aggregated_chemical_other: "Chemicals"
     demand_industry_other_food: "Food"
+    demand_industry_other_ict: "Central ICT"
     demand_industry_other_paper: "Paper"
     demand_industry_aggregated_other_nl: "Other"
     demand_industry_aggregated_other_other: "Other"

--- a/config/locales/nl_input_elements.yml
+++ b/config/locales/nl_input_elements.yml
@@ -178,6 +178,8 @@ nl:
     industry_useful_demand_for_other_food_efficiency: "Efficiëntieverbetering"
     industry_useful_demand_for_other_other: "Grootte"
     industry_useful_demand_for_other_other_efficiency: "Efficiëntieverbetering"
+    industry_useful_demand_for_other_other: "Grootte"
+    industry_useful_demand_for_other_other_efficiency: "Efficiëntieverbetering"
     industry_useful_demand_for_other_paper: "Grootte"
     industry_useful_demand_for_other_paper_efficiency: "Efficiëntieverbetering"
     industry_chemicals_fertilizers_burner_wood_pellets_share: "Biomassaketel"

--- a/config/locales/nl_output_element_series.yml
+++ b/config/locales/nl_output_element_series.yml
@@ -19,6 +19,7 @@ nl:
       gas: "Gas"
       geothermal: "Geothermisch"
       households: "Huishoudens"
+      ict: "Centrale ICT"
       industry: "Industrie"
       metal: "Metaal"
       nuclear: "Nucleair"

--- a/config/locales/nl_output_elements.yml
+++ b/config/locales/nl_output_elements.yml
@@ -314,6 +314,7 @@ nl:
     use_of_final_demand_in_industry_chemical_refineries_detailed: "Eindgebruik energie in raffinaderijen"
     use_of_final_demand_in_industry_chemical_fertilizers_detailed: "Eindgebruik energie in de kunstmestindustrie"
     use_of_final_demand_in_industry_chemical_other_detailed: "Eindgebruik energie in de overige chemische industrie"
+    use_of_final_demand_in_industry_food: "Eindgebruik elektriciteit in de centrale ICT industrie"
     use_of_final_demand_in_industry_food: "Eindgebruik energie in de voedingsmiddelenindustrie"
     use_of_final_demand_in_industry_other: "Eindgebruik energie in de overige industrie"
     use_of_final_demand_in_industry_paper: "Eindgebruik energie in de papierindustrie"

--- a/config/locales/nl_slides.yml
+++ b/config/locales/nl_slides.yml
@@ -60,6 +60,7 @@ nl:
     demand_industry_chemical_other: "Chemie"
     demand_industry_aggregated_chemical_other: "Chemie"
     demand_industry_other_food: "Voedsel"
+    demand_industry_other_ict: "Centrale ICT"
     demand_industry_other_paper: "Papier"
     demand_industry_aggregated_other_nl: "Overig"
     demand_industry_aggregated_other_other: "Overig"


### PR DESCRIPTION
This PR features front-end texts for sliders and charts for new ICT additions in https://github.com/quintel/etsource/pull/1152.

S This branch has been misnamed to `refineries`, but should have been called `ict`.