### PR TITLE
Changed some flexibility legend names to make them more understandable

### DIFF
--- a/config/locales/en_output_element_series.yml
+++ b/config/locales/en_output_element_series.yml
@@ -236,7 +236,7 @@ en:
     energy_chp_ultra_supercritical_lignite: 'Lignite plant for district heat (CHP)'
     energy_export_electricity: "Exported"
     energy_flexibility_curtailment_electricity: "Curtailed"
-    energy_flexibility_p2g_electricity: 'Converted to gas for transport'
+    energy_flexibility_p2g_electricity: 'Converted to hydrogen for transport'
     energy_import: "Energy import"
     energy_power_combined_cycle_ccs_coal: 'Coal IGCC CCS'
     energy_power_combined_cycle_ccs_network_gas: 'Gas CCGT CCS'
@@ -335,8 +335,8 @@ en:
     households_collective_chp_network_gas: 'Gas CHP households'
     households_collective_chp_wood_pellets: 'Biomass CHP households'
     households_cooling_demand: "Cooling households"
-    households_flexibility_p2h_electricity: 'Converted to heat'
-    households_flexibility_p2p_electricity: 'Stored in batteries'
+    households_flexibility_p2h_electricity: 'Converted to heat for households'
+    households_flexibility_p2p_electricity: 'Stored in household batteries'
     households_heating_demand: "Heating households"
     households_solar_pv_solar_radiation: 'Solar panels households'
     households_space_heater_coal: "Coal-fired heater space heating"
@@ -380,7 +380,7 @@ en:
     industry_chp_engine_gas_power_fuelmix: 'Gas motor CHP industry'
     industry_chp_turbine_gas_power_fuelmix: 'Gas turbine CHP industry'
     industry_chp_ultra_supercritical_coal: 'Coal CHP industry'
-    industry_flexibility_p2g_electricity: "Converted to gas for industry"
+    industry_flexibility_p2g_electricity: "Converted hydrogen for industry"
     industry_flexibility_p2h_electricity: "Converted to heat for industry"
     inland: "Inland"
     insulation_savings_new_houses: "Insulation savings, new houses"

--- a/config/locales/nl_output_element_series.yml
+++ b/config/locales/nl_output_element_series.yml
@@ -234,7 +234,7 @@ nl:
     energy_chp_ultra_supercritical_lignite: 'Bruinkoolcentrale met warmtelevering (WKK)'
     energy_export_electricity: 'Geëxporteerd'
     energy_flexibility_curtailment_electricity: 'Productieverlaging'
-    energy_flexibility_p2g_electricity: 'Omgezet naar gas voor transport'
+    energy_flexibility_p2g_electricity: 'Omgezet naar waterstof voor transport'
     energy_import: "Energie-import"
     energy_power_combined_cycle_ccs_coal: 'Kolenvergassing CCS'
     energy_power_combined_cycle_ccs_network_gas: 'Gas STEG CCS'
@@ -333,8 +333,8 @@ nl:
     households_collective_chp_network_gas: 'Gas WKK huishoudens'
     households_collective_chp_wood_pellets: 'Biomassa WKK huishoudens'
     households_cooling_demand: "Koeling huishoudens"
-    households_flexibility_p2h_electricity: 'Omgezet naar warmte'
-    households_flexibility_p2p_electricity: 'Opgeslagen in batterijen'
+    households_flexibility_p2h_electricity: 'Omgezet naar warmte voor huishoudens'
+    households_flexibility_p2p_electricity: 'Opgeslagen in thuisbatterijen'
     households_heating_demand: "Verwarming huishoudens"
     households_solar_pv_solar_radiation: 'Zonnepanelen huishoudens'
     households_space_heater_coal: "Kolenketel ruimteverwarming"
@@ -378,8 +378,8 @@ nl:
     industry_chp_engine_gas_power_fuelmix: 'Gasmotor WKK industrie'
     industry_chp_turbine_gas_power_fuelmix: 'Gasturbine WKK industrie'
     industry_chp_ultra_supercritical_coal: 'Kolen WKK industrie'
-    industry_flexibility_p2g_electricity: "Omgezet naar gas voor industrie"
-    industry_flexibility_p2g_electricity: "Omgezet naar warmte voor industrie"
+    industry_flexibility_p2g_electricity: "Omgezet naar waterstof voor industrie"
+    industry_flexibility_p2h_electricity: "Omgezet naar warmte voor industrie"
     inland: "Op land"
     insulation_savings_new_houses: "Isolatiebesparingen, nieuwe huizen"
     insulation_savings_old_houses: "Isolatiebesparingen, oude huizen"


### PR DESCRIPTION
1. Fixing issue #2675 

2. Updating other legend names to more understandable ones:

- converted to gas > converted to **hydrogen**
- converted to heat > converted to heat **for households**
- stored in batteries > stored in **household** batteries
