### PR TITLE
Require that input elements have a position

### DIFF
--- a/app/models/input_element.rb
+++ b/app/models/input_element.rb
@@ -27,6 +27,7 @@ class InputElement < ActiveRecord::Base
   belongs_to :slide
 
   validates :key, presence: true, uniqueness: true
+  validates :position, numericality: true
 
   scope :households_heating_sliders, -> { where(share_group: 'heating_households') }
   scope :ordered, -> { order('position') }

--- a/spec/factories/input_element.rb
+++ b/spec/factories/input_element.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :input_element do
     sequence(:key) {|n| "input_element_#{n}" }
+    sequence(:position) { |n| n }
   end
 end

--- a/spec/models/input_element_spec.rb
+++ b/spec/models/input_element_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe InputElement do
+  it { is_expected.not_to allow_value('invalid').for(:position) }
+  it { is_expected.not_to allow_value(nil).for(:position) }
+  it { is_expected.not_to allow_value('').for(:position) }
+  it { is_expected.to allow_value(0).for(:position) }
+  it { is_expected.to allow_value(1).for(:position) }
+end


### PR DESCRIPTION
Validates that input elements have a numerical position assigned. Not having a position causes `sort_by(&:position)` to [throw an exception](https://quintel.airbrake.io/projects/32209/groups/2088489103767969068).