### PR TITLE
add missing output element series for household batteries

### DIFF
--- a/config/locales/en_output_element_series.yml
+++ b/config/locales/en_output_element_series.yml
@@ -260,6 +260,7 @@ en:
     electricity_demand_excluding_heating: "Electricity demand, excluding heating"
     electricity_import: "Electricity import"
     electricity_stored_in_batteries: "Stored in batteries"
+    electricity_stored_in_household_batteries: "Stored in household batteries"
     electricity_stored_in_EV: "Stored in EV"
     electricity_stored_in_opac: "Stored in underground pumped hydro storage"
     electricity_stored_in_mv_batteries: "Stored in large-scale batteries"

--- a/config/locales/nl_output_elements.yml
+++ b/config/locales/nl_output_elements.yml
@@ -298,6 +298,7 @@ nl:
         annual_electricity_input: "Jaarlijkse inzet elektriciteit"
         annual_energy_output: "Jaarlijkse output energie"
         electricity_stored_in_batteries: "Opslag in batterijen"
+        electricity_stored_in_household_batteries: "Opslag in thuisbatterijen"
         electricity_stored_in_EV: "Opslag in elektrische auto's"
         electricity_stored_in_pumped_storage: "Opslag in stuwmeren"
         electricity_stored_in_opac: "Opslag in OPAC"


### PR DESCRIPTION
Found a missing translation for households batteries. @antw If you have time, could you deploy this to production?