### PR TITLE
Make optimal use of space for charts

### DIFF
--- a/app/assets/stylesheets/chart.sass
+++ b/app/assets/stylesheets/chart.sass
@@ -1,8 +1,9 @@
 .chart_holder
   width: 600px
-  float: left
+  display: inline-block
   min-height: 300px
-  margin-right: 2px
+  vertical-align: top
+  margin: 0 2px 15px 0
   header
     background: #dfe8f3
     height: 30px


### PR DESCRIPTION
Closes: #2248

Managed to fix it with a few CSS rules:

![screen shot 2018-01-19 at 11 53 59](https://user-images.githubusercontent.com/2676542/35147611-7bce577c-fd0f-11e7-9672-9aa486955776.png)

Support `inline-block` : https://caniuse.com/#feat=inline-block 