### PR TITLE
Added availability to merit order table and profitability table

### DIFF
--- a/app/assets/javascripts/lib/views/plant_profitability_table_view.coffee
+++ b/app/assets/javascripts/lib/views/plant_profitability_table_view.coffee
@@ -17,11 +17,13 @@ class @PlantProfitabilityTableView extends HtmlTableChartView
       else
         'N/A'
       continue if values.capacity == 0
+
       items.push
         profitability: profitability
         key: key
         position: values.position
         capacity: values.capacity
+        availability: values.availability
         full_load_hours: values.full_load_hours
         profit_per_mwh_electricity: values.profit_per_mwh_electricity
         label: @series_labels[key] || key

--- a/app/views/output_elements/tables/_chart_116.html.haml
+++ b/app/views/output_elements/tables/_chart_116.html.haml
@@ -6,6 +6,7 @@
       %th= t 'output_elements.tables.merit_order.position'
       %th= t 'output_elements.tables.merit_order.operating_costs'
       %th= t 'output_elements.tables.merit_order.installed_capacity'
+      %th= t 'output_elements.tables.merit_order.availability'
       %th= t 'output_elements.tables.merit_order.flh_future'
       %th= t 'output_elements.tables.merit_order.flh_present'
     %tr
@@ -13,6 +14,7 @@
       %th
       %th EUR/MWh
       %th MW
+      %th %
       %th Hr
       %th Hr
   %tbody
@@ -57,5 +59,6 @@
         %td.position{:data => {:decimals => 0, :gquery => "merit_order_#{key}_position_in_merit_order_table", :on_zero => '-'}}
         %td.cost{:data => {:decimals => 0, :gquery => "merit_order_#{key}_operating_costs_in_merit_order_table"}}
         %td.capacity{:data => {:decimals => 0, :gquery => "merit_order_#{key}_capacity_in_merit_order_table"}}
+        %td.availability{:data => {:decimals => 0, :gquery => "merit_order_#{key}_availability_in_merit_order_table"}}
         %td{:data => {:decimals => 0, :gquery => "merit_order_#{key}_full_load_hours_in_merit_order_table"}}
         %td{:data => {:decimals => 0, :gquery => "merit_order_#{key}_full_load_hours_in_merit_order_table", :graph => :present}}

--- a/app/views/output_elements/tables/_chart_140.html.erb
+++ b/app/views/output_elements/tables/_chart_140.html.erb
@@ -4,7 +4,8 @@
       <tr>
         <th class="technology"><%= t("output_elements.tables.merit_order.technology") %></th>
         <th class="position"><%= t("output_elements.tables.merit_order.position") %></th>
-        <th><%= t("output_elements.tables.merit_order.available_capacity") %></th>
+        <th><%= t("output_elements.tables.merit_order.installed_capacity") %></th>
+        <th><%= t("output_elements.tables.merit_order.availability") %></th>
         <th><%= t("output_elements.tables.merit_order.flh_future") %></th>
         <th><%= t("output_elements.tables.merit_order.profits_per_mwh_electricity") %></th>
       </tr>
@@ -17,6 +18,7 @@
           </td>
           <td class="position"><%%= serie.position || '-' %></td>
           <td><%%= Metric.autoscale_value(serie.capacity, 'MW') %></td>
+          <td><%%= Metric.autoscale_value(serie.availability, '%')%></td>
           <td><%%= Metric.round_number(serie.full_load_hours, 0) %></td>
           <td><%%= Metric.autoscale_value(serie.profit_per_mwh_electricity, 'euro', 0) %></td>
         </tr>
@@ -24,7 +26,7 @@
     </tbody>
     <tfoot>
       <tr>
-        <td colspan="5">
+        <td colspan="6">
           <span class="legend_block" style="background: green"></span>
           <span class="legend_label"><%= t 'output_elements.tables.merit_order.profitable' %></span>
           <span class="legend_block" style="background: orange"></span>

--- a/config/locales/en_output_elements.yml
+++ b/config/locales/en_output_elements.yml
@@ -121,6 +121,7 @@ en:
       energy: "power"
     tables:
       merit_order:
+        availability: "Availability"
         available_capacity: "Available capacity"
         installed_capacity: "Installed capacity"
         central_gas_chp: "Gas plant for district heat"

--- a/config/locales/nl_output_elements.yml
+++ b/config/locales/nl_output_elements.yml
@@ -118,6 +118,7 @@ nl:
       merit_order:
         available_capacity: "Beschikbaar vermogen"
         installed_capacity: "Geïnstalleerd vermogen"
+        availability: "Beschickbaarheid"
         central_gas_chp: "Gascentrale met warmtelevering"
         coal_chp: "Kolen WKK"
         coal_chp_cofiring: "Kolen WKK met houtpellet bijstook"

--- a/config/locales/nl_output_elements.yml
+++ b/config/locales/nl_output_elements.yml
@@ -118,7 +118,7 @@ nl:
       merit_order:
         available_capacity: "Beschikbaar vermogen"
         installed_capacity: "Geïnstalleerd vermogen"
-        availability: "Beschickbaarheid"
+        availability: "Beschikbaarheid"
         central_gas_chp: "Gascentrale met warmtelevering"
         coal_chp: "Kolen WKK"
         coal_chp_cofiring: "Kolen WKK met houtpellet bijstook"


### PR DESCRIPTION
I have updated both the merit order table and the profitability table to include the columns: installed_capacity and availability. 