### PR TITLE
Remove duplicate nuclear 3rd gen and add nuclear 2rd gen

### DIFF
--- a/app/views/output_elements/tables/_merit_order_table.html.haml
+++ b/app/views/output_elements/tables/_merit_order_table.html.haml
@@ -51,7 +51,7 @@
         'lignite_oxy',
         'must_run',
         'nuclear_iii',
-        'nuclear_iii',
+        'nuclear_ii',
         'oil_plant',
         'offshore_wind_turbines',
         'onshore_wind_turbines',


### PR DESCRIPTION
 A client pointed out this issue:

![Screen Shot 2020-01-20 at 13 56 26](https://user-images.githubusercontent.com/32833996/72729269-211afb80-3b8f-11ea-878e-d26a141f0aa1.png)

It is already fixed on BETA, but not on LIVE
