### PR TITLE
Add translation for excess heat

### DIFF
--- a/config/locales/en_output_element_series.yml
+++ b/config/locales/en_output_element_series.yml
@@ -72,7 +72,7 @@ en:
     households_heat_network_connection_steam_hot_water_in_heat_network_mekko: "Households"
     energy_interconnector_imported_electricity: "Imported electricity"
     energy_steel_hisarna_transformation_coal: "Cyclone furnace on biomass - steel industry"
-    excess_heat_industrial_heat_network: "Excess heat going to other heat networks"
+    excess_heat_to_central_network: "Excess heat going to other heat networks"
     heat_from_central_heat_network: "Heat from other heat sources"
     heat_network_demand_industry: "Industry"
     heat_network_demand_households: "Households"


### PR DESCRIPTION
- Remove (redundant) translation for `excess_heat_industrial_heat_network`
- Add missing translation for `excess_heat_to_central_network`