### PR TITLE
Add input to toggle heat network storage

### DIFF
--- a/config/locales/en_slides.yml
+++ b/config/locales/en_slides.yml
@@ -183,6 +183,7 @@ en:
     supply_heat_network_agriculture: "Heat network agriculture"
     supply_heat_network_large_scale: "Large-scale heat and residual heat"
     supply_heat_network_order: "Priority of dispatchable heat producers"
+    supply_heat_network_storage_toggle: "Heat storage"
     supply_hydrogen_demand: "Hydrogen demand"
     supply_hydrogen_production: "Hydrogen production"
     supply_hydrogen_transport: "Hydrogen transport"

--- a/config/locales/en_slides.yml
+++ b/config/locales/en_slides.yml
@@ -183,7 +183,7 @@ en:
     supply_heat_network_agriculture: "Heat network agriculture"
     supply_heat_network_large_scale: "Large-scale heat and residual heat"
     supply_heat_network_order: "Priority of dispatchable heat producers"
-    supply_heat_network_storage_toggle: "Heat storage"
+    supply_heat_network_storage_toggle: "(Seasonal) storage of heat"
     supply_hydrogen_demand: "Hydrogen demand"
     supply_hydrogen_production: "Hydrogen production"
     supply_hydrogen_transport: "Hydrogen transport"

--- a/config/locales/nl_slides.yml
+++ b/config/locales/nl_slides.yml
@@ -186,6 +186,7 @@ nl:
     supply_heat_network_agriculture: "Warmtenet landbouw"
     supply_heat_network_large_scale: "Grootschalige warmte en restwarmte"
     supply_heat_network_order: "Inzetvolgorde van regelbare warmtebronnen"
+    supply_heat_network_storage_toggle: "Warmteopslag"
     supply_hydrogen_demand: "Waterstofvraag"
     supply_hydrogen_production: "Waterstofproductie"
     supply_hydrogen_transport: "Waterstoftransport"

--- a/config/locales/nl_slides.yml
+++ b/config/locales/nl_slides.yml
@@ -186,7 +186,7 @@ nl:
     supply_heat_network_agriculture: "Warmtenet landbouw"
     supply_heat_network_large_scale: "Grootschalige warmte en restwarmte"
     supply_heat_network_order: "Inzetvolgorde van regelbare warmtebronnen"
-    supply_heat_network_storage_toggle: "Warmteopslag"
+    supply_heat_network_storage_toggle: "(Seizoens)opslag van warmte"
     supply_hydrogen_demand: "Waterstofvraag"
     supply_hydrogen_production: "Waterstofproductie"
     supply_hydrogen_transport: "Waterstoftransport"

--- a/db/migrate/20191219125858_add_heat_storage_toggle_input.rb
+++ b/db/migrate/20191219125858_add_heat_storage_toggle_input.rb
@@ -16,10 +16,12 @@ class AddHeatStorageToggleInput < ActiveRecord::Migration[5.2]
           of dispatchable capacity required during large spikes in demand.
         TEXT
         content_nl: <<-TEXT.strip_heredoc
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam rutrum
-          in nunc quis feugiat. Fusce ut mauris orci. Ut facilisis quam ex, in
-          pellentesque neque volutpat ut. Aenean pulvinar ligula sed ullamcorper
-          vestibulum. Aliquam hendrerit hendrerit nulla.
+          Scenario's met een grote hoeveelheid 'must run' en volatiele warmteproductie
+          zoals zonthermie, geothermie of restwarmte, hebben vaak een aanzienlijke
+          warmteproductie in uren met geen of weinig vraag. (Seizoens)opslag stelt
+          je in staat om deze warmte op te slaan en op een later moment in te zetten.
+          Hierdoor is er minder regelbaar vermogen nodig, zoals warmteketels, om de
+          vraagpieken te voorzien.
         TEXT
       }
     )

--- a/db/migrate/20191219125858_add_heat_storage_toggle_input.rb
+++ b/db/migrate/20191219125858_add_heat_storage_toggle_input.rb
@@ -1,0 +1,40 @@
+class AddHeatStorageToggleInput < ActiveRecord::Migration[5.2]
+  def up
+    sidebar_item = SidebarItem.where(key: 'heat').first!
+    output_element = OutputElement.where(key: 'collective_heat_mekko').first!
+
+    slide = Slide.create!(
+      key: 'supply_heat_network_storage_toggle',
+      sidebar_item: sidebar_item,
+      output_element: output_element,
+      position: sidebar_item.slides.ordered.last.position + 1,
+      description_attributes: {
+        content_en: <<-TEXT.strip_heredoc,
+          Scenarios with large amounts of "must-run" heat production will often
+          have considerable excesses of heat. Storage allows you to preserve
+          this heat for later use (subject to some losses), reducing the amount
+          of dispatchable capacity required during large spikes in demand.
+        TEXT
+        content_nl: <<-TEXT.strip_heredoc
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam rutrum
+          in nunc quis feugiat. Fusce ut mauris orci. Ut facilisis quam ex, in
+          pellentesque neque volutpat ut. Aenean pulvinar ligula sed ullamcorper
+          vestibulum. Aliquam hendrerit hendrerit nulla.
+        TEXT
+      }
+    )
+
+    InputElement.create!(
+      key: 'heat_storage_enabled',
+      unit: 'boolean',
+      slide: slide,
+      step_value: 1,
+      position: 1
+    )
+  end
+
+  def down
+    InputElement.where(key: 'heat_storage_enabled').first!.destroy!
+    Slide.where(key: 'supply_heat_network_storage_toggle').first!.destroy!
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_19_103918) do
+ActiveRecord::Schema.define(version: 2019_12_19_125858) do
 
   create_table "area_dependencies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "dependent_on"


### PR DESCRIPTION
Adds a toggle switch to the heat networks section, allowing the visitor to toggle on or off storage within the heat network.

There's [a description text needed](https://github.com/quintel/etmodel/blob/7322496e6b8797efaf65d0622d6a791e05739c02/db/migrate/20191219125858_add_heat_storage_toggle_input.rb#L18-L23) before this can be merged.

Merge first: https://github.com/quintel/etsource/pull/2168