### PR TITLE
Fixes formatting of request bodies in APIProxy

### DIFF
--- a/app/controllers/api_proxy_controller.rb
+++ b/app/controllers/api_proxy_controller.rb
@@ -7,7 +7,9 @@ class ApiProxyController < ApplicationController
   def default
     uri = "/#{params[:url]}"
     uri += ".#{params[:format]}" if params[:format]
-    parameters = params.except('controller', 'action', 'url', 'format').to_json
+
+    parameters =
+      params.permit!.to_h.except('controller', 'action', 'url', 'format')
 
     response = if request.get?
       NastyProxy.get uri


### PR DESCRIPTION
`to_hash` is set to be deprecated in Rails 5.1, and `to_json` mangles array parameters (such as the list of gqueries). Switched to explicitly permitting all params, filtering out those we don't want, and using the (non-deprecated) `to_h` instead.

Fixes #2418