### PR TITLE
Factsheet link

### DIFF
--- a/app/controllers/factsheets_controller.rb
+++ b/app/controllers/factsheets_controller.rb
@@ -3,6 +3,7 @@ class FactsheetsController < ApplicationController
 
   def show
     @scenario = Api::Scenario.find(params[:id])
+    @saved_scenario = SavedScenario.find_by(scenario_id: @scenario.id)
   rescue ActiveResource::ResourceNotFound
     # No such scenario.
     render_not_found('scenario')

--- a/app/views/factsheets/show.html.haml
+++ b/app/views/factsheets/show.html.haml
@@ -190,8 +190,7 @@
   %footer
     Deze factsheet is gegenereerd door het Energietransitiemodel
     - if @saved_scenario
-      voor het volgende
-      scenario:
+      voor het volgende scenario:
       = link_to(saved_scenario_url(@saved_scenario.id).gsub(%r{^https?://}, ''), saved_scenario_url(@saved_scenario.id))
 
 #factsheet-reverse(style="display: none")

--- a/app/views/factsheets/show.html.haml
+++ b/app/views/factsheets/show.html.haml
@@ -188,9 +188,11 @@
               %span(data-query="factsheet_demand_of_biomass_other") &mdash;
 
   %footer
-    Deze factsheet is gegenereerd door het Energietransitiemodel voor het volgende
-    scenario:
-    = link_to(scenario_url(@scenario.id).gsub(%r{^https?://}, ''), scenario_url(@scenario.id))
+    Deze factsheet is gegenereerd door het Energietransitiemodel
+    - if @saved_scenario
+      voor het volgende
+      scenario:
+      = link_to(saved_scenario_url(@saved_scenario.id).gsub(%r{^https?://}, ''), saved_scenario_url(@saved_scenario.id))
 
 #factsheet-reverse(style="display: none")
   .columns


### PR DESCRIPTION
Another one for the factsheets :)
The link in the bottom of the factsheet currently points to the scenario. Requests have been made to change this to the saved_scenario, for a more stable shareable factsheet. (After a lot of calls from confused users)