### PR TITLE
Only set scenario id when page is loaded with scenario=true

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -26,7 +26,6 @@ class PagesController < ApplicationController
     @time ||= 'present'
     @year = Current.setting.end_year if @time == 'future'
     @year ||= @area.analysis_year
-    @scenario_id = Current.setting.api_session_id if params[:scenario]
   end
 
   # Popup with the text description. This is confusing because the title can

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -26,6 +26,7 @@ class PagesController < ApplicationController
     @time ||= 'present'
     @year = Current.setting.end_year if @time == 'future'
     @year ||= @area.analysis_year
+    @scenario_id = Current.setting.api_session_id if params[:scenario]
   end
 
   # Popup with the text description. This is confusing because the title can

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -39,4 +39,19 @@ module PagesHelper
       class: 'area-flag', alt: ''
     )
   end
+
+  # Public: Returns the options for the co2 factsheet.
+  def co2_factsheet_options
+    {
+      area: @area.area,
+      host: APP_CONFIG[:api_url],
+      max_year: Setting::MAX_YEAR,
+      min_year: Setting::MIN_YEAR,
+      default_year: Setting::DEFAULT_YEAR,
+      scenario_id: params[:scenario],
+      time: @time,
+      non_energy: params[:non_energy]
+    }
+  end
+
 end

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -53,5 +53,4 @@ module PagesHelper
       non_energy: params[:non_energy]
     }
   end
-
 end

--- a/app/views/pages/dataset.html.haml
+++ b/app/views/pages/dataset.html.haml
@@ -20,10 +20,12 @@
         - if params[:scenario]
           %ul.toggle_year{ data: { time: @time } }
             %li#present
-              = link_to @area.analysis_year, region_path(time: 'present', scenario: params[:scenario] , non_energy: params[:non_energy]), class: 'button'
+              = link_to @area.analysis_year,
+                        region_path(time: 'present', scenario: params[:scenario] , non_energy: params[:non_energy]), class: 'button'
 
             %li#future
-              = link_to Current.setting.end_year, region_path(time: 'future', scenario: params[:scenario] ,non_energy: params[:non_energy]), class: 'button'
+              = link_to Current.setting.end_year,
+                        region_path(time: 'future', scenario: params[:scenario] ,non_energy: params[:non_energy]), class: 'button'
 
       .clearfix
 

--- a/app/views/pages/dataset.html.haml
+++ b/app/views/pages/dataset.html.haml
@@ -10,7 +10,7 @@
           = image_tag 'reports/print.svg'
           %span= t('report.print')
 
-    .page#establishment_shot{ data: { area: @area.area, host: APP_CONFIG[:api_url], max_year: Setting::MAX_YEAR, min_year: Setting::MIN_YEAR, default_year: Setting::DEFAULT_YEAR, scenario_id: @scenario_id, time: @time, non_energy: params[:non_energy] } }
+    .page#establishment_shot{ data: co2_factsheet_options }
       .title
         %h1
           = t('establishment_shot.header_html', area: I18n.t("areas.#{@area.area}"))
@@ -20,10 +20,10 @@
         - if params[:scenario]
           %ul.toggle_year{ data: { time: @time } }
             %li#present
-              = link_to @area.analysis_year, region_path(time: 'present', scenario: true, non_energy: params[:non_energy]), class: 'button'
+              = link_to @area.analysis_year, region_path(time: 'present', scenario: params[:scenario] , non_energy: params[:non_energy]), class: 'button'
 
             %li#future
-              = link_to Current.setting.end_year, region_path(time: 'future', scenario: true,non_energy: params[:non_energy]), class: 'button'
+              = link_to Current.setting.end_year, region_path(time: 'future', scenario: params[:scenario] ,non_energy: params[:non_energy]), class: 'button'
 
       .clearfix
 
@@ -73,9 +73,9 @@
           .small-text.no-print
             **
             - if params[:non_energy] == "off"
-              = link_to I18n.t("establishment_shot.show"), region_path(time: @time, scenario: true)
+              = link_to I18n.t("establishment_shot.show"), region_path(time: @time, scenario: params[:scenario])
             - else
-              = link_to I18n.t("establishment_shot.hide"), region_path(time: @time, scenario: true, non_energy: "off")
+              = link_to I18n.t("establishment_shot.hide"), region_path(time: @time, scenario: params[:scenario], non_energy: "off")
             #{I18n.t("establishment_shot.toggle_non_energy")} #{@area.analysis_year}.
             = I18n.t("establishment_shot.non_energy_info")
 

--- a/app/views/pages/dataset.html.haml
+++ b/app/views/pages/dataset.html.haml
@@ -10,7 +10,7 @@
           = image_tag 'reports/print.svg'
           %span= t('report.print')
 
-    .page#establishment_shot{ data: { area: @area.area, host: APP_CONFIG[:api_url], max_year: Setting::MAX_YEAR, min_year: Setting::MIN_YEAR, default_year: Setting::DEFAULT_YEAR, scenario_id: Current.setting.api_session_id, time: @time, non_energy: params[:non_energy] } }
+    .page#establishment_shot{ data: { area: @area.area, host: APP_CONFIG[:api_url], max_year: Setting::MAX_YEAR, min_year: Setting::MIN_YEAR, default_year: Setting::DEFAULT_YEAR, scenario_id: @scenario_id, time: @time, non_energy: params[:non_energy] } }
       .title
         %h1
           = t('establishment_shot.header_html', area: I18n.t("areas.#{@area.area}"))

--- a/app/views/pages/dataset.html.haml
+++ b/app/views/pages/dataset.html.haml
@@ -73,9 +73,11 @@
           .small-text.no-print
             **
             - if params[:non_energy] == "off"
-              = link_to I18n.t("establishment_shot.show"), region_path(time: @time, scenario: params[:scenario])
+              = link_to I18n.t("establishment_shot.show"),
+                        region_path(time: @time, scenario: params[:scenario])
             - else
-              = link_to I18n.t("establishment_shot.hide"), region_path(time: @time, scenario: params[:scenario], non_energy: "off")
+              = link_to I18n.t("establishment_shot.hide"),
+                        region_path(time: @time, scenario: params[:scenario], non_energy: "off")
             #{I18n.t("establishment_shot.toggle_non_energy")} #{@area.analysis_year}.
             = I18n.t("establishment_shot.non_energy_info")
 

--- a/db/migrate/20191125082234_update_link_on_slide_co2_sheets.rb
+++ b/db/migrate/20191125082234_update_link_on_slide_co2_sheets.rb
@@ -1,0 +1,20 @@
+class UpdateLinkOnSlideCo2Sheets < ActiveRecord::Migration[5.2]
+  def change
+    description = Slide.find_by_key(:data_visuals_co2_sheet).description
+
+    find = 'scenario=true'
+    replace = 'scenario=%{scenario_id}'
+
+    reversible do |dir|
+      dir.up   { update_description(description, find, replace) }
+      dir.down { update_description(description, replace, find) }
+    end
+  end
+
+  def update_description(description, find, replace)
+    description.content_en = description.content_en.gsub(find, replace)
+    description.content_nl = description.content_nl.gsub(find, replace)
+
+    description.save(validate: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_11_141808) do
+ActiveRecord::Schema.define(version: 2019_11_25_082234) do
 
   create_table "area_dependencies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "dependent_on"


### PR DESCRIPTION
This is what was happening:
The CO2 sheet was taking the current scenario_id to base the chart on - even when clicking the link from the root page. So if you made a scenario, but decided to check another regions CO2 sheet from the root page, you would instead get a chart based on the scenario you had just been working on.