### PR TITLE
Remove info and tutorial buttons above charts

### DIFF
--- a/app/views/layouts/etm/_title.html.haml
+++ b/app/views/layouts/etm/_title.html.haml
@@ -1,15 +1,6 @@
 %h2= raw t("sidebar_items.#{@interface.current_sidebar_item.key}.long_name")
 
 .help
-  %a.info.fancybox{ href: @interface.tab_info_path }
-    %span.fa.fa-book
-    = t("header.information").rstrip
-
-  - if @interface.current_tutorial_movie
-    %a.tutorial.fancybox{:href => @interface.tutorial_movie_path, :title => "Tutorial"}<>
-      %span.fa.fa-video-camera
-      Tutorial
-
   %a.add_chart{:href => output_elements_path}
     %span.fa.fa-plus-square
     = t 'header.add_chart'


### PR DESCRIPTION
As requested on [basecamp](https://3.basecamp.com/3797409/buckets/6180918/messages/2318471980) by @marliekeverweij 