### PR TITLE
Update heat network part of report due to heat network updates

### DIFF
--- a/config/reports/main.en.liquid
+++ b/config/reports/main.en.liquid
@@ -288,22 +288,22 @@
         Electricity mix.
       {% endchart %}
 
-    <h2>Central heat network</h2>
+    <h2>District heating</h2>
 
       <p>
-        The central heat network in your scenario can be used to heat houses and
-        buildings and provides heat to the industry and agricultural sectors. The
-        chart below show the balance of heat produced and consumed centrally.
+        District heating in your scenario can be used to heat houses and
+        buildings and provide heat to agricultural sectors. The
+        chart below shows the yearly balance of heat produced and consumed.
       </p>
 
-      {% chart 174 %}
-        Heat balance of central heat network.
+      {% chart 248 %}
+         Demand and supply of district heating
       {% endchart %}
 
       {% if future.energy_heat_unused_steam_hot_water_in_collective_heat_network_mekko > 0.0 %}
         <p>
           There is
-          {{ future.energy_heat_unused_steam_hot_water_in_collective_heat_network_mekko | autoscale: 'PJ'}}
+          {{ future.energy_heat_unused_steam_hot_water_in_collective_heat_network_mekko | autoscale: 'MJ'}}
           excess heat produced in agriculture or industry which flows back into the central heat
           network but is not used by other sectors.
         </p>
@@ -311,15 +311,14 @@
         <p>You can balance the network by</p>
 
         <ul>
-          <li><strong>Reducing heat production</strong>: in the industry and agriculture sections you can
-            decrease numbers of CHPs and burners.</li>
-          <li><strong>Increase demand</strong>: by increasing the demand of all sectors in the left-hand side
-            of the diagram.</li>
+          <li><strong>Reducing heat production</strong>: you can decrease the number of heat sources</li>
+          <li><strong>Increase demand</strong>: you can increase the demand of all sectors in the left-hand side
+            of the diagram</li>
         </ul>
       {% else %}
         <p>
           There is
-          {{ future.energy_heat_backup_burner_network_gas_in_collective_heat_network_mekko | autoscale: 'PJ'}}
+          {{ future.energy_heat_backup_burner_network_gas_in_collective_heat_network_mekko | autoscale: 'MJ'}}
           insufficient heat produced to satisfy the demand of the central heat network. A backup
           gas heater is deployed to satisfy the deficit.
         </p>
@@ -327,10 +326,9 @@
         <p>You can balance the network by</p>
 
         <ul>
-          <li><strong>Building more heat production</strong>: in the industry and agriculture sections you can
-            generate more heat by increasing numbers of CHPs and burners.</li>
+          <li><strong>Building more heat production</strong>: you can generate more heat by increasing the number of heat sources</li>
           <li><strong>Decreasing demand</strong>: by reducing the demand of all sectors in the left-hand side
-            of the diagram.</li>
+            of the diagram</li>
         </ul>
       {% endif %}
 
@@ -637,7 +635,7 @@
       For electricity generation, the renewability is
       {{ future.share_of_renewable_electricity | times: 100 | round: 1 }}%.
 
-      {% chart 112 %}
+      {% chart 212 %}
         Renewability of produced electricity. The renewability is defined as all renewable electricity
         production divided by local electricity consumption and can be larger than 100%.
       {% endchart %}

--- a/config/reports/main.nl.liquid
+++ b/config/reports/main.nl.liquid
@@ -375,7 +375,7 @@
     Hieronder zie je een overzicht van de vraag (links) en aanbod (rechts) op het warmtenet. Wanneer er te
 	weinig warmteaanbod is in het scenario, dan springt er een gas back-up ketel aan. Wanneer er overschotten zijn,
 	dan zie je dit aan de linkerkant in het lichtroze.
-        {% chart 234 %}
+        {% chart 248 %}
         Vraag (links) en aanbod (rechts) op het warmtenet in {{ settings.end_year }}.
         {% endchart %}
   	</p>
@@ -383,28 +383,27 @@
   	{% if future.energy_heat_unused_steam_hot_water_in_collective_heat_network_mekko > 0.0 %}
         <p>
           Er wordt
