### PR TITLE
Rename 'Waterstofproductie' and 'Hydrogen production' to 'H2 voor

### DIFF
--- a/config/locales/en_sidebar_items.yml
+++ b/config/locales/en_sidebar_items.yml
@@ -70,8 +70,8 @@ en:
       short_name: "Households"
       long_name: "Household energy demand"
     hydrogen_production:
-      short_name: "Hydrogen production"
-      long_name: "Hydrogen production"
+      short_name: "H<sub>2</sub> for transport"
+      long_name: "Hydrogen for transport"
     industry:
       short_name: "Industry"
       long_name: "Industry energy demand"

--- a/config/locales/nl_sidebar_items.yml
+++ b/config/locales/nl_sidebar_items.yml
@@ -70,8 +70,8 @@ nl:
       short_name: "Huishoudens"
       long_name: "Energievraag Huishoudens"
     hydrogen_production:
-      short_name: "Waterstofproductie"
-      long_name: "Waterstofproductie"
+      short_name: "H<sub>2</sub> voor transport"
+      long_name: "Waterstof voor transport"
     industry:
       short_name: "Industrie"
       long_name: "Energievraag Industrie"


### PR DESCRIPTION
transport' and 'H2 for transport' respectively. Used subscript as this is also used for 'CO2 biomassa'. Closes #2229