### PR TITLE
fixed a bug where scenarios created in the ETE couldn't be loaded

### DIFF
--- a/app/views/scenarios/show.html.haml
+++ b/app/views/scenarios/show.html.haml
@@ -6,7 +6,7 @@
 
   %h1= @scenario.title.nil? ? t('scenario.no_title').truncate(40, separator: ' ') : @scenario.title.truncate(40, separator: ' ')
 
-  = link_to t("scenario.load"), load_saved_scenario_path(@scenario), class: "button primary"
+  = link_to t("scenario.load"), load_scenario_path(@scenario), class: "button primary"
 
   - if @scenario.description
     %em= @description


### PR DESCRIPTION
@antw My last PR did break scenarios that didn't have a corresponding saved_scenario. This fixes it.