-          {{ future.energy_heat_unused_steam_hot_water_in_collective_heat_network_mekko | autoscale: 'PJ'}}
+          {{ future.energy_heat_unused_steam_hot_water_in_collective_heat_network_mekko | autoscale: 'MJ'}}
           aan restwarmte uit het netwerk niet gebruikt!
         </p>
 
         <p>Je kunt vraag en aanbod als volgt op elkaar afstemmen:</p>
 
         <ul>
-          <li><strong>Productieverlaging</strong>: verlaag het aantal WKK-centrales in landbouw en industrie.</li>
-          <li><strong>Vraagtoename</strong>: vergroot de vraag van de sectoren in het linkerdeel van de grafiek.</li>
+          <li><strong>Productieverlaging</strong>: verlaag het aantal warmtbronnen</li>
+          <li><strong>Vraagtoename</strong>: vergroot de warmtevraag van de sectoren in het linkerdeel van de grafiek</li>
         </ul>
    	{% else %}
         <p>
         Er is onvoldoende warmte geproduceerd. Een back-up gasketel wordt nu ingezet om het tekort van
-		{{ future.energy_heat_backup_burner_network_gas_in_collective_heat_network_mekko | autoscale: 'PJ'}} op te vangen.
+		{{ future.energy_heat_backup_burner_network_gas_in_collective_heat_network_mekko | autoscale: 'MJ'}} op te vangen.
         </p>
 
         <p>Je kunt vraag en aanbod als volgt op elkaar afstemmen:</p>
 
         <ul>
-          <li><strong>Productieverhoging</strong>: vergroot het aantal WKK-centrales en branders in
-            landbouw en industrie.</li>
-          <li><strong>Vraagverlaging</strong>: reduceer de warmtevraag van de sectoren in het linkerdeel van de grafiek.</li>
+          <li><strong>Productieverhoging</strong>: vergroot het aantal warmtebronnen
+          <li><strong>Vraagverlaging</strong>: reduceer de warmtevraag van de sectoren in het linkerdeel van de grafiek</li>
         </ul>
  	{% endif %}
 

--- a/config/reports/regional.en.liquid
+++ b/config/reports/regional.en.liquid
@@ -287,22 +287,22 @@
         Electricity mix.
       {% endchart %}
 
-    <h2>Central heat network</h2>
+    <h2>District heating</h2>
 
       <p>
-        The central heat network in your scenario can be used to heat houses and
-        buildings and provides heat to the industry and agricultural sectors. The
-        chart below show the balance of heat produced and consumed centrally.
+        District heating in your scenario can be used to heat houses and
+        buildings and provide heat to agricultural sectors. The
+        chart below shows the yearly balance of heat produced and consumed.
       </p>
 
-      {% chart 174 %}
-        Heat balance of central heat network.
+      {% chart 248 %}
+        Demand and supply of district heating
       {% endchart %}
 
       {% if future.energy_heat_unused_steam_hot_water_in_collective_heat_network_mekko > 0.0 %}
         <p>
           There is
-          {{ future.energy_heat_unused_steam_hot_water_in_collective_heat_network_mekko | autoscale: 'PJ'}}
+          {{ future.energy_heat_unused_steam_hot_water_in_collective_heat_network_mekko | autoscale: 'MJ'}}
           excess heat produced in agriculture or industry which flows back into the central heat
           network but is not used by other sectors.
         </p>
@@ -310,15 +310,14 @@
         <p>You can balance the network by</p>
 
         <ul>
-          <li><strong>Reducing heat production</strong>: in the industry and agriculture sections you can
-            decrease numbers of CHPs and burners.</li>
-          <li><strong>Increase demand</strong>: by increasing the demand of all sectors in the left-hand side
-            of the diagram.</li>
+          <li><strong>Reducing heat production</strong>: you can decrease the number of heat sources</li>
+          <li><strong>Increase demand</strong>: you can increase the demand of all sectors in the left-hand side
+            of the diagram</li>
         </ul>
       {% else %}
         <p>
           There is
-          {{ future.energy_heat_backup_burner_network_gas_in_collective_heat_network_mekko | autoscale: 'PJ'}}
+          {{ future.energy_heat_backup_burner_network_gas_in_collective_heat_network_mekko | autoscale: 'MJ'}}
           insufficient heat produced to satisfy the demand of the central heat network. A backup
           gas heater is deployed to satisfy the deficit.
         </p>
