### PR TITLE
Set correct scaling attributes in session

### DIFF
--- a/app/assets/javascripts/lib/models/input_element.coffee
+++ b/app/assets/javascripts/lib/models/input_element.coffee
@@ -12,7 +12,7 @@ class @InputElement extends Backbone.Model
   conversions: ->
     conversions = @get('conversions') or []
 
-    if App.settings.get('scaling') and Quantity.isSupported(@get('unit'))
+    if App.settings.get_scaling() and Quantity.isSupported(@get('unit'))
       base   = new Quantity(@get('start_value'), @get('unit'))
       scaled = base.smartScale()
 
@@ -74,7 +74,7 @@ class @InputElementList extends Backbone.Collection
         start_value: values.default
         label: if _.isObject(values.label) then values.label else null
 
-      if App.settings.get('scaling')
+      if App.settings.get_scaling()
         if ! i.get('step_value') || i.get('step_value') > values.step
           # When region scaling, the pre-defined input step is too large for
           # some inputs. We therefore use the values from ETEngine which

--- a/app/assets/javascripts/lib/models/setting.coffee
+++ b/app/assets/javascripts/lib/models/setting.coffee
@@ -8,6 +8,9 @@ class @Setting extends Backbone.Model
   # Always use PUT requests
   isNew : -> false
 
+  get_scaling: =>
+    @get('scaling') || @get('area_scaling')
+
   toggle_fce: (event) =>
     @set(use_fce: !! $(event.target).attr('checked'))
 

--- a/app/assets/javascripts/lib/views/constraint_view.coffee
+++ b/app/assets/javascripts/lib/views/constraint_view.coffee
@@ -84,7 +84,7 @@ class @ConstraintView extends Backbone.View
         Metric.ratio_as_percentage(result)
       when 'bio_footprint'
         formatted = "#{Metric.round_number(result, 1)}x"
-        if App.settings.get('scaling')
+        if App.settings.get_scaling()
           formatted
         else
           "#{formatted}#{App.settings.country().toUpperCase()}"

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -61,20 +61,23 @@ protected
     Current.setting.end_year = (params[:end_year] == "other") ? params[:other_year] : params[:end_year]
     Current.setting.area_code = params[:area_code]
     Current.setting.preset_scenario_id = params[:preset_scenario_id]
-    Current.setting.scaling = assign_scaling(params)
+
+    assign_scaling_attributes(params)
 
     redirect_to play_path and return
   end
 
 public
 
-  def assign_scaling(params)
+  def assign_scaling_attributes(params)
     area = Api::Area.find_by_country_memoized(params[:area_code])
 
+    if area.derived?
+      Current.setting.area_scaling = area.scaling.attributes
+    end
+
     if params[:scaling_attribute]
-      Api::Scenario.scaling_from_params(params)
-    elsif area.derived?
-      area.scaling.attributes
+      Current.setting.scaling = Api::Scenario.scaling_from_params(params)
     end
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -61,15 +61,22 @@ protected
     Current.setting.end_year = (params[:end_year] == "other") ? params[:other_year] : params[:end_year]
     Current.setting.area_code = params[:area_code]
     Current.setting.preset_scenario_id = params[:preset_scenario_id]
-
-    if params[:scaling_attribute]
-      Current.setting.scaling = Api::Scenario.scaling_from_params(params)
-    end
+    Current.setting.scaling = assign_scaling(params)
 
     redirect_to play_path and return
   end
 
 public
+
+  def assign_scaling(params)
+    area = Api::Area.find_by_country_memoized(params[:area_code])
+
+    if params[:scaling_attribute]
+      Api::Scenario.scaling_from_params(params)
+    elsif area.derived?
+      area.scaling.attributes
+    end
+  end
 
   def update_footer
     render :partial => "layouts/etm/footer"

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -27,6 +27,7 @@ class Setting
       locked_charts:          {},
       last_etm_page:          nil,
       scaling:                nil,
+      area_scaling:           nil,
       preset_scenario_id:     nil,
       api_session_id:         nil
     }


### PR DESCRIPTION
~~Related to https://github.com/quintel/etengine/pull/898~~

----

- [x] Don't save ScenarioScaling when using a local dataset 