### PR TITLE
spelling corrections co2 biomass

### DIFF
--- a/config/locales/en_input_elements.yml
+++ b/config/locales/en_input_elements.yml
@@ -46,7 +46,7 @@ en:
     number_of_buildings: "Number of buildings"
     climate_relevant_co2_biomass_gas_present: "Gas"
     climate_relevant_co2_biomass_liquid_present: "Liquid"
-    climate_relevant_co2_biomass_solid_present: "Vast"
+    climate_relevant_co2_biomass_solid_present: "Solid"
     climate_relevant_co2_biomass_gas_future: "Gas"
     climate_relevant_co2_biomass_liquid_future: "Liquid"
     climate_relevant_co2_biomass_solid_future: "Solid" 


### PR DESCRIPTION
Changed en translation for biomass solid from "Vast" to "Solid"