### PR TITLE
Scenario button to PRO

### DIFF
--- a/app/views/saved_scenarios/show.html.haml
+++ b/app/views/saved_scenarios/show.html.haml
@@ -4,12 +4,16 @@
     .warning
       = @warning
 
-  %h1= @scenario.title.nil? ? t('scenario.no_title').truncate(40, separator: ' ') : @scenario.title.truncate(40, separator: ' ')
+  %h1= (@scenario.title or t 'scenario.no_title' ).truncate(40, separator: ' ')
 
-  = link_to t("scenario.load"), load_saved_scenario_path(@saved_scenario), class: "button primary"
+  = link_to t("scenario.load"),
+            load_saved_scenario_path(@saved_scenario),
+            class: "button primary"
 
-  -# Seems a to be a reduntant check to me. Don't think this is reachable
-  -# without a saved scenario
+  = link_to t("scenario.load_factsheet"),
+            factsheet_scenario_path(@saved_scenario.scenario_id),
+            class: "button"
+
   - if @scenario.description
     %em= @description
 

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -183,6 +183,7 @@ en:
     go_back: "Or go back to"
     link: "Save your current settings into a scenario"
     load: "Open this scenario"
+    load_factsheet: "Open energy mix infographic"
     no_title: "Scenario without title"
     overview: "overview"
     overwritten: "Please note: Your current settings get overwritten."

--- a/config/locales/en_output_element_series.yml
+++ b/config/locales/en_output_element_series.yml
@@ -133,6 +133,8 @@ en:
     buildings_collective_burner_network_gas: "Gas-fired burner - buildings"
     buildings_collective_geothermal: "Geothermal - buildings"
     buildings_collective_heatpump_water_water_electricity: "Collective heat pump - buildings"
+    buildings_cooling_demand: "Cooling buildings"
+    buildings_heating_demand: "Heating buildings"
     buildings_solar_pv_solar_radiation: 'Solar panels buildings'
     bunkers_flexibility_p2g_electricity: "Converted to kerosene for aviation"
     busses: "Busses"

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -184,6 +184,7 @@ nl:
     go_back: " of ga anders terug naar"
     link: "Sla uw huidige instellingen op in een scenario"
     load: "Open dit scenario"
+    load_factsheet: "Open energie-mix infographic"
     no_title: "Scenario zonder titel"
     overview: "overzicht"
     overwritten: "Let op: Je huidige instellingen worden overschreven."

--- a/config/locales/nl_output_element_series.yml
+++ b/config/locales/nl_output_element_series.yml
@@ -131,6 +131,8 @@ nl:
     buildings_collective_burner_network_gas: "Gasketel - gebouwen"
     buildings_collective_geothermal: "Geothermisch - gebouwen"
     buildings_collective_heatpump_water_water_electricity: "Collectieve warmtepomp - gebouwen"
+    buildings_cooling_demand: "Koeling - Gebouwen"
+    buildings_heating_demand: "Verwarming - Gebouwen"
     buildings_solar_pv_solar_radiation: 'Zonnepanelen gebouwen'
     bunkers_flexibility_p2g_electricity: "Omgezet naar kerosine voor luchtvaart"
     busses: "Bussen"


### PR DESCRIPTION
@ChaelKruip, @antw If you both agree: is it okay to cherry-pick the new 'load energy mix' button to PRO?
It is currently very difficult for users to open the energy mix for a saved scenario due to the new save/save as function.

Edit: also included a translation that is currently missing on PRO