### PR TITLE
Change landing page ETM to overview > introduction and more

### DIFF
--- a/app/assets/javascripts/lib/router.coffee
+++ b/app/assets/javascripts/lib/router.coffee
@@ -1,24 +1,9 @@
 class @Router extends Backbone.Router
   routes:
-    "demand/:sidebar(/:slide)" : "demand"
-    "costs/:sidebar(/:slide)"  : "costs"
-    "overview/:sidebar(/:slide)": "overview"
-    "supply/:sidebar(/:slide)" : "supply"
-    "flexibility/:sidebar(/:slide)" : "flexibility"
-    "data/:sidebar(/:slide)" : "data"
     "report" : "report"
     ":tab/:sidebar(/:slide)" : "load_slides"
     "" : "load_default_slides"
-
-  demand:  (sidebar, slide) => @load_slides('demand', sidebar, slide)
-  costs:   (sidebar, slide) => @load_slides('costs', sidebar, slide)
-  overview: (sidebar, slide) => @load_slides('overview', sidebar, slide)
-  supply:  (sidebar, slide) => @load_slides('supply', sidebar, slide)
-  flexibility:  (sidebar, slide) => @load_slides('flexibility', sidebar, slide)
-  data:  (sidebar, slide) => @load_slides('data', sidebar, slide)
-
-  # root:
-
+    
   report: =>
     # pass
 

--- a/app/assets/javascripts/lib/router.coffee
+++ b/app/assets/javascripts/lib/router.coffee
@@ -1,8 +1,23 @@
 class @Router extends Backbone.Router
   routes:
+    "demand/:sidebar(/:slide)" : "demand"
+    "costs/:sidebar(/:slide)"  : "costs"
+    "overview/:sidebar(/:slide)": "overview"
+    "supply/:sidebar(/:slide)" : "supply"
+    "flexibility/:sidebar(/:slide)" : "flexibility"
+    "data/:sidebar(/:slide)" : "data"
     "report" : "report"
     ":tab/:sidebar(/:slide)" : "load_slides"
     "" : "load_default_slides"
+
+  demand:  (sidebar, slide) => @load_slides('demand', sidebar, slide)
+  costs:   (sidebar, slide) => @load_slides('costs', sidebar, slide)
+  overview: (sidebar, slide) => @load_slides('overview', sidebar, slide)
+  supply:  (sidebar, slide) => @load_slides('supply', sidebar, slide)
+  flexibility:  (sidebar, slide) => @load_slides('flexibility', sidebar, slide)
+  data:  (sidebar, slide) => @load_slides('data', sidebar, slide)
+
+  # root:
 
   report: =>
     # pass
@@ -25,7 +40,7 @@ class @Router extends Backbone.Router
     $("#sidebar li##{sidebar}").addClass 'active'
 
   ui_fragments: ->
-    (Backbone.history.getFragment() || 'demand/households').split('/')
+    (Backbone.history.getFragment() || 'overview/introduction').split('/')
 
   load_default_slides: =>
     [tab, sidebar, slide] = @ui_fragments()

--- a/app/models/interface.rb
+++ b/app/models/interface.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Interface
-  DEFAULT_TAB = 'demand'
+  DEFAULT_TAB = 'overview'
 
   def initialize(tab = nil, sidebar = nil, slide = nil)
     @tab = tab || DEFAULT_TAB

--- a/config/locales/en_dashboard_items.yml
+++ b/config/locales/en_dashboard_items.yml
@@ -7,8 +7,8 @@ en:
       label: "Blackouts"
       title: "Number of blackout hours"
     co2_reduction:
-      label: "CO<sub>2</sub> emissions"
-      title: "Total CO<sub>2</sub> emissions"
+      label: "CO<sub>2</sub> relative to 1990"
+      title: "CO<sub>2</sub> emissions relative to 1990"
     local_co2_reduction:
       label: "Domestic CO<sub>2</sub> emissions"
       title: "Domestic CO<sub>2</sub> emissions"

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -10,7 +10,6 @@ en:
     demand: "Demand"
     supply: "Supply"
     costs: "Costs"
