### PR TITLE
Add slider to enable "cold snap" (1987 heat curves)

### DIFF
--- a/config/locales/en_slides.yml
+++ b/config/locales/en_slides.yml
@@ -91,6 +91,7 @@ en:
     flexibility_electricity_import_export_interconnectors: "Effects of increasing interconnector capacity"
     flexibility_electricity_import_export_markets: "Integration of the electricity markets"
     flexibility_electricity_import_export_renewables: "Effects of additional renewable generation"
+    flexibility_flexibility_cold_snap: "Cold snap"
     flexibility_flexibility_demand_increase: "Demand increase"
     flexibility_flexibility_demand_response_ev: "Demand response - Electric vehicles"
     flexibility_flexibility_demand_response_hp: "Demand response - Heat pumps"

--- a/config/locales/nl_slides.yml
+++ b/config/locales/nl_slides.yml
@@ -91,6 +91,7 @@ nl:
     flexibility_electricity_import_export_interconnectors: "Effecten van extra interconnectiecapaciteit"
     flexibility_electricity_import_export_markets: "Koppeling van de elektriciteitsmarkt"
     flexibility_electricity_import_export_renewables: "Effecten van toenemende hernieuwbare opwek"
+    flexibility_flexibility_cold_snap: "Cold snap"
     flexibility_flexibility_demand_increase: "Vraagtoename"
     flexibility_flexibility_demand_response_ev: "Vraagsturing - Elektrische auto's"
     flexibility_flexibility_demand_response_hp: "Vraagsturing - Warmtepompen"

--- a/config/locales/nl_slides.yml
+++ b/config/locales/nl_slides.yml
@@ -91,7 +91,7 @@ nl:
     flexibility_electricity_import_export_interconnectors: "Effecten van extra interconnectiecapaciteit"
     flexibility_electricity_import_export_markets: "Koppeling van de elektriciteitsmarkt"
     flexibility_electricity_import_export_renewables: "Effecten van toenemende hernieuwbare opwek"
-    flexibility_flexibility_cold_snap: "Cold snap"
+    flexibility_flexibility_cold_snap: "Koude winter"
     flexibility_flexibility_demand_increase: "Vraagtoename"
     flexibility_flexibility_demand_response_ev: "Vraagsturing - Elektrische auto's"
     flexibility_flexibility_demand_response_hp: "Vraagsturing - Warmtepompen"

--- a/db/migrate/20170905121107_add_cold_snap_input_element.rb
+++ b/db/migrate/20170905121107_add_cold_snap_input_element.rb
@@ -10,21 +10,28 @@ class AddColdSnapInputElement < ActiveRecord::Migration[5.0]
     temperature. When turned off (the default), the ETM will use 2013 demand and
     temperature curves as the basis for your scenario.
 
-    The average temperature in 1987 was 1 <sup>o</sup>C higher than the actual average temperature. To simulate this set the climate slide to -1 []o[]C.
+    The average temperature in 1987 was 1&deg;C lower than in 2013. To simulate
+    this set the
+    <a href="/scenario/demand/households/climate">outdoor temperature</a>
+    to -1&deg;C.
   TEXT
 
   NL_DESCRIPTION = <<-TEXT.strip_heredoc
-    In 1987 was er in Nederland een uitzonderlijk koude periode gedurende de tweede week van januari. 
-    Dit zorgde voor een significante toename van de warmtevraag. Een dergelijk koude periode kan in de toekomst weer voorkomen. 
-    De vraag is of de opgestelde warmtetechnologieën dan voldoende vermogen zullen hebben om in de warmtevraag te voorzien. 
-    Om dat te verkennen kan hieronder een koud jaar worden geselecteerd.
+    In 1987 was er in Nederland een uitzonderlijk koude periode gedurende de
+    tweede week van januari. Dit zorgde voor een significante toename van de
+    warmtevraag. Een dergelijk koude periode kan in de toekomst weer voorkomen.
+    De vraag is of de opgestelde warmtetechnologieën dan voldoende vermogen
+    zullen hebben om in de warmtevraag te voorzien. Om dat te verkennen kan
+    hieronder een koud jaar worden geselecteerd.
 
-    Voor de standaard warmtevraag- en temperatuurprofielen gebruikt het ETM data uit 2013.
-    Selecteer hieronder de &ldquo;cold snap&rdquo; om om de profielen die passen bij het jaar 1987 te gebruiken.
+    Voor de standaard warmtevraag- en temperatuurprofielen gebruikt het ETM data
+    uit 2013. Selecteer hieronder de &ldquo;koude winter&rdquo; om om de
+    profielen die passen bij het jaar 1987 te gebruiken.
 
-    In 1987 was de gemiddelde temperatuur 1 1 <sup>o</sup>C lager dan in 2013. 
-    Dit is te simuleren door bij "klimaat" een temperatuur van -1 <sup>o</sup>C in te stellen.
-
+    In 1987 was de gemiddelde temperatuur 1&deg;C lager dan in 2013.
+    Dit is te simuleren door bij
+    <a href="/scenario/demand/households/climate">&ldquo;klimaat&rdquo; een
+    temperatuur</a> van -1&deg;C in te stellen.
   TEXT
 
   def up

