### PR TITLE
Add slider "draw to" min / max attributes

### DIFF
--- a/app/assets/javascripts/lib/models/input_element.coffee
+++ b/app/assets/javascripts/lib/models/input_element.coffee
@@ -41,6 +41,30 @@ class @InputElement extends Backbone.Model
   logUpdate: =>
     App.debug "Slider #{@get 'key'}: #{@get('user_value')}"
 
+  # The lowest value which should be shown on the input element.
+  #
+  # If this is not set, or the value is higher than the input mininum value, the
+  # input minimum is returned instead.
+  #
+  # Returns a number.
+  drawToMin: ->
+    unless this.get('draw_to_min')?
+      return this.get('min_value')
+
+    Math.min(this.get('draw_to_min'), this.get('min_value'))
+
+  # The highest value which should be shown on the input element.
+  #
+  # If this is not set, or the value is lower than the input maxinum value, the
+  # input maximum is returned instead.
+  #
+  # Returns a number.
+  drawToMax: ->
+    unless this.get('draw_to_max')?
+      return this.get('max_value')
+
+    Math.max(this.get('draw_to_max'), this.get('max_value'))
+
   # if we're caching the user_values hash then we have to store locally the
   # user_values, without querying the engine
   update_collection: =>

--- a/app/assets/javascripts/lib/views/input_element_view.js
+++ b/app/assets/javascripts/lib/views/input_element_view.js
@@ -373,6 +373,11 @@
         step:       quinnStep,
         disable:    this.model.get('disabled'),
 
+        drawTo:     {
+          left: this.model.drawToMin(),
+          right: this.model.drawToMax()
+        },
+
         // Don't round initial values which don't fit the step.
         strict:     false,
 

--- a/app/assets/stylesheets/admin.sass
+++ b/app/assets/stylesheets/admin.sass
@@ -69,6 +69,18 @@ body#admin_section
       line-height: 1.6
       margin-top: 3px
 
+    .input_element_draw_to_min, .input_element_draw_to_max
+      display: inline-block
+      margin-bottom: 0
+      input
+        width: 133px
+      label
+        display: block
+        float: none
+        margin-left: 0
+        text-align: left
+        width: 153px
+
 // page-specific CSS
 body.output_elements_show
   #chart_preview

--- a/app/models/input_element.rb
+++ b/app/models/input_element.rb
@@ -53,9 +53,11 @@ class InputElement < ActiveRecord::Base
   # Used by the interface to setup quinn
   def json_attributes
     Jbuilder.encode do |json|
-      json.(self, :id, :unit, :share_group, :key, :related_converter, :step_value,
-            :disabled, :translated_name, :sanitized_description,
-            :fixed, :has_flash_movie)
+      json.call(
+        self, :id, :unit, :share_group, :key, :related_converter, :step_value,
+        :draw_to_min, :draw_to_max, :disabled, :translated_name,
+        :sanitized_description, :fixed, :has_flash_movie
+      )
     end
   end
 

--- a/app/views/admin/input_elements/_form.html.haml
+++ b/app/views/admin/input_elements/_form.html.haml
@@ -10,6 +10,19 @@
       :hint => "Sliders with the same interface_group will be shown as a group inside the slide, divided by a line and sub_header"
     = f.input :step_value, :as => :float, :required => true
     = f.input :unit, :required => true
+    .input.float
+      %label.text.optional.control-label
+        Draw to
+      = f.input :draw_to_min, :as => :float, :label => 'Minimum'
+      = f.input :draw_to_max, :as => :float, :label => 'Maximum'
+      %span.hint
+        Set custom minimum and maximum values to which the slider will be
+        drawn. Note that  the "draw to" settings will be ignored when higher
+        (for the minimum) or lower (for the maximum) than the ETEngine input
+        min/max. For example, if the input minimum is 50 and maximum is 100, you
+        may choose to set the draw to minimum to 25; this will draw a slider
+        which starts at 25 and ends at 100, but the user will not be able to
+        select a value below 50.
     = f.input :command_type, :as => :select,
       :collection => ['growth_rate', 'value', 'efficiency_improvement'],
       :hint => "This is used by the backcasting module"

--- a/db/migrate/20190613132730_add_draw_to_attributes_to_input_element.rb
+++ b/db/migrate/20190613132730_add_draw_to_attributes_to_input_element.rb
@@ -1,0 +1,6 @@
+class AddDrawToAttributesToInputElement < ActiveRecord::Migration[5.2]
+  def change
+    add_column :input_elements, :draw_to_min, :float, after: :step_value
+    add_column :input_elements, :draw_to_max, :float, after: :draw_to_min
+  end
+end

--- a/db/migrate/20190614144041_add_draw_to_min_to_insulation_inputs.rb
+++ b/db/migrate/20190614144041_add_draw_to_min_to_insulation_inputs.rb
@@ -1,0 +1,19 @@
+class AddDrawToMinToInsulationInputs < ActiveRecord::Migration[5.2]
+  KEYS = %i[
+    buildings_insulation_level
+    households_insulation_level_apartments
+    households_insulation_level_corner_houses
+    households_insulation_level_detached_houses
+    households_insulation_level_semi_detached_houses
+    households_insulation_level_terraced_houses
+  ]
+
+  def change
+    inputs = InputElement.where(key: KEYS)
+
+    reversible do |dir|
+      dir.up { inputs.update_all(draw_to_min: 0.0 )}
+      dir.down { inputs.update_all(draw_to_min: nil) }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_15_125123) do
+ActiveRecord::Schema.define(version: 2019_06_14_144041) do
 
   create_table "area_dependencies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "dependent_on"
@@ -59,6 +59,8 @@ ActiveRecord::Schema.define(version: 2019_05_15_125123) do
     t.string "key"
     t.string "share_group"
     t.float "step_value"
+    t.float "draw_to_min"
+    t.float "draw_to_max"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "unit"


### PR DESCRIPTION
Implements minimum and maximum "draw to" settings for sliders. Allows admins to set a custom minimum or maximum value to which a slider will be drawn – but users will not be allowed to select a value smaller or larger than the ETEngine input allows.

This provides us the ability to "draw" insulation sliders starting at zero, while disallowing the visitor from reducing the slider below the starting value.

To be merged simultaneously with quintel/etsource#2053

Closes #2984