-    targets: "Overview"
     flexibility: "Flexibility"
     data: "Results"
     overview: "Overview"

--- a/config/locales/en_intro.yml
+++ b/config/locales/en_intro.yml
@@ -4,12 +4,14 @@ en:
     introduction: "Explore the future energy system!"
     your_current_scenario: "Your current scenario"
     root_text: |
-      We all need energy every day. Fifty years from now, will energy still be
-      cheap and abundant in the Western World? Using verified energy data, the
-      Energy Transition Model provides insight as to what may happen in the
-      future, and is completely free to use.
+      The 2016 Paris Climate Agreement means countries are making plans
+      to reduce their greenhouse gas emissions. In those plans, emissions from
+      energy use play a big role. The transition of the energy system can take
+      different directions, while many options affect each other. The ETM is
+      developed to improve everyone's understanding of the energy system in
+      order to make more substantiated plans.
     help: |
-      To start a new scenario, choose one of our 150 modelled regions and a year
+      To start a new scenario, choose one of our modelled regions and a year
       in the future. Not sure what to choose? The Netherlands is our most
       detailed region, and 2050 is commonly used when simulating energy and
       climate scenarios.

--- a/config/locales/en_output_elements.yml
+++ b/config/locales/en_output_elements.yml
@@ -28,7 +28,7 @@ en:
     import_export: "Import/export"
     hydrogen: "Hydrogen"
   output_elements:
-    co2_sankey: "Flowchart of energetic on-the-spot CO<sub>2</sub> emissions"
+    co2_sankey: "Energetic on-the-spot CO<sub>2</sub> emissions (flowchart)"
     common:
       total: "Total"
       old_browser: "Sorry! This chart is not supported by your browser. Please use Google Chrome, Firefox or Safari or Internet Explorer version 9 or higher."
@@ -355,6 +355,8 @@ en:
     gas_flow_to_sectors: "Gas flow to sectors"
     gas_network_mix: "Green gas in gas network"
     gas_versus_other_primary_energy: "Gas versus other primary energy"
+    final_energy_demand_per_sector_joule: "Final demand per sector [joule]"
+    final_energy_demand_per_sector_percentage: "Final demand per sector [%]"
     heat_deficit: "Heat deficit"
     households_final_demand_per_application: 'Final demand households per application'
     household_heat_demand_and_production: "Heat demand and production in households"
@@ -416,8 +418,8 @@ en:
     renewable_electricity: "Renewable electricity"
     required_capacity_lv_network: "Required capacity LV Network"
     required_network_capacity: "Required electricity network capacity"
-    sankey: "Flowchart of future energy flows"
-    sankey_2010: "Flowchart of present energy flows"
+    sankey: "Future energy flows"
+    sankey_2010: "Present energy flows"
     security_of_supply: "Security of supply"
     source_of_cooking_in_households: "Final energy demand - Cooking"
     source_of_cooling_in_buildings: "Cooling demand in buildings"

--- a/config/locales/en_output_elements.yml
+++ b/config/locales/en_output_elements.yml
@@ -28,7 +28,7 @@ en:
     import_export: "Import/export"
     hydrogen: "Hydrogen"
   output_elements:
-    co2_sankey: "Sankey diagram of energetic on-the-spot CO<sub>2</sub> emissions"
+    co2_sankey: "Flowchart of energetic on-the-spot CO<sub>2</sub> emissions"
     common:
       total: "Total"
       old_browser: "Sorry! This chart is not supported by your browser. Please use Google Chrome, Firefox or Safari or Internet Explorer version 9 or higher."
@@ -416,8 +416,8 @@ en:
     renewable_electricity: "Renewable electricity"
     required_capacity_lv_network: "Required capacity LV Network"
     required_network_capacity: "Required electricity network capacity"
-    sankey: "Sankey diagram of future energy flows"
-    sankey_2010: "Sankey diagram of present energy flows"
+    sankey: "Flowchart of future energy flows"
+    sankey_2010: "Flowchart of present energy flows"
     security_of_supply: "Security of supply"
     source_of_cooking_in_households: "Final energy demand - Cooking"
     source_of_cooling_in_buildings: "Cooling demand in buildings"

