### PR TITLE
Update DB and tables to use utf8mb4

### DIFF
--- a/db/migrate/20190816120851_set_mysql_encoding.rb
+++ b/db/migrate/20190816120851_set_mysql_encoding.rb
@@ -1,0 +1,64 @@
+class SetMysqlEncoding < ActiveRecord::Migration[5.2]
+  def up
+    unless ActiveRecord::Base.connection.adapter_name.downcase =~ /^mysql/
+      return
+    end
+
+    ActiveRecord::Base.transaction do
+      # Indexed VARCHAR columns must have length 191 or less when using MySQL
+      # 5.6 or older (*cough* Semaphore). https://stackoverflow.com/a/31474509
+      change_column :ar_internal_metadata, :key, :string, limit: 191
+      change_column :area_dependencies, :dependable_type, :string, limit: 191
+      change_column :constraints, :key, :string, limit: 191
+      change_column :descriptions, :describable_type, :string, limit: 191
+      change_column :input_elements, :key, :string, limit: 191
+      change_column :input_elements, :command_type, :string, limit: 191
+      change_column :output_elements, :key, :string, limit: 191
+      change_column :schema_migrations, :version, :string, limit: 191
+      change_column :sessions, :session_id, :string, limit: 191
+      change_column :sidebar_items, :key, :string, limit: 191
+      change_column :slides, :key, :string, limit: 191
+      change_column :tabs, :key, :string, limit: 191
+      change_column :texts, :key, :string, limit: 191
+      change_column :users, :email, :string, limit: 191
+
+      say_with_time "Updating database" do
+        ActiveRecord::Base.connection.execute(<<~SQL)
+          ALTER DATABASE #{ActiveRecord::Base.connection.current_database}
+          CHARACTER SET = utf8mb4
+          COLLATE = utf8mb4_unicode_ci
+        SQL
+      end
+
+      ActiveRecord::Base.connection.tables.each do |table|
+        say_with_time "Updating #{table}" do
+          ActiveRecord::Base.connection.execute(<<~SQL)
+            ALTER TABLE #{table}
+            CONVERT TO CHARACTER SET utf8mb4
+            COLLATE utf8mb4_unicode_ci
+          SQL
+        end
+      end
+
+      # Updating to mb4 seems to switch TEXT columns to MEDIUMTEXT. I guess this
+      # makes sense where they may be long text descriptions, but in most cases
+      # it isn't needed...
+      text_length = 64.kilobytes - 1
+
+      change_column :area_dependencies, :description, :text, limit: text_length
+      change_column :descriptions, :short_content_en, :text, limit: text_length
+      change_column :descriptions, :short_content_nl, :text, limit: text_length
+      change_column :input_elements, :comments, :text, limit: text_length
+      change_column :saved_scenarios, :settings, :text, limit: text_length
+      change_column :sidebar_items, :percentage_bar_query, :text, limit: text_length
+      change_column :texts, :short_content_en, :text, limit: text_length
+      change_column :texts, :short_content_nl, :text, limit: text_length
+    end
+  end
+
+  def down
+    if ActiveRecord::Base.connection.adapter_name.downcase =~ /^mysql/
+      raise ActiveRecord::IrreversibleMigration
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,22 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_07_115016) do
+ActiveRecord::Schema.define(version: 2019_08_16_120851) do
 
-  create_table "area_dependencies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "area_dependencies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "dependent_on"
     t.text "description"
     t.integer "dependable_id"
-    t.string "dependable_type"
+    t.string "dependable_type", limit: 191
     t.index ["dependable_id", "dependable_type"], name: "index_area_dependencies_on_dependable_id_and_dependable_type"
   end
 
-  create_table "constraints", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "key"
+  create_table "constraints", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "key", limit: 191
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "gquery_key"
-    t.string "group", limit: 25, default: "", null: false
+    t.string "group", limit: 25, null: false
     t.integer "position"
     t.boolean "disabled", default: false
     t.integer "output_element_id"
@@ -34,19 +34,19 @@ ActiveRecord::Schema.define(version: 2019_08_07_115016) do
     t.index ["position"], name: "index_constraints_on_position"
   end
 
-  create_table "descriptions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.text "content_en"
+  create_table "descriptions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.text "content_en", limit: 16777215
     t.text "short_content_en"
     t.integer "describable_id"
-    t.string "describable_type"
+    t.string "describable_type", limit: 191
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text "content_nl"
+    t.text "content_nl", limit: 16777215
     t.text "short_content_nl"
     t.index ["describable_id", "describable_type"], name: "index_descriptions_on_describable_id_and_describable_type"
   end
 
-  create_table "general_user_notifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "general_user_notifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "key"
     t.string "notification_nl"
     t.string "notification_en"
@@ -55,8 +55,8 @@ ActiveRecord::Schema.define(version: 2019_08_07_115016) do
     t.datetime "updated_at"
   end
 
-  create_table "input_elements", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "key"
+  create_table "input_elements", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "key", limit: 191
     t.string "share_group"
     t.float "step_value"
     t.float "draw_to_min"
@@ -67,7 +67,7 @@ ActiveRecord::Schema.define(version: 2019_08_07_115016) do
     t.boolean "fixed"
     t.text "comments"
     t.string "interface_group"
-    t.string "command_type"
+    t.string "command_type", limit: 191
     t.string "related_converter"
     t.integer "slide_id"
     t.integer "position"
