### PR TITLE
Updated reverse side of energy factsheet

### DIFF
--- a/app/views/factsheets/_reverse.html.haml
+++ b/app/views/factsheets/_reverse.html.haml
@@ -1,63 +1,53 @@
 %h1 Toelichting &ndash; Energiemix
 
 %p
-  Deze Energiemix geeft inzicht in de mogelijke vraag en aanbod van energie in
-  een energie neutrale gemeente/regio. Met (inter)nationale afspraken als
-  uitgangspunt is de gemeente vrij van fossiele brandstoffen zoals aardgas,
-  benzine, diesel en kolen. Deze Energiemix geeft een indicatie van hoeveel er
-  bespaard kan worden, welke energievraag er in de toekomst is en welke duurzame
-  bronnen er nodig zijn. Het toont een met gemeenten afgestemd scenario van de
-  totale opgave die voor ons ligt en de urgentie om stappen te zetten. Het is
-  geen keuzemenu, maar een combinatie van energiesystemen die gezamenlijk nodig
-  zijn voor een CO<sub>2</sub> vrije samenleving. Deze energiemix is een
-  inschatting van dit moment.
+  De Energiemix geeft inzicht in de mogelijke energievraag in 2050 en het
+  benodigde aanbod aan hernieuwbare energiebronnen om deze vraag op te vangen.
+  In navolging van huidige (inter)nationale klimaatafspraken is het uitgangspunt
+  dat het gebruik van fossiele brandstoffen zoals aardgas, benzine, diesel en
+  kolen volledig wordt uitgefaseerd. Deze Energiemix toont een met gemeenten
+  afgestemd scenario van de totale opgave die voor ons ligt en de urgentie om
+  stappen te zetten. Het is geen keuzemenu, maar een combinatie van
+  veranderingen in de huidige energiesystemen die gezamenlijk nodig zijn voor
+  een klimaatneutrale samenleving.
 
 %p
-  Belangrijke stakeholders binnen de Provincie Gelderland werken samen aan het
-  Gelders Energie Akkoord (GEA) en hebben de volgende doelen afgesproken:
-
-%ul
-  %li 16% duurzame energie opwekking in 2023
-  %li 55% CO<sub>2</sub> reductie in 2030
-  %li Energieneutraal Gelderland in 2050
-  %li 1,5% energiebesparing per jaar
-
-%p
-  Deze toelichting bevat een uitleg van de hoofdlijnen van de Energiemix. De
-  berekeningen zijn gemaakt met behulp van het
-  = link_to('Energie Transitie Model', root_url)
+  De berekeningen zijn gemaakt met behulp van het
+  = link_to('EnergieTransitieModel', root_url)
   van bureau Quintel. Door adviesbureau Over Morgen is in samenspraak met
-  gemeenten en het GEA voor elke gemeente een scenario opgesteld. Alle
+  gemeenten en de provincie voor elke gemeente een scenario opgesteld. Alle
   uitgangspunten en instellingen van het scenario zijn terug te vinden en te
   wijzigen via de link onderaan de Energiemix. De berekeningen zijn gebaseerd op
-  bewezen technieken van dit moment, hoewel er nog veel innovaties en
-  financieringsconstructies nodig zijn voordat we al deze technieken
-  grootschalig kunnen toepassen. Naast deze technieken verwachten we komende
-  jaren veel innovaties die een deel van de opgave kunnen invullen.
+  bewezen technieken van dit moment met de kanttekening dat er nog veel
+  innovaties en financieringsconstructies nodig zijn voordat al deze technieken
+  grootschalig kunnen worden toegepast. Daarnaast verwachten we komende jaren de
+  opkomst van nieuwe technieken die op de langere termijn een deel van de opgave
+  kunnen invullen.
 
 %p
   Energietransitie betekent dat we naar een energiesysteem toegaan met minimale
