### PR TITLE
New names of new transport keys

### DIFF
--- a/config/locales/en_establishment_shot.yml
+++ b/config/locales/en_establishment_shot.yml
@@ -42,3 +42,7 @@ en:
       co2_sheet_industry_other_co2_emissions: Other
       co2_sheet_agriculture_heat_co2_emissions: Heat
       co2_sheet_agriculture_power_and_light_co2_emissions: Power & Light
+      co2_sheet_transport_total_domestic_aviation_co2_emissions: Domestic aviation
+      co2_sheet_transport_total_domestic_freight_co2_emissions: Freight transport
+      co2_sheet_transport_total_private_transport_co2_emissions: Private transport
+      co2_sheet_transport_total_public_transport_co2_emissions: Public transport

--- a/config/locales/nl_establishment_shot.yml
+++ b/config/locales/nl_establishment_shot.yml
@@ -43,3 +43,7 @@ nl:
       co2_sheet_industry_other_co2_emissions: Overig
       co2_sheet_agriculture_heat_co2_emissions: Warmte
       co2_sheet_agriculture_power_and_light_co2_emissions: Kracht & Licht
+      co2_sheet_transport_total_domestic_aviation_co2_emissions: Binnenlandse vluchten
+      co2_sheet_transport_total_domestic_freight_co2_emissions: Vrachtvervoer
+      co2_sheet_transport_total_private_transport_co2_emissions: Eigen vervoer
+      co2_sheet_transport_total_public_transport_co2_emissions: Openbaar vervoer


### PR DESCRIPTION
  Added the new keys to etmodel. @grdw This are the keys which need to be coupled with the transport chart. All the other keys can be removed from the transport chart.

 co2_sheet_transport_total_domestic_aviation_co2_emissions
 co2_sheet_transport_total_domestic_freight_co2_emissions
 co2_sheet_transport_total_private_transport_co2_emissions
 co2_sheet_transport_total_public_transport_co2_emissions