### PR TITLE
Bio-footprint uses base_dataset map for local datasets

### DIFF
--- a/app/helpers/constraint_helper.rb
+++ b/app/helpers/constraint_helper.rb
@@ -1,0 +1,18 @@
+module ConstraintHelper
+  # Public: The path to a map image representing the region. Derived datasets
+  # fall back to the NL image.
+  def area_map_path(suffix = nil)
+    country = (
+      area_setting.try(:base_dataset) ||
+      area_setting.area
+    ).to_s.gsub(/\d+$/, '')
+
+    country = country.split('-')[0] if country.include?('-')
+
+    "/assets/maps/#{country}_map#{suffix}.png"
+  end
+
+  def area_setting
+    Current.setting.area
+  end
+end

--- a/app/views/constraints/_bio_footprint.html.haml
+++ b/app/views/constraints/_bio_footprint.html.haml
@@ -1,15 +1,9 @@
-:ruby
-  country  = Current.setting.area_code
-  country  = country.split('-')[0] if country.include?('-')
-  map      = "/assets/maps/#{country}_map.png"
-  map_grey = "/assets/maps/#{country}_map_gray.png"
-
 .item
-  .present{:style => "background: url(#{map_grey}) repeat-x;"}
+  .present{:style => "background: url(#{area_map_path('_grey')}) repeat-x;"}
     %h3.tal= Current.setting.start_year
-    .overlay{:style => "background: url(#{map}) repeat-x"} &nbsp;
+    .overlay{:style => "background: url(#{area_map_path}) repeat-x"} &nbsp;
 
 .item
-  .future{:style => "background: url(#{map_grey}) repeat-x"}
+  .future{:style => "background: url(#{area_map_path('_grey')}) repeat-x"}
     %h3.tal= Current.setting.end_year
-    .overlay{:style => "background: url(#{map}) repeat-x"} &nbsp;
+    .overlay{:style => "background: url(#{area_map_path}) repeat-x"} &nbsp;

--- a/spec/helpers/constraint_helper.rb
+++ b/spec/helpers/constraint_helper.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the ApplicationHelper. For example:
+#
+# describe ApplicationHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+describe ConstraintHelper do
+  describe 'area_map_path' do
+    let(:area) { double(area: area_code, base_dataset: base_dataset) }
+    let(:area_code) { nil }
+    let(:base_dataset) { nil }
+
+    before do
+      allow(helper).to receive(:area_setting).and_return(area)
+    end
+
+    context 'with "nl"' do
+      let(:area_code) { 'nl' }
+
+      it 'returns the path to the NL image' do
+        expect(helper.area_map_path).to end_with('/nl_map.png')
+      end
+
+      context 'and a suffix "_grey"' do
+        it 'returns the path to the grey NL image' do
+          expect(helper.area_map_path('_grey')).to end_with('/nl_map_grey.png')
+        end
+      end
+    end
+
+    context 'with nl2013' do
+      let(:area_code) { 'nl2013' }
+
+      it 'returns the path to the NL image' do
+        expect(helper.area_map_path).to end_with('/nl_map.png')
+      end
+    end
+
+    context 'with nl-hi' do
+      let(:area_code) { 'nl-hi' }
+
+      it 'returns the path to the NL image' do
+        expect(helper.area_map_path).to end_with('/nl_map.png')
+      end
+    end
+
+    context 'with a base_dataset=de' do
+      let(:area_code) { 'frankfurt' }
+      let(:base_dataset) { 'de' }
+
+      it 'returns the path to the DE image' do
+        expect(helper.area_map_path).to end_with('/de_map.png')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes the bio-footprint dashboard item to use the map for the base dataset. i.e. NL local datasets will use the NL map, DE local datasets use the DE map, etc.

Groningen, before and after:

| Before | After |
| --- | --- |
| ![screen shot 2018-01-11 at 14 09 32](https://user-images.githubusercontent.com/4383/34829577-105681ea-f6d9-11e7-9cf2-d731d082a64d.png) | ![screen shot 2018-01-11 at 14 09 26](https://user-images.githubusercontent.com/4383/34829582-15946e60-f6d9-11e7-9f5b-a45f316a3a91.png) |