-  CO<sub>2</sub> uitstoot. Om dit te bereiken worden de Gelderse energievraag,
-  infrastructuur en energiebronnen verduurzaamd. Dit betekent concreet dat de
-  gaskraan dicht gaat voor woningen, kantoren en bedrijven. Als alternatief gaan
-  we collectieve warmtenetten gebruiken of individueel verwarmen. Dit vraagt om
-  de aanleg van warmtenetten en verzwaarde elektriciteitsnetten. Motorvoertuigen
-  rijden niet langer op fossiele brandstoffen maar elektrisch, op waterstof
-  en/of op biobrandstof. De elektriciteit die we voor verwarming en mobiliteit
-  nodig hebben wekken we duurzaam op met bijvoorbeeld zonnepanelen en
-  windturbines.
+  CO<sub>2</sub> uitstoot. Om dit te bereiken worden de energievraag,
+  infrastructuur en energiebronnen aangepast. Dit betekent concreet dat
+  bijvoorbeeld de aardgaskraan dichtgaat voor woningen, kantoren en bedrijven.
+  Als alternatief gaan we collectieve warmtenetten gebruiken of individueel
+  verwarmen (denk aan groen gas, pellets of warmtepomp). Dit vraagt om de aanleg
+  van warmtenetten, verzwaarde elektriciteitsnetten en het deels verwijderen van
+  gasnetten. Motorvoertuigen rijden niet langer op fossiele brandstoffen maar
+  elektrisch, op waterstof en/of op biobrandstof. De elektriciteit die we voor
+  verwarming en mobiliteit nodig hebben, naast licht en elektronica, wekken we
+  duurzaam op met bijvoorbeeld zonnepanelen en windturbines.
 
 %h2 1. Energievraag eindgebruik
 
 %p
   Dit onderdeel van de Energiemix toont de huidige finale vraag van alle energie
   die binnen de gemeente, regio of provincie wordt gebruikt, oftewel gebouwde
-  omgeving, mobiliteit, industrie en landbouw. We noemen dit ook wel &lsquo;de
-  vraag aan de meter&rsquo;. De energievraag van dit moment is gebaseerd op
-  gegevens van 2015 uit de Klimaatmonitor van Rijkswaterstaat. Dit is gebaseerd
-  op de methodiek die binnen het GEA wordt toegepast. Energiegebruik van
-  vliegverkeer, opwekking van energie en zonnepanelen achter de meter zit hier
-  niet in. De energievraag bestaat uit:
+  omgeving, mobiliteit, industrie en landbouw. We noemen dit ook wel ‘de vraag
+  aan de meter’. De energievraag van dit moment is gebaseerd op de laatste
+  complete set gegevens uit de Klimaatmonitor van Rijkswaterstaat (peiljaar
+  2016). Energiegebruik van internationaal vracht- en vliegverkeer en
+  grootschalige opwekking van energie zit hier niet in. De energievraag bestaat
+  uit:
 
 %ul
   %li
@@ -79,13 +69,14 @@
     Alle elektriciteitsgebruik.
 
 %p
-  Het verschil tussen de energievraag in 2015 en in de toekomst wordt bepaald
-  door de mogelijke besparing. Dit getal is opgebouwd uit een deel actieve
-  besparing door isolatie en gedragsverandering (1,5% per jaar) en een deel
-  efficiëntie afhankelijk van de gekozen technieken in de Energiemix.
+  Het verschil tussen de energievraag van dit moment en in de toekomst wordt
+  bepaald door de mogelijke besparing. Dit getal is opgebouwd uit een deel
+  actieve besparing door isolatie en gedragsverandering en een deel efficiëntie
+  afhankelijk van de gekozen technieken in de Energiemix.
 
 %p
-  Een groot aantal veranderingen liggen ten grondslag aan de energietransitie:
+  Een groot aantal veranderingen ligt ten grondslag aan de energietransitie en
+  de geschetste situatie in 2050:
 
 %ul
   %li
@@ -99,7 +90,7 @@
     waterstof) en biobrandstof gebruiken in plaats van fossiele brandstoffen;
   %li
     De gebouwde omgeving wordt niet meer verwarmd met aardgas, maar collectief
-    met warmtenetten,  individueel met elektriciteit, zonnecollectoren en/of
+    met warmtenetten, individueel met elektriciteit, zonnecollectoren en/of
     biomassa;
   %li
     De industrie en landbouw gebruiken nu bijna volledig aardgas voor
@@ -111,7 +102,7 @@
 %h2 2. Energiebronnen toekomst
 
 %p
