### PR TITLE
Add "results" tip/popup

### DIFF
--- a/app/assets/javascripts/lib/views/results_tip_view.js
+++ b/app/assets/javascripts/lib/views/results_tip_view.js
@@ -1,0 +1,98 @@
+(function() {
+  var closeButton = _.template(
+    '<li>' +
+      '<button class="<%= cssClass %>">' +
+        '<% if (showIcon) { %>' +
+          '<span class="fa fa-times"></span> ' +
+        '<% } %>' +
+        '<%- message %>' +
+      '</button>' +
+    '</li>'
+  );
+
+  var ResultsTipView = Backbone.View.extend({
+    id: 'results-tip',
+
+    events: {
+      'click .controls .close':         'close',
+      'click .controls .close-forever': 'closeForever',
+    },
+
+    render: function() {
+      this.$el
+        .append(this.t('message'))
+        .append(this.renderControls());
+
+      return this.$el;
+    },
+
+    /**
+     * Returns an Element containing the "close" controls for the ResultsTip.
+     */
+    renderControls: function() {
+      var controls = $('<ol/>').addClass('controls');
+
+      controls.append(closeButton({
+        cssClass: 'close',
+        message: this.t('hide'),
+        showIcon: true
+      }));
+
+      controls.append(closeButton({
+        cssClass: 'close-forever',
+        message: this.t('hide_forever'),
+        showIcon: false
+      }));
+
+      return controls;
+    },
+
+    /**
+     * Closes the tip. If the browser supports local storage, prevent the tip
+     * from being shown again for this scenario.
+     */
+    close: function(event, scenarioID) {
+      event && event.preventDefault();
+
+      $.ajax({
+        dataType: 'json',
+        url: '/settings/hide_results_tip',
+        method: 'PUT',
+        data: { scenario_id: this.scenarioID(scenarioID) }
+      });
+
+      this.$el.fadeOut()
+    },
+
+    /**
+     * Determines the scenario. Uses the given ID, if present, otherwise falls
+     * back to using the getScenarioID option.
+     */
+    scenarioID: function(id) {
+      return id ||
+        (this.options.getScenarioID && this.options.getScenarioID()) ||
+        'all';
+    },
+
+    closeForever: function(event) {
+      this.close(event, 'all');
+    },
+
+    /**
+     * Returns a translated string.
+     */
+    t: function (key) {
+      return I18n.t('results_tip.' + key)
+    },
+  });
+
+  /**
+   * Returns if the results tip view should be shown to the user. If the user
+   * has previously dismissed the tip, it will not be shown again.
+   */
+  ResultsTipView.shouldShow = function () {
+    return window.globals.show_results_tip;
+  }
+
+  window.ResultsTipView = ResultsTipView;
+})(window);

--- a/app/assets/javascripts/lib/views/sidebar_view.coffee
+++ b/app/assets/javascripts/lib/views/sidebar_view.coffee
@@ -9,13 +9,22 @@
 # hash
 class @SidebarView extends Backbone.View
   bootstrap: ->
+    self = this
+
     # setup accordion
     $('#sidebar h4').on 'click', ->
+      tab = $(this)
+
       $("#sidebar h4").removeClass("active")
-      $(this).addClass('active')
-      target = $(this).next('ul')
+      tab.addClass('active')
+
+      target = tab.next('ul')
       target.slideDown('fast')
+
       $("#sidebar ul").not(target).slideUp('fast')
+
+      if tab.data('key') == 'data' && self.results_tip
+        self.results_tip.close()
 
     # Create gqueries for the inline bars
     for item in $("#sidebar ul li")
@@ -41,6 +50,7 @@ class @SidebarView extends Backbone.View
       App.router.navigate(key, { trigger: true })
 
     @show_sub_items()
+    @setup_results_tip()
 
   show_sub_items: ->
     e = $("#sidebar ul li.active")
@@ -74,3 +84,18 @@ class @SidebarView extends Backbone.View
 
       $item.find('.bar').animate(width: pixels, 300)
       $item.find('.value').html("#{ percentage }%").animate(left: vPixels, 300)
