### PR TITLE
Ask user to confirm before resetting their scenario

### DIFF
--- a/app/views/layouts/etm/_settings_menu.html.haml
+++ b/app/views/layouts/etm/_settings_menu.html.haml
@@ -32,7 +32,7 @@
 
         %a.save_as{:href => new_scenario_path}= t("header.save_scenario_as")
 
-        %a#reset_scenario{:href => scenario_reset_path}= t("header.reset_scenario")
+        %a#reset_scenario{ href: scenario_reset_path, data: { confirm: t('header.reset_scenario_confirm') } }= t("header.reset_scenario")
 
     - if controller_name != 'pages' && has_active_scenario?
       %li.sep

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -60,6 +60,7 @@ en:
     prominent_users: "Prominent users"
     prominent_users_of_etm: "Prominent users of the Energy Transition Model"
     reset_scenario: "Reset scenario"
+    reset_scenario_confirm: "Are you sure you wish to reset this scenario to the default settings? You will lose any changes you have made."
     save_scenario: "Save scenario"
     save_scenario_as: "Save scenario as"
     scenario_report: "Scenario report"

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -60,6 +60,7 @@ nl:
     prominent_users: "Prominente gebruikers"
     prominent_users_of_etm: "Prominente gebruikers van het Energietransitiemodel"
     reset_scenario: "Scenario resetten"
+    reset_scenario_confirm: "Are you sure you wish to reset this scenario to the default settings? You will lose any changes you have made."
     save_scenario: "Scenario opslaan"
     save_scenario_as: "Scenario opslaan als"
     settings: "Opties"

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -60,7 +60,7 @@ nl:
     prominent_users: "Prominente gebruikers"
     prominent_users_of_etm: "Prominente gebruikers van het Energietransitiemodel"
     reset_scenario: "Scenario resetten"
-    reset_scenario_confirm: "Are you sure you wish to reset this scenario to the default settings? You will lose any changes you have made."
+    reset_scenario_confirm: "Weet je zeker dat het scenario wil terugzetten naar de beginwaarden van dit scenario? Alle wijzigingen die je hebt gemaakt, zullen verloren gaan."
     save_scenario: "Scenario opslaan"
     save_scenario_as: "Scenario opslaan als"
     settings: "Opties"


### PR DESCRIPTION
Show a pop-up message asking the user to confirm that they wish to reset their scenario before doing so. Intended to prevent accidental mis-clicks. :wink:

Would you mind adding an appropriate translation in [config/locales/nl_etm.yml](https://github.com/quintel/etmodel/blob/41f7434f0dffdb43ad6b34413a0fe0e559850dbb/config/locales/nl_etm.yml#L63)?

Please reassign as you see fit.

---

Ref #3039