-  Om voldoende finale energie te kunnen leveren is een mix aan duurzame
+  Om voldoende finale energie te kunnen leveren is een mix aan hernieuwbare
   energiebronnen nodig. De hoeveelheid benodigde bronnen bij onderdeel 2 is
   groter dan de finale energie die aan de meter geleverd wordt bij onderdeel 1.
   Dat heeft te maken met omzettingsverliezen zoals bij elektriciteit naar
@@ -119,7 +110,7 @@
   elektriciteit aan de meter geleverd die bij onderdeel 1 wordt meegerekend,
   terwijl ook veel omgevingswarmte wordt gebruikt die niet als finale vraag bij
   onderdeel 1 wordt gerekend, maar wel als benodigde bron bij onderdeel 2.
-  Daarom valt de hoeveelheid duurzame energiebronnen altijd hoger uit dan de
+  Daarom valt de hoeveelheid hernieuwbare energiebronnen altijd hoger uit dan de
   finale energievraag in de toekomst.
 
 %h2 3. Opgave per thema
@@ -145,9 +136,7 @@
   %li
     Windturbines op land (o.b.v. wat nodig is om voldoende elektriciteit op te
     wekken);
-  %li
-    Windturbines op zee, als de zekerheid er is dat regio’s hiervan gebruik
-    kunnen maken.
+  %li Windturbines op zee, worden niet toegekend aan individuele regio’s.
 
 %h3 Collectieve warmte
 
@@ -155,10 +144,10 @@
 
 %p
   Meerdere woningen en gebouwen worden met elkaar verbonden door een warmtenet.
-  Om gebouwen te kunnen verwarmen is minimaal 40°C nodig. Echter moet daarvoor
-  op nieuwbouw niveau geïsoleerd worden. Dit is voor veel bestaande gebouwen
-  vaak economisch of technisch niet haalbaar. Daarom zijn temperaturen van
-  ongeveer 70°C voor deze bestaande bouw nodig. Diepe en ultradiepe geothermie
+  Om gebouwen te kunnen verwarmen is minimaal 40°C nodig. Echter moet hiervoor
+  het gebouw op nieuwbouw niveau geïsoleerd zijn. Dit is voor veel bestaande
+  gebouwen vaak economisch of technisch niet haalbaar. Daarom zijn temperaturen
+  van ongeveer 70°C nodig voor de bestaande bouw. Diepe en ultradiepe geothermie
   van 3 tot 7 kilometer diepte kan deze temperatuur leveren. Een andere optie is
   restwarmte voor zover deze in de toekomst nog beschikbaar is.
 
@@ -168,7 +157,7 @@
   wel een industriële warmtepomp nodig om de temperatuur van het water naar 70°C
   te brengen. Bij de ontwikkeling van warmtenetten kan ook een biomassacentrale
   als transitiebron worden ingezet. Als het warmtenet voldoende groot is kan dan
-  worden overgestapt op bijvoorbeeld geothermie.
+  later worden overgestapt op bijvoorbeeld geothermie.
 
 
 %h3 Individuele warmte
@@ -177,11 +166,11 @@
 
 %p
   Individuele verwarming kan met bijvoorbeeld elektrische warmtepompen, met hout
-  in gesloten pelletkachels/ketels en door nog te ontwikkelen innovatieve
-  oplossingen zoals zonnecollectoren in combinatie met warmteopslag.
-  Warmtepompen bij woningen maken meestal gebruik van bodemenergie of
-  buitenlucht. Hout is schaars en zal daarom in de toekomst maar beperkt kunnen
-  worden ingezet voor het verwarmen van gebouwen en woningen.
+  in gesloten pelletkachels/ketels en door oplossingen zoals zonnecollectoren in
+  combinatie met warmteopslag. Warmtepompen bij woningen maken meestal gebruik
+  van bodemenergie of buitenlucht. Hout is schaars en zal daarom in de toekomst
+  maar beperkt kunnen worden ingezet voor het verwarmen van gebouwen en
+  woningen.
 
 %h3 Hernieuwbaar gas
 
@@ -189,12 +178,13 @@
 = image_tag('factsheet/biogas.png', alt: '', width: 45, style: 'float: right; margin-right: 5px')
 
 %p
