### PR TITLE
Change order of groups in chart list

### DIFF
--- a/app/models/output_element.rb
+++ b/app/models/output_element.rb
@@ -19,9 +19,10 @@
 #
 
 class OutputElement < ActiveRecord::Base
-  MENU_ORDER = %w[Overview Merit Cost Supply Demand Network Policy FCE].freeze
+  MENU_ORDER = %w[Overview Merit Supply Demand Cost Network Policy FCE].freeze
 
   SUB_GROUP_ORDER = %w[
+    overview
     households
     buildings
     transport
@@ -30,7 +31,9 @@ class OutputElement < ActiveRecord::Base
     other
 
     electricity
-    heat
+    network_gas
+    collective_heat
+    hydrogen
     transport_fuels
     biomass
     production_curves_and_import


### PR DESCRIPTION
Updated order of groups and subgroups in chart list

- Updated order of subgroups within the 'Supply'-group:

![Screen Shot 2020-01-14 at 14 57 03](https://user-images.githubusercontent.com/32833996/72350157-2d5e0f00-36de-11ea-826c-bcd77056b606.png)

- Moved the 'Costs'-group more down

Closing https://github.com/quintel/etmodel/issues/3203