### PR TITLE
Fix the mekko for central heat network

### DIFF
--- a/app/assets/javascripts/d3/mekko.coffee
+++ b/app/assets/javascripts/d3/mekko.coffee
@@ -85,7 +85,10 @@ D3.mekko =
       Quantity.scaleAndFormatBy(max_y_value, @model.get('unit'))
 
     is_empty: =>
-      _.sum(@model.values_future()) <= 0
+      _.sum(@series.map((s) ->
+        s.attributes.gquery.attributes.present +
+        s.attributes.gquery.attributes.future
+      )) <= 0
 
     draw: =>
       @prepare_data()


### PR DESCRIPTION
@antw appearantly the `is_empty()` method doesn't work for the central heat network mekko as described in issue #2766 . This fixes that problem.