### PR TITLE
Added load factsheet button to show saved scenario page

### DIFF
--- a/app/views/saved_scenarios/show.html.haml
+++ b/app/views/saved_scenarios/show.html.haml
@@ -12,7 +12,7 @@
 
   = link_to t("scenario.load_factsheet"),
             factsheet_scenario_path(@saved_scenario.scenario_id),
-            class: "button primary"
+            class: "button"
 
   - if @scenario.description
     %em= @description

--- a/app/views/saved_scenarios/show.html.haml
+++ b/app/views/saved_scenarios/show.html.haml
@@ -4,10 +4,18 @@
     .warning
       = @warning
 
-  %h1= @scenario.title.nil? ? t('scenario.no_title').truncate(40, separator: ' ') : @scenario.title.truncate(40, separator: ' ')
+  %h1
+    = (@scenario.title.nil? ? t('scenario.no_title') : @scenario.title) |
+        .truncate(40, separator: ' ')                                   |
 
-  = link_to t("scenario.load"), load_saved_scenario_path(@saved_scenario), class: "button primary"
-  = link_to t("scenario.load_factsheet"), factsheet_scenario_path(@saved_scenario.scenario_id), class: "button primary"
+  = link_to t("scenario.load"),
+            load_saved_scenario_path(@saved_scenario),
+            class: "button primary"
+
+  = link_to t("scenario.load_factsheet"),
+            factsheet_scenario_path(@saved_scenario.scenario_id),
+            class: "button primary"
+
   -# Seems a to be a reduntant check to me. Don't think this is reachable
   -# without a saved scenario
   - if @scenario.description

--- a/app/views/saved_scenarios/show.html.haml
+++ b/app/views/saved_scenarios/show.html.haml
@@ -7,7 +7,7 @@
   %h1= @scenario.title.nil? ? t('scenario.no_title').truncate(40, separator: ' ') : @scenario.title.truncate(40, separator: ' ')
 
   = link_to t("scenario.load"), load_saved_scenario_path(@saved_scenario), class: "button primary"
-
+  = link_to t("scenario.load_factsheet"), factsheet_scenario_path(@saved_scenario.scenario_id), class: "button primary"
   -# Seems a to be a reduntant check to me. Don't think this is reachable
   -# without a saved scenario
   - if @scenario.description

--- a/app/views/saved_scenarios/show.html.haml
+++ b/app/views/saved_scenarios/show.html.haml
@@ -4,9 +4,7 @@
     .warning
       = @warning
 
-  %h1
-    = (@scenario.title.nil? ? t('scenario.no_title') : @scenario.title) |
-        .truncate(40, separator: ' ')                                   |
+  %h1= (@scenario.title or t 'scenario.no_title' ).truncate(40, separator: ' ')
 
   = link_to t("scenario.load"),
             load_saved_scenario_path(@saved_scenario),
@@ -16,8 +14,6 @@
             factsheet_scenario_path(@saved_scenario.scenario_id),
             class: "button primary"
 
-  -# Seems a to be a reduntant check to me. Don't think this is reachable
-  -# without a saved scenario
   - if @scenario.description
     %em= @description
 

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -183,6 +183,7 @@ en:
     go_back: "Or go back to"
     link: "Save your current settings into a scenario"
     load: "Open this scenario"
+    load_factsheet: "Open energy mix infographic"
     no_title: "Scenario without title"
     overview: "overview"
     overwritten: "Please note: Your current settings get overwritten."

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -184,6 +184,7 @@ nl:
     go_back: " of ga anders terug naar"
     link: "Sla uw huidige instellingen op in een scenario"
     load: "Open dit scenario"
+    load_factsheet: "Open energie-mix infographic"
     no_title: "Scenario zonder titel"
     overview: "overzicht"
     overwritten: "Let op: Je huidige instellingen worden overschreven."


### PR DESCRIPTION
Some users want to share factsheets about scenarios that are stable over for a long time. 
At the moment there is no easy way to generate a factsheet from a saved scenario. The current path always leads the user to an "API scenario".

This change enables a user to load a factsheet directly from the "show saved_scenario page".  The reason that I opted for this solution over the one in #3107 is that it has less impact in both development time and maintainability and it is closer to the workflow previously employed by users.
