### PR TITLE
New dashboard item: Share of renewable energy in households

### DIFF
--- a/app/assets/javascripts/lib/views/constraint_view.coffee
+++ b/app/assets/javascripts/lib/views/constraint_view.coffee
@@ -78,6 +78,10 @@ class @ConstraintView extends Backbone.View
         Metric.round_number(result, 1)
       when 'renewable_percentage'
         Metric.ratio_as_percentage(result)
+      when 'renewable_percentage_households'
+        Metric.ratio_as_percentage(result)
+      when 'renewable_electricity_percentage'
+        Metric.ratio_as_percentage(result)
       when 'bio_footprint'
         formatted = "#{Metric.round_number(result, 1)}x"
         if App.settings.get('scaling')
@@ -88,8 +92,6 @@ class @ConstraintView extends Backbone.View
         null
       when 'loss_of_load', 'blackout_hours', 'total_number_of_excess_events'
         "#{Metric.round_number(result, 0)} #{I18n.t('units.hours')}"
-      when 'renewable_electricity_percentage'
-        Metric.ratio_as_percentage(result)
       when 'score'
         parseInt(result,10)
       else

--- a/config/locales/en_dashboard_items.yml
+++ b/config/locales/en_dashboard_items.yml
@@ -33,6 +33,12 @@ en:
     renewable_percentage:
       label: "Renewables"
       title: "Total share of renewable energy"
+    renewable_percentage_households:
+      label: "Renewables households"
+      title: "Share of renewable energy in households"
+    renewable_electricity_percentage:
+      label: "Renewable el."
+      title: "Total share of renewable electricity"
     targets_met:
       label: "Targets"
       title: "Targets that are met or not"
@@ -42,9 +48,6 @@ en:
     loss_of_load:
       label: "Loss of load"
       title: "Loss of load expectation"
-    renewable_electricity_percentage:
-      label: "Renewable el."
-      title: "Total share of renewable electricity"
     employment:
       label: "Employment"
       title: "Employment"

--- a/config/locales/en_dashboard_items.yml
+++ b/config/locales/en_dashboard_items.yml
@@ -34,7 +34,7 @@ en:
       label: "Renewables"
       title: "Total share of renewable energy"
     renewable_percentage_households:
-      label: "Renewables households"
+      label: "Household renewables"
       title: "Share of renewable energy in households"
     renewable_electricity_percentage:
       label: "Renewable el."

--- a/config/locales/nl_dashboard_items.yml
+++ b/config/locales/nl_dashboard_items.yml
@@ -33,6 +33,12 @@ nl:
     renewable_percentage:
       label: "Hernieuwbaar"
       title: "Totaal aandeel hernieuwbare energie"
+    renewable_percentage_households:
+      label: "Hernieuwbaar huishoudens"
+      title: "Aandeel hernieuwbare energie in huishoudens"
+    renewable_electricity_percentage:
+      label: "Hernieuwbare el."
+      title: "Totaal aandeel hernieuwbare elektriciteit"
     targets_met:
       label: "Doelen"
       title: "Beleidsdoelen die wel of niet gehaald worden"
@@ -42,9 +48,6 @@ nl:
     loss_of_load:
       label: "Onvermogen"
       title: "Verwachte onvermogen"
-    renewable_electricity_percentage:
-      label: "Hernieuwbare el."
-      title: "Totaal aandeel hernieuwbare elektriciteit"
     employment:
       label: "Werkgelegenheid"
       title: "Werkgelegenheid"

--- a/db/migrate/20161217095256_add_constraint_for_household_renewables.rb
+++ b/db/migrate/20161217095256_add_constraint_for_household_renewables.rb
@@ -1,0 +1,12 @@
+class AddConstraintForHouseholdRenewables < ActiveRecord::Migration
+  def change
+    output_element = OutputElement.find_by_key('renewability')
+
+    Constraint.create!(
+      key:               'renewable_percentage_households',
+      gquery_key:        'dashboard_renewability_households',
+      group:             'renewable',
+      output_element_id: output_element.id
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160705092705) do
+ActiveRecord::Schema.define(version: 20161217095256) do
 
   create_table "area_dependencies", force: true do |t|
     t.string  "dependent_on"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -403,7 +403,8 @@ Constraint.create!([
   { :id => 10, :key => "loss_of_load", :created_at => "2011-12-02 11:30:00", :updated_at => "2012-01-30 13:56:33", :gquery_key => "dashboard_security_of_supply", :group => "import", :position => nil, :disabled => false },
   { :id => 11, :key => "renewable_electricity_percentage", :created_at => "2012-01-04 14:01:41", :updated_at => "2012-01-23 13:49:03", :gquery_key => "dashboard_share_of_renewable_electricity", :group => "renewable", :position => nil, :disabled => false },
   { :id => 12, :key => "employment", :created_at => "2012-03-14 08:18:01", :updated_at => "2012-03-14 14:59:32", :gquery_key => "dashboard_employment", :group => "costs", :position => nil, :disabled => false },
-  { :id => 13, :key => "profitability", :created_at => "2012-12-10 13:14:42", :updated_at => "2012-12-17 13:40:03", :gquery_key => "dashboard_profitability", :group => "costs", :position => nil, :disabled => false }
+  { :id => 13, :key => "profitability", :created_at => "2012-12-10 13:14:42", :updated_at => "2012-12-17 13:40:03", :gquery_key => "dashboard_profitability", :group => "costs", :position => nil, :disabled => false },
+  { :id => 14, :key => "renewable_percentage_households", :created_at => "2016-11-15 16:55:37", :updated_at => "2016-11-15 16:56:37", :gquery_key => "dashboard_renewability_households", :group => "renewable", :position => nil, :disabled => false }
 ])
 
 


### PR DESCRIPTION
- This commit only contains translations and javascript
- Create the constraint (i.e. dashboard item) with:
  ```
  INSERT INTO `constraints` (`id`,`key`,`created_at`,`updated_at`,`gquery_key`,`group`,`position`,`disabled`,`output_element_id`)
  VALUES (18,'renewable_percentage_households',NOW(),NOW(),'dashboard_renewability_households','renewable',NULL,0,49);
  ```
- Also merge quintel/etsource#1200

Closes #2299 