-  Gelderland heeft de ambitie om volledig aardgasvrij te worden. Alternatieve
-  gasvormen zijn biogas en waterstofgas. We benutten de potentie biogas
-  afkomstig uit de DANK dataset van Alterra.  Deze is gebaseerd op
+  Alternatieve gasvormen zijn biogas en waterstofgas. We benutten de potentie
+  biogas afkomstig uit de DANK dataset van Alterra. Deze is gebaseerd op
   mono-vergisting, dat wil zeggen biogas uit mest halen zonder bijproducten te
   gebruiken. De resterende vraag naar gas kan ingevuld worden met waterstofgas,
-  die in het model gekoppeld is aan lokale productie bij zonnevelden.
+  die in het model gekoppeld is aan lokale productie bij zonnevelden. Hierdoor
+  wordt de benodigde elektriciteit voor de productie van waterstofgas volledig
+  toegekend aan de regio, er is zodoende geen import van waterstofgas nodig.
 
 %h3 Biomassa
 
@@ -202,27 +192,28 @@
 
 %p
   We gebruiken maximaal de lokaal beschikbare houtsoortige biomassa volgens de
-  DANK dataset van Alterra (Link). Biomassa wordt in de Energiemix ingezet voor
-  de verwarming van gebouwen met pelletkachels en –ketels. Komende jaren is
+  DANK dataset van Alterra. Biomassa wordt in de Energiemix ingezet voor de
+  verwarming van gebouwen met pelletkachels en -ketels. Komende jaren is
   biomassa ook geschikt als transitiebrandstof voor warmtenetten. Naast het
   benutten van biomassa voor energie kan het ook benut worden voor het maken van
   nieuwe producten in een circulaire economie. De inzet van biomassa voor het
   opwekken van energie zal daarom op lange termijn beperkt zijn en uitgaan van
-  cascadering
+  cascadering.
 
 %h3 Opslag van energie
 
 = image_tag('factsheet/solar-pv.png', alt: '', width: 100, style: 'float: right')
 
 %p
-  Bij de opwek van duurzame elektriciteit en warmte ontstaat een groot onbalans
-  tussen het moment waarop energie beschikbaar is en wanneer we het gebruiken.
-  De zon levert bijvoorbeeld de meeste stroom en warmte in de zomer en midden op
-  de dag, maar veel minder in de winter en &lsquo;s avonds. In de toekomst zal
-  deze onbalans opgelost moeten worden door middel van opslag van energie en het
-  slim sturen van de energievraag door middel van een smart grid en slimme
-  apparatuur. Daarvoor is veel technische innovatie nodig. Mogelijkheden voor
-  opslag van elektriciteit en warmte naar huidige inzichten zijn:
+  Bij de opwek van hernieuwbare elektriciteit en warmte ontstaat een groot
+  onbalans tussen het moment waarop energie beschikbaar is en wanneer we het
+  gebruiken. De zon levert bijvoorbeeld de meeste stroom en warmte in de zomer
+  en midden op de dag, maar veel minder in de winter en ‘s avonds. In de
+  toekomst zal deze onbalans opgelost moeten worden door middel van opslag van
+  energie en het slim sturen van de energievraag door middel van een smart grid
+  en slimme apparatuur. Daarvoor is veel technische innovatie nodig.
+  Mogelijkheden voor opslag van elektriciteit en warmte naar huidige inzichten
+  zijn:
 
 %ul
   %li
@@ -235,9 +226,10 @@
     bodem (500 m. diepte) en grote ondergrondse boilervaten.
 
 #disclaimer
-  Deze infographic is automatisch gegenereerd met het Energietransitiemodel op basis
-  van een scenario dat niet is gevalideerd door een expert. Quintel of Over Morgen
-  zijn dan ook niet verantwoordelijk of aansprakelijk voor de inhoud of uitkomsten
-  van deze infographic.
+  Deze infographic is automatisch gegenereerd met het Energietransitiemodel op
+  basis van een scenario dat niet is gevalideerd door een expert. Quintel of
+  Over Morgen zijn dan ook niet verantwoordelijk of aansprakelijk voor de inhoud
+  of uitkomsten van deze infographic.
+
   - if can_dismiss_disclaimer?
     %button Hide disclaimer


### PR DESCRIPTION
Updated text on reverse side of factsheet. The previous text focussed on one specific project/area (Gelderland). The new text is more general.

@antw If you have time, could have a quick check if everything's all right (it looks fine on my local machine) and deploy this to PRO as well? See: https://github.com/quintel/etmodel/pull/2919 for PR to pro