+
+  # Shows a pop-up tip directing the user to the "Results" section some time
+  # after the scenario has loaded.
+  setup_results_tip: (after = 60000) =>
+    return unless ResultsTipView.shouldShow()
+
+    window.setTimeout(
+      =>
+        @results_tip = new ResultsTipView(
+          getScenarioID: App.scenario.api_session_id
+        )
+
+        $('#sidebar').append(@results_tip.render().hide().fadeIn())
+      after
+    )

--- a/app/assets/stylesheets/sidebar.sass
+++ b/app/assets/stylesheets/sidebar.sass
@@ -115,3 +115,66 @@ $sidebar-active-bg: #e2e2e2
       &.empty
         margin: 0 0 0 20px
         padding: 5px 0 5px 5px
+
+  #results-tip
+    background: #fffbe6
+    background: linear-gradient(#fffbe6, #fff6cb)
+    border-bottom-color: #c5bb92
+    border-radius: 3px
+    border: 1px solid #d4c99f
+    box-shadow: 0 2px 2px rgba(0, 0, 0, 0.1)
+    color: #6f6743
+    font-size: 12px
+    line-height: 1.5
+    margin: -4px -10px 10px 10px
+    padding: 15px
+    position: relative
+
+    &:before, &:after
+      right: auto
+      content: ""
+      display: inline-block
+      position: absolute
+
+    &:before
+      left: 15px
+      top: -18px
+      border: 9px solid transparent
+      border-bottom-color: #c5bb92
+
+    &:after
+      left: 16px
+      top: -16px
+      border: 8px solid transparent
+      border-bottom-color: #fffbe6
+
+    .controls
+      font-size: 11px
+      list-style: none
+      margin: 10px 0 0
+      padding: 0
+      white-space: nowrap
+
+      li
+        display: inline-block
+
+        & + li
+          border-left: 1px solid #ecdf98
+          margin-left: 7px
+          padding-left: 7px
+
+      button
+        background: transparent
+        border: 0
+        color: #a29a71
+        cursor: pointer
+        font-family: $body_font_family
+        margin: -5px -7px
+        outline: none
+        padding: 5px 7px
+
+        .fa
+          font-size: 12px
+
+        &:hover
+          color: #6f6743

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -88,6 +88,33 @@ class SettingsController < ApplicationController
     render json: { error: e.message }, status: :bad_request
   end
 
+
+  # Records that the user has hidden the "results tip" which advises them of
+  # the results/data section.
+  #
+  # The user may hide the tip for a specific scenario (given as a paramter) or
+  # for all scenarios.
+  #
+  # PUT /settings/hide_results_tip
+  #
+  def hide_results_tip
+    scenario_id =
+      if params[:scenario_id].to_s.match(/\A\d+\z/)
+        params[:scenario_id].to_i
+      else
+        :all
+      end
+
+    if scenario_id == :all && current_user
+      current_user.update_attribute(:hide_results_tip, true)
+      session.delete(:hide_results_tip)
+    else
+      session[:hide_results_tip] = scenario_id
+    end
+
+    render json: {}, status: :ok
+  end
+
   #######
   private
   #######

--- a/app/helpers/scenario_helper.rb
+++ b/app/helpers/scenario_helper.rb
@@ -14,4 +14,18 @@ module ScenarioHelper
       check_box_tag("has_#{ name }", '1', checked)
     end
   end
+
+  # Determines if the user should be shown the tooltip highlighting the results
+  # section.
+  def show_results_tip?
+    # Logged-in user who has the tip hidden?
+    return false if current_user&.hide_results_tip
+
+    setting = session[:hide_results_tip]
+
+    return true unless setting
+    return false if setting == :all
+
+    setting != Current.setting.api_session_id
+  end
 end

--- a/app/views/layouts/etm/_javascript_globals.html.erb
+++ b/app/views/layouts/etm/_javascript_globals.html.erb
@@ -1,12 +1,13 @@
 <script>
   var globals = <%= Jbuilder.encode do |json|
-        json.api_url        APP_CONFIG[:api_url]
-        json.api_proxy_url  APP_CONFIG[:api_proxy_url]
-        json.api_session_id Current.setting.api_session_id
-        json.disable_cors   APP_CONFIG[:disable_cors]
-        json.standalone     APP_CONFIG[:standalone]
-        json.settings       Current.setting
-        json.debug_js       admin?
-        json.env            Rails.env
+        json.api_url          APP_CONFIG[:api_url]
+        json.api_proxy_url    APP_CONFIG[:api_proxy_url]
+        json.api_session_id   Current.setting.api_session_id
+        json.disable_cors     APP_CONFIG[:disable_cors]
+        json.standalone       APP_CONFIG[:standalone]
+        json.settings         Current.setting
+        json.debug_js         admin?
+        json.env              Rails.env
+        json.show_results_tip show_results_tip?
       end.html_safe %>;
 </script>

--- a/config/i18n-js.yml
+++ b/config/i18n-js.yml
@@ -29,3 +29,4 @@ translations:
       - '*.local_global.*'
       - '*.factsheet.*'
       - '*.establishment_shot.*'
+      - '*.results_tip.*'

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -83,6 +83,10 @@ en:
   fce_toggle:
     'on': "On"
     'off': "Off"
+  results_tip:
+    message: See the outcomes of your scenario and download data in the results section.
+    hide: Hide
+    hide_forever: Don't show again
 
   # ----------- Intro ----------- #
   intro:

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -83,6 +83,10 @@ nl:
   fce_toggle:
     'on': "Aan"
     'off': "Uit"
+  results_tip:
+    message: See the outcomes of your scenario and download data in the results section.
+    hide: Sluiten
+    hide_forever: Voor altijd sluiten
 
   # ----------- Intro ----------- #
   intro:

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -84,7 +84,7 @@ nl:
     'on': "Aan"
     'off': "Uit"
   results_tip:
-    message: See the outcomes of your scenario and download data in the results section.
+    message: Bekijk en download de uitkomsten van je scenario in de resultaten-sectie.
     hide: Sluiten
     hide_forever: Voor altijd sluiten
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,8 +36,9 @@ Etm::Application.routes.draw do
 
   resource :settings, only: [:edit, :update]
 
-  get '/settings/dashboard', to: 'settings#dashboard'
-  put '/settings/dashboard', to: 'settings#update_dashboard'
+  get '/settings/dashboard',        to: 'settings#dashboard'
+  put '/settings/dashboard',        to: 'settings#update_dashboard'
+  put '/settings/hide_results_tip', to: 'settings#hide_results_tip'
 
   namespace :admin do
     root to: 'pages#index'

--- a/db/migrate/20181128115253_add_hide_results_tip_to_user.rb
+++ b/db/migrate/20181128115253_add_hide_results_tip_to_user.rb
@@ -1,0 +1,6 @@
+class AddHideResultsTipToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :hide_results_tip, :boolean,
+      null: false, default: false, after: :role_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_20_114830) do
+ActiveRecord::Schema.define(version: 2018_11_28_115253) do
 
   create_table "area_dependencies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "dependent_on"