@@ -326,10 +325,9 @@
         <p>You can balance the network by</p>
 
         <ul>
-          <li><strong>Building more heat production</strong>: in the industry and agriculture sections you can
-            generate more heat by increasing numbers of CHPs and burners.</li>
+          <li><strong>Building more heat production</strong>: you can generate more heat by increasing the number of heat sources</li>
           <li><strong>Decreasing demand</strong>: by reducing the demand of all sectors in the left-hand side
-            of the diagram.</li>
+            of the diagram</li>
         </ul>
       {% endif %}
 
@@ -636,7 +634,7 @@
       For electricity generation, the renewability is
       {{ future.share_of_renewable_electricity | times: 100 | round: 1 }}%.
 
-      {% chart 112 %}
+      {% chart 212 %}
         Renewability of produced electricity. The renewability is defined as all renewable electricity
         production divided by local electricity consumption and can be larger than 100%.
       {% endchart %}

--- a/config/reports/regional.nl.liquid
+++ b/config/reports/regional.nl.liquid
@@ -162,12 +162,41 @@
     </p>
 
     <h2 class="banner">A. Warmtenetten</h2>
-      <p>
-      Hieronder zie je een overzicht van de vraag (links) en aanbod (rechts) op het warmtenet. Wanneer er te weinig warmteaanbod is in het scenario, springt er een gas back-up ketel aan. Wanneer er overschotten zijn, zie je dit aan de linkerkant in het lichtroze.
-        {% chart 234 %}
-          Vraag (links) en aanbod (rechts) op het warmtenet in {{ settings.end_year }}.
+    <p>
+    Hieronder zie je een overzicht van de vraag (links) en aanbod (rechts) op het warmtenet. Wanneer er te
+	weinig warmteaanbod is in het scenario, dan springt er een gas back-up ketel aan. Wanneer er overschotten zijn,
+	dan zie je dit aan de linkerkant in het lichtroze.
+        {% chart 248 %}
+        Vraag (links) en aanbod (rechts) op het warmtenet in {{ settings.end_year }}.
         {% endchart %}
-      </p>
+  	</p>
+
+  	{% if future.energy_heat_unused_steam_hot_water_in_collective_heat_network_mekko > 0.0 %}
+        <p>
+          Er wordt
+          {{ future.energy_heat_unused_steam_hot_water_in_collective_heat_network_mekko | autoscale: 'MJ'}}
+          aan restwarmte uit het netwerk niet gebruikt!
+        </p>
+
+        <p>Je kunt vraag en aanbod als volgt op elkaar afstemmen:</p>
+
+        <ul>
+          <li><strong>Productieverlaging</strong>: verlaag het aantal warmtbronnen</li>
+          <li><strong>Vraagtoename</strong>: vergroot de warmtevraag van de sectoren in het linkerdeel van de grafiek</li>
+        </ul>
+   	{% else %}
+        <p>
+        Er is onvoldoende warmte geproduceerd. Een back-up gasketel wordt nu ingezet om het tekort van
+		{{ future.energy_heat_backup_burner_network_gas_in_collective_heat_network_mekko | autoscale: 'MJ'}} op te vangen.
+        </p>
+
+        <p>Je kunt vraag en aanbod als volgt op elkaar afstemmen:</p>
+
+        <ul>
+          <li><strong>Productieverhoging</strong>: vergroot het aantal warmtebronnen
+          <li><strong>Vraagverlaging</strong>: reduceer de warmtevraag van de sectoren in het linkerdeel van de grafiek</li>
+        </ul>
+ 	{% endif %}
 
     <h2 class="banner">B. Elektriciteit</h2>
       <h3> B1. Vraag en aanbod (jaarlijks)</h3>


### PR DESCRIPTION
Before:
![Screen Shot 2020-01-10 at 12 30 30](https://user-images.githubusercontent.com/32833996/72150101-05e90880-33a5-11ea-95a6-bf9a8cd491eb.png)

After:
![Screen Shot 2020-01-10 at 12 27 35](https://user-images.githubusercontent.com/32833996/72149968-b1458d80-33a4-11ea-903b-9985ecc53426.png)

We could also add extra information about hourly balancing of supply/demand and storage! But I thought to first update the existing information.

BTW: also updated renewable electricity chart (was referencing to old chart number)

Notifying @michieldenhaan 