### PR TITLE
Fix translations and give PJ unit to new biomass items

### DIFF
--- a/app/assets/javascripts/lib/views/constraint_view.coffee
+++ b/app/assets/javascripts/lib/views/constraint_view.coffee
@@ -74,8 +74,8 @@ class @ConstraintView extends Backbone.View
       when 'net_energy_import', 'profitability'
         # 1 point precision
         Metric.ratio_as_percentage(result, false, 1)
-      when 'security_of_supply'
-        Metric.round_number(result, 1)
+      when 'biomass_primary_demand','biomass_final_demand'
+        "#{Metric.round_number(result, 1)} #{I18n.t('units.joules.billions')}"
       when 'renewable_percentage'
         Metric.ratio_as_percentage(result)
       when 'renewable_percentage_households'

--- a/app/assets/javascripts/lib/views/constraint_view.coffee
+++ b/app/assets/javascripts/lib/views/constraint_view.coffee
@@ -75,7 +75,7 @@ class @ConstraintView extends Backbone.View
         # 1 point precision
         Metric.ratio_as_percentage(result, false, 1)
       when 'biomass_primary_demand','biomass_final_demand'
-        "#{Metric.round_number(result, 1)} #{I18n.t('units.joules.billions')}"
+        Metric.autoscale_value(result, @model.gquery.get('unit'), 1)
       when 'renewable_percentage'
         Metric.ratio_as_percentage(result)
       when 'renewable_percentage_households'

--- a/config/locales/en_dashboard_items.yml
+++ b/config/locales/en_dashboard_items.yml
@@ -4,11 +4,11 @@ en:
       label: "Energy use"
       title: "Primary energy use"
     biomass_final_demand:
-      labeL: "Biomass use (final)"
-      labeL: "Final biomass use"
+      label: "Biomass use (final)"
+      title: "Final biomass use"
     biomass_primary_demand:
-      labeL: "Biomass use (primary)"
-      labeL: "Primary biomass use"
+      label: "Biomass use (primary)"
+      title: "Primary biomass use"
     blackout_hours:
       label: "Blackouts"
       title: "Number of blackout hours"

--- a/config/locales/nl_dashboard_items.yml
+++ b/config/locales/nl_dashboard_items.yml
@@ -4,11 +4,11 @@ nl:
       label: "Energiegebruik"
       title: "Primair energieverbruik"
     biomass_final_demand:
-      labeL: "Biomassagebruik (finaal)"
-      labeL: "Finaal biomassagebruik"
+      label: "Biomassagebruik (finaal)"
+      title: "Finaal biomassagebruik"
     biomass_primary_demand:
-      labeL: "Biomassagebruik (primair)"
-      labeL: "Primair biomassagebruik"
+      label: "Biomassagebruik (primair)"
+      title: "Primair biomassagebruik"
     blackout_hours:
       label: "Stroomuitval"
       title: "Aantal uren met stroomuitval"


### PR DESCRIPTION
I have given units to the new biomass dashboard items on BETA. However, now the unit (`PJ`) is fixed. Would be nice if this unit would automatically scale! Do you maybe have time to fix this @antw ?

For example now for a small dataset the dashboard item shows:
![Screen Shot 2019-06-05 at 16 07 13](https://user-images.githubusercontent.com/32833996/58963064-cde56b80-87ac-11e9-8f0e-6384af58c189.png)

Related issue: https://github.com/quintel/etmodel/issues/3033