--- a/config/locales/nl_dashboard_items.yml
+++ b/config/locales/nl_dashboard_items.yml
@@ -7,13 +7,13 @@ nl:
       label: "Stroomuitval"
       title: "Aantal uren met stroomuitval"
     co2_reduction:
-      label: "CO<sub>2</sub>-uitstoot"
-      title: "Totale CO<sub>2</sub>-uitstoot"
+      label: "CO<sub>2</sub> t.o.v. 1990"
+      title: "CO<sub>2</sub>-uitstoot t.o.v. 1990"
     local_co2_reduction:
       label: "Binnenlandse CO<sub>2</sub>-uitstoot"
       title: "Binnenlandse CO<sub>2</sub>-uitstoot"
     co2_reduction_relative_to_start_year:
-      label: "CO<sub>2</sub> tov startjaar"
+      label: "CO<sub>2</sub> t.o.v. startjaar"
       title: "CO<sub>2</sub>-uitstoot ten opzichte van het startjaar"
     costs_fte:
       label: "FTE delta analyse"
@@ -31,7 +31,7 @@ nl:
       label: "Bio-voetafdruk"
       title: "Voetafdruk door biomassatoepassingen"
     renewable_percentage:
-      label: "Hernieuwbaar"
+      label: "Hernieuwbaarheid"
       title: "Totaal aandeel hernieuwbare energie"
     renewable_percentage_households:
       label: "Hernieuwbaar huishoudens"

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -10,7 +10,6 @@ nl:
     demand: "Vraag"
     supply: "Aanbod"
     costs: "Kosten"
-    targets: "Overzicht"
     flexibility: "Flexibiliteit"
     data: "Resultaten"
     overview: "Overzicht"

--- a/config/locales/nl_intro.yml
+++ b/config/locales/nl_intro.yml
@@ -4,12 +4,14 @@ nl:
     introduction: "Verken het energiesysteem van de toekomst!"
     your_current_scenario: "Jouw huidige scenario"
     root_text: |
-      We hebben allemaal elke dag energie nodig. Zal energie over vijftig jaar
-      nog steeds goedkoop en in overvloed beschikbaar zijn in de westerse
-      wereld? Hoe kunnen we ons voorbereiden op een toekomst waarin energie
-      niet meer vanzelfsprekend is? Het Energietransitiemodel maakt gebruik van
-      feiten over energie om je inzicht te geven in wat er in de toekomst zou
-      kunnen gebeuren.
+      Sinds het klimaatakkoord van Parijs worden in hoog tempo plannen gemaakt
+      om de uitstoot van broeikasgassen terug te dringen. In die plannen is
+      een grote rol weggelegd voor het verduurzamen van de energievoorziening.
+      Die energievoorziening kent een groot aantal knoppen waaraan gedraaid kan
+      worden; veel van die knoppen staan niet op zich, maar hangen sterk met
+      elkaar samen. Het Energietransitiemodel is ontwikkeld om overzicht
+      én inzicht te krijgen in het energiesysteem en zo beter onderbouwde
+      plannen te maken.
     help: |
       Een nieuw scenario kan je starten door één van onze gemodelleerde regio's
       te kiezen en het toekomstjaar waarvoor je het scenario wil maken. Weet je

--- a/config/locales/nl_output_element_series.yml
+++ b/config/locales/nl_output_element_series.yml
@@ -359,7 +359,7 @@ nl:
     heat_production: "Warmteproductie en -netten"
     heat_network_hot_water: "Warmtenet (voor warm water)"
     heat_network_heating: "Warmtenet (voor verwarming)"
-    heat_demand_apartments: "Warmtevraag appartmenten"
+    heat_demand_apartments: "Warmtevraag appartementen"
     heat_demand_detached_houses: "Warmtevraag vrijstaande huizen"
     heat_demand_semi_detached_houses: "Warmtevraag twee-onder-een-kapwoningen"
     heat_demand_terraced_houses: "Warmtevraag rijtjeshuizen"

--- a/config/locales/nl_output_elements.yml
+++ b/config/locales/nl_output_elements.yml
@@ -25,7 +25,7 @@ nl:
     import_export: "Import/export"
     hydrogen: "Waterstof"
   output_elements:
-    co2_sankey: "Stroomdiagram van directe energetische CO<sub>2</sub> uitstoot"
+    co2_sankey: "Directe energetische CO<sub>2</sub> uitstoot (flowchart)"
     common:
       old_browser: "Sorry! Deze grafiek werkt niet in uw browser. Gebruik a.u.b. Google Chrome, Firefox, Safari of Internet Explorer versie 9 of nieuwer."
       read_more: "lees verder"
@@ -336,6 +336,8 @@ nl:
     electricity_mv_network_load: "Belasting op middenspanningsnet"
     electricity_hv_network_load: "Belasting op hoogspanningsnet"
     employment_categories: "Binnenlandse werkgelegenheid"
+    final_energy_demand_per_sector_joule: "Eindgebruik per sector [joule]"
+    final_energy_demand_per_sector_percentage: "Eindgebruik per sector [%]"
     fuel_chain_emissions: "Broeikasemissies brandstofproductie en -gebruik (1/4)"
     fuel_chain_emissions_scaled_for_greengas: "Broeikasemissies brandstofproductie en -gebruik (3/4)"
     fuel_chain_emissions_scaled_for_liquid_biofuels: "Broeikasemissies brandstofproductie en -gebruik (2/4)"
@@ -407,8 +409,8 @@ nl:
     renewable_electricity: "Hernieuwbare elektriciteit"
     required_capacity_lv_network: "Benodigde capaciteit LV netwerk"
     required_network_capacity: "Benodigde elektriciteit capaciteitnetwerk"
-    sankey: "Stroomdiagram van toekomstig energiegebruik"
-    sankey_2010: "Stroomdiagram van huidig energiegebruik"
+    sankey: "Toekomstige energiestromen"
+    sankey_2010: "Huidige energiestromen"
     security_of_supply: "Leveringszekerheid"
     source_of_cooking_in_households: "Eindgebruik energie in huishoudens voor koken"
     source_of_cooling_in_buildings: "Vraag naar koeling in gebouwen"

--- a/config/locales/nl_output_elements.yml
+++ b/config/locales/nl_output_elements.yml
@@ -25,7 +25,7 @@ nl:
     import_export: "Import/export"
     hydrogen: "Waterstof"
   output_elements:
-    co2_sankey: "Sankey diagram van directe energetische CO<sub>2</sub> uitstoot"
+    co2_sankey: "Stroomdiagram van directe energetische CO<sub>2</sub> uitstoot"
     common:
       old_browser: "Sorry! Deze grafiek werkt niet in uw browser. Gebruik a.u.b. Google Chrome, Firefox, Safari of Internet Explorer versie 9 of nieuwer."
       read_more: "lees verder"
@@ -407,8 +407,8 @@ nl:
     renewable_electricity: "Hernieuwbare elektriciteit"
     required_capacity_lv_network: "Benodigde capaciteit LV netwerk"
     required_network_capacity: "Benodigde elektriciteit capaciteitnetwerk"
-    sankey: "Sankey diagram van toekomstig energiegebruik"
-    sankey_2010: "Sankey diagram van huidig energiegebruik"
+    sankey: "Stroomdiagram van toekomstig energiegebruik"
+    sankey_2010: "Stroomdiagram van huidig energiegebruik"
     security_of_supply: "Leveringszekerheid"
     source_of_cooking_in_households: "Eindgebruik energie in huishoudens voor koken"
     source_of_cooling_in_buildings: "Vraag naar koeling in gebouwen"


### PR DESCRIPTION
More = 
- I've moved part of the introduction text to the start page and made an English version

![Screen Shot 2019-04-29 at 14 20 51](https://user-images.githubusercontent.com/32833996/56895828-6b50cf80-6a8a-11e9-9955-108a8b9f014b.png)

![Screen Shot 2019-04-29 at 16 54 42](https://user-images.githubusercontent.com/32833996/56904900-85e17380-6a9f-11e9-9b4f-09e66df684b7.png)

- Renaming some Sankey-charts to 'easier' names
- Renaming some dashboard items to more understandable names
- Adding chart names for new final demand overview charts