--- a/db/migrate/20170905121107_add_cold_snap_input_element.rb
+++ b/db/migrate/20170905121107_add_cold_snap_input_element.rb
@@ -1,0 +1,58 @@
+class AddColdSnapInputElement < ActiveRecord::Migration[5.0]
+  EN_DESCRIPTION = <<-TEXT.strip_heredoc
+    In 1987, the Netherlands experienced an exceptional cold snap in the
+    second week of January, which significantly increased the demand for space
+    heating. This may happen again in the future, and low temperatures may
+    negatively affect the ability for air and hybrid heat pumps to satisfy
+    demand.
+
+    Enable the &ldquo;cold snap&rdquo; below to use the 1987 heat demand and air
+    temperature. When turned off (the default), the ETM will use 2013 demand and
+    temperature curves as the basis for your scenario.
+  TEXT
+
+  NL_DESCRIPTION = <<-TEXT.strip_heredoc
+    In 1987, the Netherlands experienced an exceptional cold snap in the
+    second week of January, which significantly increased the demand for space
+    heating. This may happen again in the future, and low temperatures may
+    negatively affect the ability for air and hybrid heat pumps to satisfy
+    demand.
+
+    Enable the &ldquo;cold snap&rdquo; below to use the 1987 heat demand and air
+    temperature. When turned off (the default), the ETM will use 2013 demand and
+    temperature curves as the basis for your scenario.
+  TEXT
+
+  def up
+    slide = Slide.create!(
+      key: :flexibility_flexibility_cold_snap,
+      position: 12,
+      description_attributes: {
+        content_en: paragraphs(EN_DESCRIPTION),
+        content_nl: paragraphs(NL_DESCRIPTION)
+      },
+      sidebar_item: SidebarItem.find_by_key(:electricity_storage),
+      output_element: OutputElement.find_by_key(:household_heat_demand_and_production)
+    )
+
+    InputElement.create!(
+      key: :settings_heat_curve_set,
+      slide: slide,
+      step_value: 1,
+      unit: 'boolean'
+    )
+  end
+
+  def down
+    InputElement.find_by_key(:settings_heat_curve_set).destroy!
+    Slide.find_by_key(:flexibility_flexibility_cold_snap).destroy!
+  end
+
+  private
+
+  def paragraphs(text)
+    text.gsub(/\n([^\n])/, ' \1').strip.split("\n").map do |para|
+      "<p>#{ para.strip }</p>"
+    end.join("\n\n")
+  end
+end

--- a/db/migrate/20170905121107_add_cold_snap_input_element.rb
+++ b/db/migrate/20170905121107_add_cold_snap_input_element.rb
@@ -9,18 +9,22 @@ class AddColdSnapInputElement < ActiveRecord::Migration[5.0]
     Enable the &ldquo;cold snap&rdquo; below to use the 1987 heat demand and air
     temperature. When turned off (the default), the ETM will use 2013 demand and
     temperature curves as the basis for your scenario.
+
+    The average temperature in 1987 was 1 <sup>o</sup>C higher than the actual average temperature. To simulate this set the climate slide to -1 []o[]C.
   TEXT
 
   NL_DESCRIPTION = <<-TEXT.strip_heredoc
-    In 1987, the Netherlands experienced an exceptional cold snap in the
-    second week of January, which significantly increased the demand for space
-    heating. This may happen again in the future, and low temperatures may
-    negatively affect the ability for air and hybrid heat pumps to satisfy
-    demand.
+    In 1987 was er in Nederland een uitzonderlijk koude periode gedurende de tweede week van januari. 
+    Dit zorgde voor een significante toename van de warmtevraag. Een dergelijk koude periode kan in de toekomst weer voorkomen. 
+    De vraag is of de opgestelde warmtetechnologieën dan voldoende vermogen zullen hebben om in de warmtevraag te voorzien. 
+    Om dat te verkennen kan hieronder een koud jaar worden geselecteerd.
 
-    Enable the &ldquo;cold snap&rdquo; below to use the 1987 heat demand and air
-    temperature. When turned off (the default), the ETM will use 2013 demand and
-    temperature curves as the basis for your scenario.
+    Voor de standaard warmtevraag- en temperatuurprofielen gebruikt het ETM data uit 2013.
+    Selecteer hieronder de &ldquo;cold snap&rdquo; om om de profielen die passen bij het jaar 1987 te gebruiken.
+
+    In 1987 was de gemiddelde temperatuur 1 1 <sup>o</sup>C lager dan in 2013. 
+    Dit is te simuleren door bij "klimaat" een temperatuur van -1 <sup>o</sup>C in te stellen.
+
   TEXT
 
   def up

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170901155749) do
+ActiveRecord::Schema.define(version: 20170905121107) do
 
   create_table "area_dependencies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string  "dependent_on"


### PR DESCRIPTION
This PR adds a slide to Electricity balance → Flexibility called "Cold snap". Within is a single slider that swaps between 2013 and 1987 heat profile and air temperature curves.

---

@DorinevanderVlies A couple of translations need to be added before this can be merged:

* Slide title ["Cold snap" in config/locals/nl_slides.yml](https://github.com/quintel/etmodel/blob/cold-snap/config/locales/nl_slides.yml#L94):

  https://github.com/quintel/etmodel/blob/dc625d9fcad4e655fe8c265de0fc82eaec16e432/config/locales/nl_slides.yml#L94

* The description [in db/migrate/20170905121107_add_cold_snap_input_element.rb](https://github.com/quintel/etmodel/blob/cold-snap/db/migrate/20170905121107_add_cold_snap_input_element.rb#L15-L23):

  https://github.com/quintel/etmodel/blob/dc625d9fcad4e655fe8c265de0fc82eaec16e432/db/migrate/20170905121107_add_cold_snap_input_element.rb#L14-L24

If you're not comfortable editing these files yourself, just post the texts in a reply and I'll add them to the pull request.

---

![screen shot 2017-09-04 at 20 50 02](https://user-images.githubusercontent.com/4383/30065120-cc9cf70a-924b-11e7-9546-2d3930c0c09e.png)

![screen shot 2017-09-04 at 20 50 10](https://user-images.githubusercontent.com/4383/30065123-cfc2b546-924b-11e7-9597-c2eaaa85f177.png)

---

FYI @ChaelKruip 