@@ -77,23 +77,23 @@ ActiveRecord::Schema.define(version: 2019_08_07_115016) do
     t.index ["slide_id"], name: "index_input_elements_on_slide_id"
   end
 
-  create_table "multi_year_chart_scenarios", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "multi_year_chart_scenarios", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "multi_year_chart_id", null: false
     t.integer "scenario_id", null: false
     t.index ["multi_year_chart_id"], name: "index_multi_year_chart_scenarios_on_multi_year_chart_id"
     t.index ["scenario_id"], name: "index_multi_year_chart_scenarios_on_scenario_id"
   end
 
-  create_table "multi_year_charts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "multi_year_charts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.string "title", default: "", null: false
-    t.string "area_code", default: "", null: false
+    t.string "title", null: false
+    t.string "area_code", null: false
     t.integer "end_year", null: false
     t.datetime "created_at", null: false
     t.index ["user_id"], name: "index_multi_year_charts_on_user_id"
   end
 
-  create_table "output_element_series", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "output_element_series", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "output_element_id"
     t.string "label"
     t.string "color"
@@ -104,18 +104,18 @@ ActiveRecord::Schema.define(version: 2019_08_07_115016) do
     t.boolean "show_at_first"
     t.boolean "is_target_line"
     t.string "target_line_position"
-    t.string "gquery", default: "", null: false
+    t.string "gquery", null: false
     t.boolean "is_1990"
     t.index ["output_element_id"], name: "index_output_element_series_on_output_element_id"
   end
 
-  create_table "output_element_types", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "output_element_types", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "output_elements", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "output_elements", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "output_element_type_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -126,7 +126,7 @@ ActiveRecord::Schema.define(version: 2019_08_07_115016) do
     t.string "sub_group"
     t.boolean "show_point_label", default: false
     t.boolean "growth_chart", default: false
-    t.string "key", default: "", null: false
+    t.string "key", limit: 191, null: false
     t.float "max_axis_value"
     t.float "min_axis_value"
     t.boolean "hidden", default: false
@@ -137,13 +137,13 @@ ActiveRecord::Schema.define(version: 2019_08_07_115016) do
     t.index ["related_output_element_id"], name: "index_output_elements_on_related_output_element_id"
   end
 
-  create_table "roles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "roles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "saved_scenarios", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "saved_scenarios", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "scenario_id", null: false
     t.string "scenario_id_history"
@@ -154,17 +154,17 @@ ActiveRecord::Schema.define(version: 2019_08_07_115016) do
     t.index ["user_id"], name: "index_saved_scenarios_on_user_id"
   end
 
-  create_table "sessions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
-    t.string "session_id", null: false
-    t.text "data"
+  create_table "sessions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "session_id", limit: 191, null: false
+    t.text "data", limit: 16777215
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["session_id"], name: "index_sessions_on_session_id"
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
-  create_table "sidebar_items", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "key"
+  create_table "sidebar_items", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "key", limit: 191
     t.string "section"
     t.text "percentage_bar_query"
     t.string "nl_vimeo_id"
@@ -178,14 +178,14 @@ ActiveRecord::Schema.define(version: 2019_08_07_115016) do
     t.index ["tab_id"], name: "index_sidebar_items_on_tab_id"
   end
 
-  create_table "slides", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "slides", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "image"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "general_sub_header"
     t.string "group_sub_header"
     t.string "subheader_image"
-    t.string "key"
+    t.string "key", limit: 191
     t.integer "position"
     t.integer "sidebar_item_id"
     t.integer "output_element_id"
@@ -195,8 +195,8 @@ ActiveRecord::Schema.define(version: 2019_08_07_115016) do
     t.index ["sidebar_item_id"], name: "index_slides_on_sidebar_item_id"
   end
 
-  create_table "tabs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "key"
+  create_table "tabs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "key", limit: 191
     t.string "nl_vimeo_id"
     t.string "en_vimeo_id"
     t.integer "position"
@@ -204,10 +204,10 @@ ActiveRecord::Schema.define(version: 2019_08_07_115016) do
     t.index ["position"], name: "index_tabs_on_position"
   end
 
-  create_table "texts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "key"
-    t.text "content_en"
-    t.text "content_nl"
+  create_table "texts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "key", limit: 191
+    t.text "content_en", limit: 16777215
+    t.text "content_nl", limit: 16777215
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "title_en"
@@ -217,16 +217,16 @@ ActiveRecord::Schema.define(version: 2019_08_07_115016) do
     t.index ["key"], name: "index_translations_on_key"
   end
 
-  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name", default: "", null: false
-    t.string "email", default: "", null: false
+  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", limit: 191, null: false
     t.string "company_school"
     t.boolean "allow_news", default: false
     t.string "heared_first_at", default: ".."
     t.string "crypted_password"
     t.string "password_salt"
-    t.string "persistence_token", default: "", null: false
-    t.string "perishable_token", default: "", null: false
+    t.string "persistence_token", null: false
+    t.string "perishable_token", null: false
     t.integer "login_count", default: 0, null: false
     t.integer "failed_login_count", default: 0, null: false
     t.datetime "last_request_at"


### PR DESCRIPTION
Updates the database and tables to use `utf8mb4` character set and `utf8mb4_unicode_ci` collation. Hopefully this will fix the constantly changing schema.rb. 😅 

Changing the character set seems to bump TEXT columns to MEDIUMTEXT (perhaps because the extra bytes might not fit in TEXT?). In most cases I don't think this extra space is needed so I adjusted those columns back down to 64kb.