### PR TITLE
Replaced blue icon fill with white fill

### DIFF
--- a/app/assets/stylesheets/factsheets.sass
+++ b/app/assets/stylesheets/factsheets.sass
@@ -398,7 +398,7 @@ body#factsheet
       fill: $text-color
 
     path
-      fill: #83B0EA
+      fill: #fff
 
     .domain, .tick
       fill: none


### PR DESCRIPTION
In the factsheet (energy mix) the wood icon in the upper left barchart was blue instead of white. I replaced the color #83b0ea for #fff. Nothing seems to break from the swap, but tell me if I overlooked something that is dependent on the blue.