### PR TITLE
Rename power_to_power to household_batteries in flex merit order

### DIFF
--- a/app/models/flexibility_order.rb
+++ b/app/models/flexibility_order.rb
@@ -1,6 +1,6 @@
 class FlexibilityOrder
   def self.all
-    %w(power_to_power
+    %w(household_batteries
        mv_batteries
        electric_vehicle
        opac

--- a/config/locales/en_output_elements.yml
+++ b/config/locales/en_output_elements.yml
@@ -72,7 +72,7 @@ en:
       electric_vehicle: "Storage in electric vehicles"
       power_to_heat: "Conversion to heat for households"
       power_to_heat_industry: "Conversion to heat for industry"
-      power_to_power: "Storage in household batteries"
+      household_batteries: "Storage in household batteries"
       power_to_gas: "Conversion to hydrogen"
       power_to_kerosene: "Conversion to kerosene for aviation"
       power_to_methane: "Conversion to methane for gas network"

--- a/config/locales/nl_output_elements.yml
+++ b/config/locales/nl_output_elements.yml
@@ -68,7 +68,7 @@ nl:
       electric_vehicle: "Opslag in elektrische auto's"
       power_to_heat: "Conversie naar warmte voor huishoudens"
       power_to_heat_industry: "Conversie naar warmte voor industrie"
-      power_to_power: "Opslag in thuisbatterijen"
+      household_batteries: "Opslag in thuisbatterijen"
       power_to_gas: "Conversie naar waterstof"
       power_to_kerosene: "Conversie naar kerosine voor luchtvaart"
       power_to_methane: "Conversie naar methaan voor gasnetwerk"


### PR DESCRIPTION
Follows name change on ETEngine (https://github.com/quintel/etengine/blob/master/app/models/flexibility_order.rb#L5)