### PR TITLE
Update data export on PRO

### DIFF
--- a/db/migrate/20200131135419_rename_queries_other_industry.rb
+++ b/db/migrate/20200131135419_rename_queries_other_industry.rb
@@ -1,0 +1,27 @@
+class RenameQueriesOtherIndustry < ActiveRecord::Migration[5.2]
+  def up
+    do_rename('aggregated_other_industry', 'other_non_specified_industry')
+  end
+
+  def down
+    do_rename('other_non_specified_industry', 'aggregated_other_industry')
+  end
+
+  def do_rename(from, to)
+    from_re = Regexp.escape(from)
+
+    OutputElementSerie.find_each do |series|
+      if series.gquery && series.gquery.include?(from)
+        series.gquery = series.gquery.gsub(from_re, to)
+        series.save(validate: false)
+      end
+    end
+
+    OutputElement.find_each do |element|
+      if element.key && element.key.include?(from)
+        element.key = element.key.gsub(from_re, to)
+        element.save(validate: false)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_26_122520) do
+ActiveRecord::Schema.define(version: 2020_01_31_135419) do
 
   create_table "area_dependencies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "dependent_on"


### PR DESCRIPTION
Update the ETM data export by the following changes:
- Move merit order group from individual appliances (childs) to aggregated parent node
- Merge all industry other subsectors (mining, minerals, etc.), except food and paper, into the non-specified subsector

This pull request includes a migration for the changes described above.

Relates to https://github.com/quintel/etsource/pull/2210, https://github.com/quintel/etsource/pull/2211, https://github.com/quintel/etmodel/pull/3225