### PR TITLE
Move "Show CO2" button adjacent to "Start"

### DIFF
--- a/app/assets/javascripts/intro.coffee
+++ b/app/assets/javascripts/intro.coffee
@@ -74,7 +74,7 @@ $ ->
     areaValue = $(this).val()
     selectedOption = $(this).find("option[value='" + areaValue + "']")
 
-    $("p.dataset_information a")
+    $(".dataset_information a")
       .attr("href", "/regions/" + areaValue)
 
   areaSelect.change(areaOnChange).change()

--- a/app/assets/stylesheets/home.sass
+++ b/app/assets/stylesheets/home.sass
@@ -16,24 +16,33 @@ body#outside-model
   background-color: #f4f4f4
   select[name=area_code]
     margin-bottom: 5px
-  p.dataset_information
-    margin: 0 0 10px 0
-
+  .dataset_information
+    border-left: 1px solid #ccc
+    border-image: linear-gradient(#f4f4f4 15%, #ccc 16%, #ccc 84%, #f4f4f4 85%) 100%
+    border-image-slice: 1
+    display: inline-block
+    margin-left: 7px
+    padding-left: 10px
     a
+      background: linear-gradient(#fff, #eee)
+      border-color: #bbb
       border-radius: 5px
-      padding: 5px 11px 5px
-
-      span
-        font-size: 100%
+      color: #444
+      font-size: 12px
+      font-weight: normal
+      margin: 0
+      padding: 6px 11px 5px
+      text-shadow: none
 
   h4
     cursor: pointer
   #new_scenario
     border-bottom: 1px solid #ddd
     padding: 20px
-
-    #submit
-      margin-top: 12px
+    p
+      line-height: 1
+    .country, .year
+      margin-bottom: 10px
   #submit button
     border-radius: 5px
     margin: 0

--- a/app/views/pages/root.html.haml
+++ b/app/views/pages/root.html.haml
@@ -11,8 +11,10 @@
       %a{href: '#top'}= t 'intro.start_a_new_scenario'
     #new_scenario{style: "display: #{ has_active_scenario? ? 'none' : 'block' };"}
       = form_tag root_path do
-        = render "pages/root_page/country_select"
-        = render "pages/root_page/year_select"
+        .country
+          = render "pages/root_page/country_select"
+        .year
+          = render "pages/root_page/year_select"
         #submit
           = render "pages/root_page/start_button"
     .clear

--- a/app/views/pages/root_page/_country_select.haml
+++ b/app/views/pages/root_page/_country_select.haml
@@ -10,8 +10,3 @@
             = country_option sub_area_code
     - else
       = country_option area_code
-
-%p.dataset_information
-  %a.button
-    %span.link
-      = t("intro.dataset_information_html")

--- a/app/views/pages/root_page/_start_button.haml
+++ b/app/views/pages/root_page/_start_button.haml
@@ -9,3 +9,7 @@
     %span.right-icon
 
   = hidden_field_tag :reset, '1'
+
+.dataset_information
+  %a.button
+    = t("intro.dataset_information_html")


### PR DESCRIPTION
As discussed with @jorisberkhout on Slack, this PR moves the "Show CO2 footprint" button to be adjacent to the "Start" button, so as not to interrupt the flow of the start scenario form (Select region → select year → start).

The current button is both bold (immediately attracting the eye in spite of being the least important part of the form) and interrupts the flow of creating a new scenario.

1. User selects a region.
2. "Oh, what's this button?" \*click\*
3. "Hmm, I'm on a different page, but I wanted to create a scenario".
4. ???
5. ~~Profit.~~

| Before | After |
| --- | --- |
| <img width="308" alt="screen shot 2018-03-22 at 19 05 55" src="https://user-images.githubusercontent.com/4383/37792591-13867552-2e04-11e8-8730-1338bd34cc85.png"> | <img width="315" alt="screen shot 2018-03-22 at 19 00 18" src="https://user-images.githubusercontent.com/4383/37792420-aa56c3de-2e03-11e8-9b94-6357ceb2cb08.png"> |

* Moves the button to the bottom of the form.
* I lightened the button slightly to match the select2 controls. Avoids the button standing out too much and attracting attention away from other parts of the form.
* There's a small border between the two buttons which I'm *hoping* pushes the eye towards "Start", which is what most people are going to want to press.

I'm open to other ideas if anyone has any; basically anything which removes the bold and moves the button away from the main flow of the form will be better.

I know we need to balance the wishes of a client, but this is perhaps the most important form in the entire application, and I feel the current placement and style of the button will confuse and risk reducing engagement.

---

A further improvement would be for the "Show CO2 footprint" button to pass through the selected year, so that the created scenario uses that instead of defaulting to 2040 every time.