### PR TITLE
Correctly format numbers with rounding errors

### DIFF
--- a/app/assets/javascripts/lib/models/metric.coffee
+++ b/app/assets/javascripts/lib/models/metric.coffee
@@ -178,7 +178,7 @@
   # 0-999: 0, 1000-999999: 1, ...
   power_of_thousand: (x) ->
     if x is 0 then 0 else
-      parseInt(Math.log(Math.abs(x)) / Math.log(1000), 10)
+      Math.trunc(Math.log(Math.abs(x)) / Math.log(1000))
 
   # Returns the string currently used on the i18n file
   power_of_thousand_to_string: (x) -> @scale_label["#{x}"]

--- a/app/assets/javascripts/lib/util/polyfills.js
+++ b/app/assets/javascripts/lib/util/polyfills.js
@@ -32,3 +32,15 @@ if (!Array.prototype.filter) {
         return res;
     };
 }
+
+Math.trunc = Math.trunc || function(x) {
+    if (isNaN(x)) {
+        return NaN;
+    }
+
+    if (x > 0) {
+        return Math.floor(x);
+    }
+
+    return Math.ceil(x);
+};


### PR DESCRIPTION
Fixes `Metric.power_of_thousand` to return the correct power of thousand when given numbers which are very close to - but not exactly - 1.0.

Before: `Metric.power_of_thousand(1.000002) // => 2`
After: `Metric.power_of_thousand(1.000002) // => 0`

Closes #2351