### PR TITLE
Allow users to delete their account

### DIFF
--- a/app/assets/stylesheets/pages.sass
+++ b/app/assets/stylesheets/pages.sass
@@ -34,3 +34,81 @@
       line-height: 2em
     tr.even
       background-color: #F0F0F0
+
+.edit_account
+  width: 725px
+
+  h1, input[type=submit]
+    margin-left: 220px
+
+.edit_account, .delete_account
+  border: 1px solid #ddd
+  border-radius: 3px
+  margin: 2rem auto
+  padding: 1rem
+  width: 725px
+  h2
+    background: #f6f6f6
+    border-bottom: 1px solid #ddd
+    border-top-left-radius: 3px
+    border-top-right-radius: 3px
+    font-size: 16px
+    margin: -1rem -1rem 1rem
+    padding: 1rem
+  button.button[type], a.button, input.btn[type]
+    font-size: 13px
+    line-height: 15px
+    padding: 10px 13px
+    &:active
+      outline: none
+
+.edit_account
+  h2
+    margin-bottom: 2rem
+
+.delete_account
+  padding: 1rem
+  margin-bottom: 150px
+  p
+    margin: 0
+  button.button, button.button:active
+    background-image: linear-gradient(#fff492, #fbd565)
+    background-color: #ffe17a
+    color: #5a3a0b
+    border: 1px solid #caaa51
+    border-bottom-color: #c7a444
+    text-shadow: 0 1px 0 #ffef8c
+    .fa
+      margin-right: 0.25rem
+  button.right
+    float: right
+    margin-top: 3px
+    margin-left: 1rem
+  button.button:active
+    box-shadow: inset 0 1px 3px #c7a360
+    border-top-color: #c7a444
+  &.confirm
+    strong
+      background: #fff48f
+      padding: 2px 3px
+    input.string
+      border-top-right-radius: 0
+      border-bottom-right-radius: 0
+      padding: 10px 10px 9px
+      position: relative
+      z-index: 1
+      &:active, &:focus
+        z-index: 3
+      &.mistake:placeholder-shown
+        border-color: #ef1b1b
+        box-shadow: 0 0 5px #ff7575
+        z-index: 3
+    button.button[type]
+      border-top-left-radius: 0
+      border-bottom-left-radius: 0
+      margin-left: -1px
+      position: relative
+      z-index: 2
+    p
+      margin-bottom: 0.75rem
+

--- a/app/views/layouts/etm/_settings_menu.html.haml
+++ b/app/views/layouts/etm/_settings_menu.html.haml
@@ -18,7 +18,7 @@
 
     - if current_user
       %li
-        = link_to t("header.my_profile"), edit_user_path(current_user)
+        = link_to t("header.my_profile"), edit_user_path
 
     %li
       %a.load{:href => scenarios_path}= t("header.load_scenario")

--- a/app/views/users/confirm_delete.html.haml
+++ b/app/views/users/confirm_delete.html.haml
@@ -1,0 +1,15 @@
+.delete_account.confirm.simple_form
+  %h2= t('user.delete_account.title')
+
+  = form_tag '/user', method: :delete do |f|
+    %p= t('user.delete_account.warning')
+    %p
+      %strong= t('user.delete_account.irreversible')
+      = t('user.delete_account.confirm', delete_me: t('user.delete_account.delete_me'))
+    .row.field
+      %input.string{ type: "password", name: "password", placeholder: t('user.delete_account.enter_password'), class: (@confirm_error ? 'mistake' : '') }
+      %button.button(type='submit')<>
+        %span.fa.fa-exclamation-triangle
+        = t('user.delete_account.title')
+      %span.or or
+      = link_to t('cancel'), root_path, class: 'button'

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,6 +1,30 @@
-%h1=t("header.edit_account")
+.edit_account
+  %h2= t("header.edit_account")
 
-= render 'form'
+  = simple_form_for @user do |f|
+    .section
+      .row
+        = f.input :name
+        = f.input :email, required: true
 
-= link_to 'Back', :back
-%br
+      .row
+        = f.input :password
+        = f.input :password_confirmation
+
+    .section.highlight
+      .row
+        = f.input :company_school
+
+    = f.input :allow_news
+
+    = f.button :submit, I18n.t('simple_form.labels.user.update'), class: 'primary'
+    = link_to t('cancel'), root_path, class: 'button'
+
+.delete_account
+  %h2= t('user.delete_account.title')
+  = form_tag confirm_delete_user_path, method: :post do |f|
+    %p
+      %button.button.right(type='submit')
+        %span.fa.fa-exclamation-triangle
+        = t('user.delete_account.title')
+      = t('user.delete_account.information')

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -206,6 +206,7 @@ en:
     scenario_saved: "Saved scenario"
     succesfully_saved: "The scenario was succesfully saved."
     unsupported_browser: "Your browser is not completely supported. <small><a href='/browser_support'>more information</a></small>"
+    account_deleted: "Your account has been deleted"
 
   footer:
     main_sponsor: "Leading partner of the Energy Transition Model"

--- a/config/locales/en_simple_form.yml
+++ b/config/locales/en_simple_form.yml
@@ -26,6 +26,7 @@ en:
         school:         "School or university"
         teacher_email:  "Your teacher's e-mail address"
         submit:         "Create my account!"
+        update:         "Save changes"
     hints:
       user:
         company_school: "If you're a member of an energy-related company, trade-group, or government agency, please let us know!"

--- a/config/locales/en_users.yml
+++ b/config/locales/en_users.yml
@@ -47,7 +47,7 @@ en:
     delete_account:
       title: Delete account
       information: |
-        If you no longer with to be a member of the Energy Transition Model, you
+        If you no longer wish to be a member of the Energy Transition Model, you
         may delete your account. You'll be prompted for confirmation on the next
         page.
       warning: |

--- a/config/locales/en_users.yml
+++ b/config/locales/en_users.yml
@@ -43,3 +43,20 @@ en:
         couple of minutes.
       reset_header_html: <strong>Reset</strong> your password
       success: "Your password was successfully updated"
+
+    delete_account:
+      title: Delete account
+      information: |
+        If you no longer with to be a member of the Energy Transition Model, you
+        may delete your account. You'll be prompted for confirmation on the next
+        page.
+      warning: |
+        You are about to delete your ETM account. All personal information about
+        you – including your name and e-mail address – will be removed.
+        Scenarios you created will no longer be associated with yourself and may
+        be deleted at a later date.
+      irreversible: This is irreversible.
+      confirm: |
+        Please enter your password to confirm you understand this and
+        still want to remove your account:
+      enter_password: Enter your password

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -208,6 +208,7 @@ nl:
     scenario_saved: "Scenario opgeslagen"
     succesfully_saved: "Het scenario is succesvol opgeslagen."
     unsupported_browser: "Je browser wordt niet volledig ondersteund. <small><a href='/browser_support'>Meer informatie</a></small>"
+    account_deleted: "Uw account is verwijderd"
   footer:
     main_sponsor: "Leading partner van het Energietransitiemodel"
     sponsor: "Partner van het Energietransitiemodel"

--- a/config/locales/nl_simple_form.yml
+++ b/config/locales/nl_simple_form.yml
@@ -25,6 +25,7 @@ nl:
         school:         "School of universiteit"
         teacher_email:  "E-mailadres docent"
         submit:         "Maak account aan"
+        update:         "Wijzigingen opslaan"
     hints:
       user:
         company_school: "Als je werkzaam bent bij een bedrijf, organisatie of overheid: laat het ons weten!"

--- a/config/locales/nl_users.yml
+++ b/config/locales/nl_users.yml
@@ -72,7 +72,7 @@ nl:
     delete_account:
       title: Account verwijderen
       information: |
-        Als u niet langer lid bent van het Energietransitiemodel, kunt u uw
+        Als u niet langer lid wilt zijn van het Energietransitiemodel, kunt u uw
         account verwijderen. U wordt om bevestiging gevraagd op de volgende
         pagina.
       warning: |
@@ -82,6 +82,6 @@ nl:
         kunnen op een later tijdstip worden verwijderd
       irreversible: Dit is onomkeerbaar.
       confirm: |
-        Voer uw wachtwoord in en bevestig dat u nog steeds uw account wilt
+        Voer uw wachtwoord in en bevestig dat u uw account wilt
         verwijderen:
       enter_password: Voer uw wachtwoord in

--- a/config/locales/nl_users.yml
+++ b/config/locales/nl_users.yml
@@ -47,6 +47,7 @@ nl:
         password: "Wachtwoord"
 
   user:
+    delete_me: Verwijder me
     forgot_password:
       account_not_found: "Het spijt ons maar je account is niet bij ons bekend!"
 
@@ -67,3 +68,20 @@ nl:
       reset_description_new: 'Vul uw e-mailadres in en druk op "Herstel wachtwoord".'
       reset_header_html: <strong>Herstel</strong> je wachtwoord
       success: "Je wachtwoord is succesvol geüpdated!"
+
+    delete_account:
+      title: Account verwijderen
+      information: |
+        Als u niet langer lid bent van het Energietransitiemodel, kunt u uw
+        account verwijderen. U wordt om bevestiging gevraagd op de volgende
+        pagina.
+      warning: |
+        U staat op het punt uw ETM-account te verwijderen. Alle persoonlijke
+        informatie over u - inclusief uw naam en e-mailadres - wordt verwijderd.
+        Scenario's die u hebt gemaakt, worden niet langer aan uzelf gekoppeld en
+        kunnen op een later tijdstip worden verwijderd
+      irreversible: Dit is onomkeerbaar.
+      confirm: |
+        Voer uw wachtwoord in en bevestig dat u nog steeds uw account wilt
+        verwijderen:
+      enter_password: Voer uw wachtwoord in

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,12 +17,15 @@ Etm::Application.routes.draw do
   get '/descriptions/charts/:id'  => 'descriptions#charts'
 
   resources :user_sessions
-  resources :users, except: [:index, :show, :destroy]
+  resources :users, except: [:index, :show, :edit, :destroy]
   resources :password_resets, only: [:new, :create, :edit, :update]
 
   get '/users/:id/unsubscribe' => 'users#unsubscribe', as: :unsubscribe
 
-  resource :user, only: [:edit, :update]
+  resource :user, only: [:edit, :update, :destroy] do
+    post :confirm_delete, on: :member
+  end
+
   resources :testing_grounds, only: [:create]
 
   # Old partner paths.


### PR DESCRIPTION
The translations are from Google Translate and I don't expect them to be (anywhere near) perfect; would you mind double-checking them and adjusting as needed?

* Fixes the "edit account" page (previously would show information about creating an account), and adds a link to delete your account.
* Adds a confirmation page where a user must enter their password to authorise deletion.
* Confirming deletion removes the `User` and associated `SavedScenario` records, then signs the visitor out.

Required for [compliance with the GDPR](https://gdpr-info.eu/art-17-gdpr/).

---

![screen shot 2018-03-01 at 12 47 28](https://user-images.githubusercontent.com/4383/36845466-c4b8b482-1d4e-11e8-8acd-edd60e060ac6.png)

---

![screen shot 2018-03-01 at 12 47 37](https://user-images.githubusercontent.com/4383/36845467-c4d51b18-1d4e-11e8-87e4-9aeff2c7bcc2.png)