@@ -228,6 +228,7 @@ ActiveRecord::Schema.define(version: 2018_11_20_114830) do
     t.string "current_login_ip"
     t.string "last_login_ip"
     t.integer "role_id"
+    t.boolean "hide_results_tip", default: false, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "phone_number"


### PR DESCRIPTION
[Only one translation is needed](https://github.com/quintel/etmodel/blob/57059a61dc46855946ad5cc6f8efe60e35c73603/config/locales/nl_etm.yml#L87), if you'd be so kind. 🤗

---

<img width="303" alt="screen shot 2018-11-28 at 15 05 14" src="https://user-images.githubusercontent.com/4383/49160641-1e23d280-f31f-11e8-9aa5-4977562630a7.png">

60 seconds after a scenario loads, a small pop-up will appear in the sidebar directing the user's attention to the results tab. I wanted to show it after the user had moved a slider or two, but this would become messy; I think 60 seconds should be long enough for a visitor to start using the ETM without it being so long that they never see it.

The user may temporarily or permanently hide the popup. Temporarily hiding will prevent the popup from reappearing until the user starts a new scenario.

Permanently hiding it depends on whether the visitor is signed in:

* **Guests:** the tip remains hidden until the visitor clears their cookies, or we delete user sessions during a deploy.
* **Signed-in visitors:** The preference is saved in the database and the popup will never be shown again while the user is signed in.