### PR TITLE
remove static width for slider units

### DIFF
--- a/app/assets/stylesheets/slider.sass
+++ b/app/assets/stylesheets/slider.sass
@@ -84,7 +84,6 @@ $slider-box-height: 22px
 
   .output
     text-align: right
-    width: 73px
     white-space: nowrap
 
   .info-wrap


### PR DESCRIPTION
Part of #2781 

----

Removing static widths is always great. This is the difference before and after:

**Before:**
![screen shot 2018-04-20 at 14 28 47](https://user-images.githubusercontent.com/2676542/39050876-4687fb42-44a7-11e8-95e2-7b5cd606c065.png)

**After:**
![screen shot 2018-04-20 at 14 28 43](https://user-images.githubusercontent.com/2676542/39050875-466afc36-44a7-11e8-811d-c6eccffa99e1.png)

----

**Before:**
![screen shot 2018-04-20 at 14 29 22](https://user-images.githubusercontent.com/2676542/39050878-46c0b3c4-44a7-11e8-8478-c9805e07d38a.png)

**After:**
![screen shot 2018-04-20 at 14 29 18](https://user-images.githubusercontent.com/2676542/39050877-46a5ef80-44a7-11e8-8a82-146516dd4245.png)