### PR TITLE
Remove 'has_wrapped_label' for mekko chart

### DIFF
--- a/app/assets/javascripts/d3/mekko.coffee
+++ b/app/assets/javascripts/d3/mekko.coffee
@@ -236,13 +236,8 @@ D3.mekko =
 
       @display_legend()
 
-      if ! @has_wrapped_labels
-        # The first time the chart is loaded, adjust labels to wrap long text
-        # and increase height.
-        @wrapLabels()
-        @fitHeightToLabels()
-        @has_wrapped_labels = true
-
+      @wrapLabels()
+      @fitHeightToLabels()
       @arrangeLabels()
       @moveArrows()
 


### PR DESCRIPTION
This fixes a bug which has to do with switching from 'full screen' to 'normal view'

Closes: #2235