### PR TITLE
Flatten descriptions for slides and input elements

### DIFF
--- a/app/models/describable.rb
+++ b/app/models/describable.rb
@@ -1,0 +1,27 @@
+
+module Describable
+  def short_content
+    t :short_content
+  end
+
+  def content
+    t :content
+  end
+
+  def t(attr_name)
+    lang = I18n.locale.to_s.split('-').first
+    description["#{attr_name}_#{lang}"]&.html_safe
+  end
+
+  # Ugly!
+  #
+  def description_embeds_player?
+    content&.include?("player")  || content&.include?("object")
+  end
+
+  # For loading multiple flowplayers classname is needed instead of id
+  #
+  def description_sanitize_embedded_player
+    content&.gsub %(id="player"), %(class="player")
+  end
+end

--- a/app/models/describable.rb
+++ b/app/models/describable.rb
@@ -23,9 +23,4 @@ module Describable
       description_content&.include?('object')
   end
 
-  # For loading multiple flowplayers classname is needed instead of id
-  #
-  def description_sanitize_embedded_player
-    description_content&.gsub %(id="player"), %(class="player")
-  end
 end

--- a/app/models/describable.rb
+++ b/app/models/describable.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
 
+# Contains methods dealing with the descriptions in YModel classes such as
+# Slides and InputElements
 module Describable
   def description_short_content
     t :short_content
@@ -16,7 +19,8 @@ module Describable
   # Ugly!
   #
   def description_embeds_player?
-    description_content&.include?("player")  || description_content&.include?("object")
+    description_content&.include?('player') ||
+      description_content&.include?('object')
   end
 
   # For loading multiple flowplayers classname is needed instead of id

--- a/app/models/describable.rb
+++ b/app/models/describable.rb
@@ -1,10 +1,10 @@
 
 module Describable
-  def short_content
+  def description_short_content
     t :short_content
   end
 
-  def content
+  def description_content
     t :content
   end
 
@@ -16,12 +16,12 @@ module Describable
   # Ugly!
   #
   def description_embeds_player?
-    content&.include?("player")  || content&.include?("object")
+    description_content&.include?("player")  || description_content&.include?("object")
   end
 
   # For loading multiple flowplayers classname is needed instead of id
   #
   def description_sanitize_embedded_player
-    content&.gsub %(id="player"), %(class="player")
+    description_content&.gsub %(id="player"), %(class="player")
   end
 end

--- a/app/models/describable.rb
+++ b/app/models/describable.rb
@@ -22,5 +22,4 @@ module Describable
     description_content&.include?('player') ||
       description_content&.include?('object')
   end
-
 end

--- a/app/models/input_element.rb
+++ b/app/models/input_element.rb
@@ -23,10 +23,11 @@
 # Model representing a slider in the front-end. Settings get stored in scenarios
 class InputElement < YModel::Base
   include AreaDependent::YModel
+  include Describable
 
   ENUM_UNITS = %w[radio weather-curves].freeze
 
-  has_one :description, as: :describable
+  # has_one :description, as: :describable
   belongs_to :slide
 
   class << self
@@ -95,7 +96,7 @@ class InputElement < YModel::Base
   end
 
   def has_flash_movie # rubocop:disable Naming/PredicateName
-    description.try :embeds_player?
+    description_embeds_player?
   end
 
   # For loading multiple flowplayers classname is needed instead of id
@@ -103,7 +104,7 @@ class InputElement < YModel::Base
   #
   def sanitized_description
     ie8_sanitize(
-      description.try(:sanitize_embedded_player)
+      description_sanitize_embedded_player
     ).html_safe
   end
 

--- a/app/models/input_element.rb
+++ b/app/models/input_element.rb
@@ -27,7 +27,6 @@ class InputElement < YModel::Base
 
   ENUM_UNITS = %w[radio weather-curves].freeze
 
-  # has_one :description, as: :describable
   belongs_to :slide
 
   class << self
@@ -104,7 +103,7 @@ class InputElement < YModel::Base
   #
   def sanitized_description
     ie8_sanitize(
-      description_sanitize_embedded_player
+      description_content
     ).html_safe
   end
 

--- a/app/models/slide.rb
+++ b/app/models/slide.rb
@@ -22,8 +22,8 @@
 # (e.g. "Insulation", "Cooking", for "Households" item)
 class Slide < YModel::Base
   include AreaDependent::YModel
+  include Describable
 
-  has_one :description, as: :describable
   has_many :input_elements
   alias_method :sliders, :input_elements
   belongs_to :output_element # default chart

--- a/app/views/scenarios/_slide.html.haml
+++ b/app/views/scenarios/_slide.html.haml
@@ -10,7 +10,7 @@
     .description
       %p
         = image_tag(slide.image_path) if slide.image.present?
-        = raw format_description(slide.description.try(:content))
+        = raw format_description(slide.description_content)
 
     .items
       - unless slide.general_sub_header.blank?

--- a/config/ymodel/input_elements.yml
+++ b/config/ymodel/input_elements.yml
@@ -23,6 +23,26 @@
   slide_id: 3
   position: 2
   dependent_on: ''
+  description:
+    content_en: "How much more efficient do you think fridges and freezers will be
+      in the future?\r\n<br/><br/>\r\nNational and European legislation is forcing
+      household appliances to use ever less energy. The energy labels that are mandatory
+      nowadays in all European countries give a good indication of the energy efficiency
+      of household appliances. \r\n<br/><br/>\r\nThe starting value of this slider
+      is the current average label of fridges and freezers. Use the slider to give
+      an estimation of the average label of fridges and freezers in the future. The
+      A+++ label corresponds to an energy reduction of 66% compared to today. \r\n\r\n"
+    content_nl: "Hoeveel efficiënter zullen koelkasten en vriezers in de toekomst
+      zijn? \r\n<br/><br/>\r\nNationale en Europese wetgeving dwingt producenten om
+      huishoudelijke apparaten ieder jaar zuiniger te maken. De energielabels die
+      tegenwoordig in alle Europese landen verplicht zijn geven een goede indicatie
+      van de efficiëntie van huishoudelijke apparaten.\r\n<br/><br/>\r\nDe startwaarde
+      van dit schuifje is het gemiddelde label van koel-en-vrieskasten die nu geïnstalleerd
+      zijn. Zet het schuifje op het label dat jij denkt dat de gemiddelde koel-en-vrieskasten
+      hebben in de toekomst. Het A+++ label komt overeen met een besparing van 66%
+      ten opzichte van vandaag."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 11
   key: costs_oil
   share_group: ''
@@ -46,6 +66,23 @@
   slide_id: 6
   position: 2
   dependent_on: ''
+  description:
+    content_en: "This slider sets the future oil price (in $/barrel) which is displayed
+      next to the slider. There is a well-developed global market for oil. Now that
+      easily accessible oil appears to become more scarce, however, it is increasingly
+      traded bilaterally.\r\n<br/><br/>\r\nThe graph below shows how the oil price
+      has varied over the past decades in terms of 2008 dollars per barrel.\r\n<br/><br/>\r\n<img
+      src=\"/assets/popups/crude_oil_price.png\"  style=\"width:440px;height:307px\"/>"
+    content_nl: "Deze schuif stelt je aanname over de toekomstige olieprijs in, uitgedrukt
+      in aantal keren de prijs van vandaag. De prijs voor WTI ruwe olie die je instelt,
+      staat naast de schuif. De oliemarkt is een echte wereldmarkt. Makkelijk winbare
+      olie wordt echter schaarser en olie wordt steeds vaker tussen twee exclusieve
+      partijen verhandeld.\r\n<br/><br/>\r\nDe grafiek hieronder laat zien hoe de
+      wereldolieprijs geschommeld heeft de afgelopen decennia, uitgedrukt in 2008
+      dollar per vat.\r\n<br/><br/>\r\n<img SRC=\"/assets/popups/crude_oil_price.png\"
+      style=\"width:440px;height:307px\" />"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 12
   key: investment_costs_wind_onshore
   share_group: ''
@@ -69,6 +106,16 @@
   slide_id: 9
   position: 1
   dependent_on:
+  description:
+    content_en: "This slider sets the height of the assumed investment costs for onshore
+      wind-generated power. Costs are compared to current costs.\r\n<br/><br/>\r\nThe
+      specifications below are for an inland wind turbine:"
+    content_nl: "Deze schuif stelt de toe-of afname in die je verwacht voor de investeringskosten
+      van windmolens op land. De kosten worden vergeleken met de kosten van vandaag
+      de dag.\r\n<br/><br/>\r\nThe
+      specificaties hieronder zijn voor een windmolen op land:"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 14
   key: investment_costs_wind_offshore
   share_group: ''
@@ -92,6 +139,18 @@
   slide_id: 9
   position: 2
   dependent_on:
+  description:
+    content_en: "This slider sets the height of the assumed investment costs for offshore
+      wind-generated power. Costs are compared to current costs.\r\n<br/>\r\nInvestment
+      costs for offshore wind turbines are essentially different from those on land.
+      This is a result of the need to rent boats and crew to build at sea.\r\n"
+    content_nl: "Deze schuif stelt je de toe-of afname in die je verwacht voor de
+      investeringskosten van windmolens op zee. De kosten worden vergeleken met de
+      kosten van vandaag de dag.\r\n<br/>\r\nDe investeringskosten voor wind op zee
+      zijn echt anders dan voor wind op land. Dit komt doordat het nodig is schepen
+      met bemanning te huren voor de bouw van de molens."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 16
   key: investment_costs_combustion_gas_plant
   share_group: ''
@@ -115,6 +174,19 @@
   slide_id: 7
   position: 1
   dependent_on: ''
+  description:
+    content_en: "This slider sets the expected change in investment costs for a gas-fired
+      power plant. Costs are compared to current costs. \r\n<br/><br/>\r\nThe past
+      years, many companies around the world have announced plans to build gas-fired
+      power generation capacity.\r\n<br/><br/>\r\nThe specification below are for
+      a CCGT plant: "
+    content_nl: "Deze schuif stelt je de toe-of afname in die je verwacht voor de
+      investeringskosten van gascentrales. De kosten worden vergeleken met de kosten
+      van vandaag de dag. \r\n<br/><br/>\r\nDe afgelopen jaren hebben veel energiebedrijven
+      aangekondigd gascentrales te willen bouwen. \r\n<br/><br/>\r\nDe specificaties
+      hieronder zijn voor een STEG centrale:"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 17
   key: investment_costs_combustion_oil_plant
   share_group: ''
@@ -138,6 +210,17 @@
   slide_id: 7
   position: 2
   dependent_on:
+  description:
+    content_en: "This slider sets the expected change in investment costs for a power
+      plant that burns oil or an oil-derivative like diesel. Costs are compared to
+      current costs.\r\n<br/>\r\nOil-fired plants are hardly being built anymore.
+      Smaller diesel-fired generators are."
+    content_nl: "Deze schuif stelt je de toe-of afname in die je verwacht voor de
+      investeringskosten van oliecentrales. De kosten worden vergeleken met de kosten
+      van vandaag de dag.\r\n<br/>\r\nEr worden nauwelijks nog oliecentrales bijgebouwd
+      in de Westerse wereld. Kleinere dieselgeneratoren worden nog wel steeds gebouwd. "
+    short_content_en: ''
+    short_content_nl: ''
 - id: 18
   key: investment_costs_combustion_coal_plant
   share_group: ''
@@ -161,6 +244,22 @@
   slide_id: 7
   position: 3
   dependent_on:
+  description:
+    content_en: "This slider sets the expected change in investment costs for a coal-fired
+      power plant. Costs are compared to current costs.\r\n<br/><br/>\r\nThe past
+      years, many companies around the world have announced plans to build coal-fired
+      power generation capacity. Also, environmental rules increasingly require these
+      plants to be outfitted with technology to reduce harmful emissions.\r\n<br/><br/>\r\nThe
+      specifications below are for an ultra-supercritical coal power plant:"
+    content_nl: "Deze schuif stelt je de toe-of afname in die je verwacht voor de
+      investeringskosten van kolencentrales. De kosten worden vergeleken met de kosten
+      van vandaag de dag. \r\n<br/><br/>\r\nDe afgelopen jaren hebben veel energiebedrijven
+      aangekondigd kolencentrales te willen bouwen. Milieuwetgeving stelt steeds strengere
+      eisen over de uitstoot van schadelijke gassen. Daarvoor moeten filtersystemen
+      worden geïnstalleerd.\r\n<br/><br/>\r\nDe specificaties hieronder zijn voor
+      een ultra-supercritische kolencentrale:"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 19
   key: investment_costs_combustion_biomass_plants
   share_group: ''
@@ -184,6 +283,15 @@
   slide_id: 7
   position: 4
   dependent_on: ''
+  description:
+    content_en: This slider sets the expected change in investment costs for a biomass-fired
+      CHPs. Costs are compared to current costs. These costs will be similar to investment
+      costs for coal-fired power plants.
+    content_nl: 'Deze schuif stelt je de toe-of afname in die je verwacht voor de
+      investeringskosten van biomassa-WKKs. De kosten worden vergeleken met de kosten
+      van vandaag de dag en zullen niet veel verschillen van de kosten voor kolencentrales. '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 43
   key: households_lighting_efficient_fluorescent_electricity_share
   share_group: household_light
@@ -207,6 +315,26 @@
   slide_id: 2
   position: 2
   dependent_on:
+  description:
+    content_en: "What share of lighting comes from Energy-saving light bulbs (ESLB)?\r\n<br/><br/>\r\nMany
+      EU countries will ban the incandescent light bulb in the future. ESLBs use ~75%
+      less energy than incandescent light bulbs, but about twice as much as LED-lights.
+      Not all ESLBs can be thrown away without danger of polluting the environment,
+      as they contain toxic substances. Incandescent light bulbs or LED-lights do
+      not. ESLB's lifetime is shortened when they are often rapidly switched on and
+      off. \r\n<br/><br/>\r\nLifetime comparison:\r\n<br/>• LED-light:      ~50.000
+      hours\r\n<br/>• ESLB:             ~7.500 hours\r\n<br/>• Incandescent:  ~1.000
+      hours"
+    content_nl: "Welk deel van de verlichting komt van spaarlampen?\r\n<br/><br/>\r\nVeel
+      EU landen gaan de gloeilamp verbieden in de toekomst. Spaarlampen gebruiken
+      ~75% minder energie dan gloeilampen, maar nog twee keer zoveel als LED lampen.
+      Je kunt een spaarlamp niet altijd weggooien zonder het milieu te vervuilen,
+      omdat er vaak kwik in zit. Gloeilampen en LED lampen niet. Spaarlampen kunnen
+      er niet goed tegen als ze vaak aan en uitgezet worden.\r\n<br/><br/>\r\nVergelijking
+      levensduren:\r\n<br/>• LED-lamp:      ~50.000 uur\r\n<br/>• Spaarlamp:             ~7.500
+      uur\r\n<br/>• Gloeilamp:  ~1.000 uur"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 44
   key: households_lighting_led_electricity_share
   share_group: household_light
@@ -230,6 +358,25 @@
   slide_id: 2
   position: 3
   dependent_on:
+  description:
+    content_en: "What share of lighting comes from Light Emitting Diodes?\r\n<br/><br/>\r\nMany
+      EU countries will ban the incandescent light bulb in the future. LEDs use only
+      10% of the energy of a normal light bulb and about half of an energy saving
+      light bulb (ESLB). Unlike ESLB’s LEDs can be switched on and off rapidly without
+      decreasing their lifetime. LED-lights cost 5 to 50 times more than the alternatives.
+      Their chief disadvantage is that they are not (yet) optimally suited for evenly
+      lighting up a room.\r\n<br/><br/>\r\nLifetime comparison:\r\n<br/>• LED-light:
+      \     ~50.000 hours\r\n<br/>• ESLB:             ~7.500 hours\r\n<br/>• Incandescent:
+      \ ~1.000 hours"
+    content_nl: "Welk deel van de verlichting komt van LED lampen?\r\n<br/><br/>\r\nVeel
+      EU landen gaan de gloeilamp verbieden in de toekomst. LED-lampen gebruiken ~10%
+      van de energie van een gloeilamp, en de helft van een spaarlamp. LED-lampen
+      kunnen er goed tegen als ze vaak aan en uitgezet worden. Hun kleuren worden
+      nog als kil ervaren en ze zijn niet zeer geschikt om de hele kamer te verlichten.\r\n<br/><br/>\r\nVergelijking
+      levensduren:\r\n<br/>• LED-lamp: ~50.000 uur\r\n<br/>• Spaarlamp: ~7.500 uur\r\n<br/>•
+      Gloeilamp: ~1.000 uur"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 47
   key: households_solar_pv_solar_radiation_market_penetration
   share_group: ''
@@ -253,6 +400,40 @@
   slide_id: 5
   position: 1
   dependent_on: ''
+  description:
+    content_en: "Market penetration means the percentage of households that has solar
+      panels. We assume that all available roof space for each house is used. \r\n<br/><br/>\r\nSolar
+      cells transform sunlight into electricity. Solar panels are installed on rooftops
+      and may compete for space with solar water heaters. This technology is developing
+      rapidly and solar panels are becoming ever more efficient and cheaper. Solar
+      panels are expected to become much cheaper in the coming 40 years. For more
+      information, see the 'technology curves'. \r\n<br/><br/>\r\nSolar panels produce
+      electricity on site, so transport of electricity is not always required. This
+      avoids losses on the grid and that saves energy. Feeding locally produced power
+      back into the local power grid requires a higher capacity or smarter local grid,
+      to prevent it from overloading. The electricity produced by these solar panels
+      is shown in the chart on the right.\r\n<br/><br/>\r\nIn the ETM solar PV panels
+      have 867 full load hours by default. Because of technological developments it
+      is likely that future solar PV panels may produce more electricity per installed
+      capacity than today. You can adjust the full load hours of solar panels <a href=\"/scenario/supply/electricity_renewable/solar-power\"
+      >here</a>.\r\n</br>"
+    content_nl: "Marktpenetratie betekent het percentage van alle huishoudens dat
+      zonnepanelen heeft. We nemen aan dat alle beschikbare ruimte op het dak gebruikt
+      wordt.\r\n<br/><br/>\r\nZonnecellen zetten licht om in elektriciteit. Zonnepanelen
+      liggen op het dak en kunnen concurreren met zonneboilers om ruimte. Deze technologie
+      is nog volop in ontwikkeling en zonnepanelen worden steeds efficiënter en goedkoper.
+      Verwacht wordt dat zonnecellen de komende 40 jaar veel goedkoper zullen worden.\r\n<br/><br/>\r\nZonnepanelen
+      produceren stroom op de plek waar het gebruikt wordt (in huis) en dus is het
+      niet altijd nodig om de elektriciteit te transporteren over het elektriciteitsnet.
+      Zo worden netwerkverliezen vermeden en energie bespaard. Stroom die niet wordt
+      gebruikt kan aan het lokale netwerk worden teruggeleverd. De stroom die deze
+      panelen produceren zie je terug in de grafiek rechts.\r\n<br/><br/>\r\nIn het
+      ETM heeft een zonnepaneel standaard 867 vollasturen. Het is aannemelijk dat
+      toekomstige zonnepanelen meer elektriciteit zullen produceren per geïnstalleerd
+      vermogen dan nu. Je kunt het aantal vollasturen voor zonnepanelen <a href=\"/scenario/supply/electricity_renewable/solar-power\"
+      >hier</a> aanpassen.\r\n</br>"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 52
   key: households_heater_electricity_share
   share_group: heating_households
@@ -276,6 +457,30 @@
   slide_id: 4
   position: 9
   dependent_on: ''
+  description:
+    content_en: "Electric heaters directly convert electricity back to heat.\r\n<br/>\r\nSome
+      people believe this is a waste of energy. Electricity is a very versatile form
+      of energy and low-grade heat can only be used to heat buildings or make hot
+      water. The waste is even bigger if the electricity is generated using fossil
+      fuels.\r\n<br/><br/>\r\nElectric heaters need to be able to produce a lot of
+      heat quickly, so they can have a large impact on the energy grid. Especially
+      if they are added to electric heat pumps as extra heating capacity during cold
+      days, impact on the local electricity grid can be extreme. If you want to see
+      what will happen to the grid you can set the electric heater slider to the same
+      percentage as electric heat pumps (ground). "
+    content_nl: "Electrische kachels zetten elektriciteit direct om in warmte. Op
+      zich is dat een zeer efficiënt proces.\r\n<br/>\r\nToch denken veel mensen dat
+      dit energieverspilling is. Elektriciteit kun je op veel verschillende manieren
+      nuttig inzetten en laagwaardige warmte kun je alleen gebruiken om warm water
+      te maken, of huizen te verwarmen. Uiteraard is de verspilling nog groter als
+      je de stroom opwekt door kostbare fossiele brandstoffen te verbranden.\r\n<br/><br/>\r\nElektrische
+      kachels of bijstook moeten snel veel warmte kunnen leveren en hebben daarom
+      een groot vermogen. Dit betekent dat ze het elektriciteitsnet sterk belasten.
+      \ Als je wilt zien wat de impact van elektrische bijstook bij warmtepompen is,
+      kun je deze schuif op hetzelfde percentage zetten als de elektrische warmtepomp
+      (bodem) schuif."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 57
   key: costs_coal
   share_group: ''
@@ -299,6 +504,16 @@
   slide_id: 6
   position: 3
   dependent_on: ''
+  description:
+    content_en: 'This slider sets the future coal price (in $/tonne), which is displayed
+      next to the slider. There is a global market for coal, but contracts often cover
+      longer periods than oil contracts.  '
+    content_nl: Deze schuif stelt je aanname over de toekomstige kolenprijs in, uitgedrukt
+      in aantal keren de prijs van vandaag. De prijs die je instelt, staat naast de
+      schuif. De kolenmarkt is een wereldmarkt, maar leveringscontracten zijn vaak
+      voor langere periodes dan olie.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 58
   key: costs_gas
   share_group: ''
@@ -322,6 +537,24 @@
   slide_id: 6
   position: 1
   dependent_on: ''
+  description:
+    content_en: "This slider sets the future natural gas price (in €/MWh), which is
+      displayed next to the slider. Gas is mostly traded bilaterally (between two
+      countries or parties) and there is no truly global market. As transport of liquefied
+      gas (LNG) by tankers increases, the gas market will become ever more global.
+      The price of gas currently follows oil prices, but this may well change in future
+      global markets. \r\n<br/><br/>\r\nFor your country it is important to know whether
+      it still has its own supplies of natural gas."
+    content_nl: "Deze schuif stelt je aanname over de toekomstige gasprijs in, uitgedrukt
+      in aantal keren de prijs van vandaag. De prijs die je instelt, staat naast de
+      schuif. Gas wordt vooral bilateraal verhandeld (tussen twee landen of partijen)
+      en er is geen echte wereldmarkt. Terwijl het transport van vloeibaar aardgas
+      (LNG) toeneemt zal de markt steeds globaler worden. Nu volgt de prijs van gas
+      nog die van olie, maar dat zal ergens in de toekomst gaan veranderen vanwege
+      marktwerking.\r\n<br/><br/>\r\nVoor jouw land kun je je afvragen of er nog aardgasvoorraden
+      zijn en hoelang nog."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 114
   key: investment_costs_water_river
   share_group: ''
@@ -345,6 +578,15 @@
   slide_id: 11
   position: 1
   dependent_on:
+  description:
+    content_en: "This slider sets the height of your assumed investment costs for
+      a run-of-the-river hydro-electric power plant (10 MWe). Costs are compared to
+      current costs.\r\n"
+    content_nl: Deze schuif stelt je de toe-of afname in die je verwacht voor de investeringskosten
+      van een waterkrachtcentrale in een grote rivier (~10 MWe). De kosten worden
+      vergeleken met de kosten van vandaag de dag.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 115
   key: investment_costs_water_mountains
   share_group: ''
@@ -368,6 +610,15 @@
   slide_id: 11
   position: 2
   dependent_on: has_mountains
+  description:
+    content_en: This slider sets the height of your assumed investment costs for a
+      large hydro-electric power plant (500 MWe) in a mountain reservoir. These plants
+      require huge investments.
+    content_nl: "Met deze schuif stel je de hoogte in van de verwachte investeringskosten
+      voor een grote waterkrachtcentrale in de bergen. \r\n<br/><br/>\r\nVoor dit
+      soort centrales zijn zeer grote investeringen nodig."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 121
   key: om_costs_nuclear_nuclear_plant
   share_group: ''
@@ -391,6 +642,18 @@
   slide_id: 20
   position: 1
   dependent_on:
+  description:
+    content_en: "This slider sets the height of your assumed operational and maintenance
+      costs for a nuclear power plant. <br/>\r\n<br/>Operational and maintenance costs
+      are a minor part of total costs for nuclear energy.\r\n<br/><br/> \r\nThe specifications
+      below are for a super modern third generation nuclear power plant."
+    content_nl: "Deze schuif stelt je de toe-of afname in die je verwacht voor de
+      onderhouds- en beheerkosten van kerncentrales. De kosten worden vergeleken met
+      de kosten van vandaag de dag.<br/>\r\n<br/>\r\nOnderhouds-en beheerkosten zijn
+      een relatief klein onderdeel van de totale kosten van kernenergie.\r\n<br/><br/>
+      \r\nDe specificaties hieronder zijn voor een super moderne derde generatie kerncentrale."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 126
   key: om_costs_wind_onshore
   share_group: ''
@@ -414,6 +677,16 @@
   slide_id: 10
   position: 1
   dependent_on:
+  description:
+    content_en: "This slider sets the height of the assumed operational and maintenance
+      costs for onshore wind-generated power. Costs are compared to current costs.<br/><br/>\r\nThe
+      specifications below are for an inland wind turbine:"
+    content_nl: "Deze schuif stelt je de toe-of afname in die je verwacht voor onderhouds-
+      en beheerkosten van windmolens op land. De kosten worden vergeleken met de kosten
+      van vandaag de dag.\r\n<br/><br/>\r\nThe specificaties hieronder zijn voor een
+      windmolen op land:"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 127
   key: om_costs_wind_offshore
   share_group: ''
@@ -437,6 +710,19 @@
   slide_id: 10
   position: 2
   dependent_on:
+  description:
+    content_en: "This slider sets the height of the assumed operational and maintenance
+      costs for offshore wind-generated power. Costs are compared to current costs.\r\n<br/>\r\nMaintenance
+      costs for offshore wind turbines are essentially different from those on land.
+      This is a result of harsher conditions like stronger winds and salt water induced
+      corrosion, for example."
+    content_nl: "Deze schuif stelt je de toe-of afname in die je verwacht voor de
+      onderhouds- en beheerkosten van windmolens op land. De kosten worden vergeleken
+      met de kosten van vandaag de dag.\r\n<br/>\r\nDe onderhoudskosten voor wind
+      op zee zijn echt anders dan voor wind op land. Dit komt doordat de weersomstandigheden
+      anders zijn en het zoute water veel slijtage veroorzaakt, bijvoorbeeld."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 129
   key: om_costs_water_river
   share_group: ''
@@ -460,6 +746,15 @@
   slide_id: 12
   position: 1
   dependent_on:
+  description:
+    content_en: This slider sets the height of your assumed operational and maintenance
+      costs for a run-of-the-river hydro-electric power plant. Costs are compared
+      to current costs.
+    content_nl: Deze schuif stelt je de toe-of afname in die je verwacht voor de onderhouds-
+      en beheerkosten van een waterkrachtcentrale in een grote rivier. De kosten worden
+      vergeleken met de kosten van vandaag de dag.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 131
   key: om_costs_water_mountains
   share_group: ''
@@ -483,6 +778,17 @@
   slide_id: 12
   position: 2
   dependent_on: has_mountains
+  description:
+    content_en: "This slider sets the height of your assumed operations and maintenance
+      costs for a large hydro-electric power plant (500 MWe) in a mountain reservoir.
+      \r\n<br/>\r\n<br/>\r\nO&amp;M costs are only a small part of total electricity
+      costs for this plant type."
+    content_nl: "Met deze schuif stel je de hoogte in van de verwachte onderhouds-
+      en beheerkosten voor een grote waterkrachtcentrale in de bergen. \r\n<br/><br/>\r\nDe
+      O&amp;B kosten zijn maar een klein onderdeel van de totale elektriciteitskosten
+      voor dit soort centrales. "
+    short_content_en: ''
+    short_content_nl: ''
 - id: 132
   key: om_costs_geothermal
   share_group: ''
@@ -506,6 +812,17 @@
   slide_id: 13
   position: 2
   dependent_on: ''
+  description:
+    content_en: "This slider sets the future change in operational and maintenance
+      costs for geothermal energy. Costs are compared to current costs. \r\n<br/>The
+      O&M costs for these plants are a lesser part of energy costs. Investments tend
+      be a bigger part."
+    content_nl: "Met deze schuif stel je de toe-of afname in die je verwacht voor
+      de onderhouds- en beheerkosten van aardwarmte. De kosten worden vergeleken met
+      de kosten van vandaag de dag.\r\n<br/><br/>\r\nDe kosten voor geothermie zijn
+      overwegend investeringskosten. Onderhoud en beheer is minder van belang."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 133
   key: investment_costs_solar_solar_panels
   share_group: ''
@@ -529,6 +846,23 @@
   slide_id: 17
   position: 1
   dependent_on: ''
+  description:
+    content_en: "This slider sets the change in investment costs for solar power compared
+      to current costs. It is expected that solar pv panels will become much cheaper
+      in the coming 40 years. Note that this slider changes the investment costs for
+      all solar panels that are modeled in the ETM: solar panels on roofs and solar
+      PV plants. With the link below you can see the costs of solar panels on roofs.
+      BTW: the cost of installing for solar panels on roofs do not change with this
+      slider (500 kEUR/MW).\r\n<br/>"
+    content_nl: "Met deze schuif stel je de toe- of afname in die je verwacht voor
+      de investeringskosten voor zonnepanelen. De kosten worden vergeleken met de
+      kosten van vandaag de dag. Verwacht wordt dat zonnecellen de komende 40 jaar
+      veel goedkoper zullen worden. Merk op dat je met deze schuif de investeringskosten
+      aanpast voor zowel zon op dak als grootschalige zonneparken. De onderstaande
+      link laat de kosten van zon op dak zien. Let op: de installatiekosten van zon
+      op dak (500 kEUR/MW) worden niet aangepast met deze schuif.\r\n<br/>"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 136
   key: investment_costs_nuclear_nuclear_plant
   share_group: ''
@@ -552,6 +886,34 @@
   slide_id: 19
   position: 1
   dependent_on:
+  description:
+    content_en: "This slider sets the height of your assumed investment costs for
+      a nuclear power plant, including the costs for decommissioning the plant at
+      the end of its lifetime. External costs for society, such as that people do
+      not like to live close to a nuclear power plant, have not been included. The
+      costs for permanent storage of nuclear waste have also not been included, as
+      it is unclear how much this would cost. External costs have also not been included
+      for other types of power plants. \r\n<br/><br/>\r\nCurrently, production capacity
+      for nuclear reactors is considerably short of what would be required to meet
+      (expected) investment plans around the world. In many countries there will most
+      likely be a shortage of trained technicians in this part of the energy sector.\r\n<br/><br/>
+      \r\nThe specifications below are for a super modern third generation nuclear
+      power plant."
+    content_nl: "Deze schuif stelt je de toe-of afname in die je verwacht voor de
+      investeringskosten voor kerncentrales. De kosten worden vergeleken met de kosten
+      van vandaag de dag. De kosten voor afbraak aan het eind van de levensduur zijn
+      hierin meegenomen. Maatschappelijke kosten, bijvoorbeeld dat sommige mensen
+      niet graag vlak bij een kerncentrale wonen, zijn niet meegenomen in de berekening.
+      Noch zijn de kosten voor 'permanente' opslag van kernafval meegenomne, aangezien
+      onduidelijk is hoeveel dat zou kosten. Zulke externe kosten zijn overigens ook
+      niet voor andere type centrales meegenomen. Er zijn ook mensen die geen windmolen
+      of CO<sub>2</sub> opslag in de achtertuin willen hebben. \r\n<br/><br/>\r\nMomenteel
+      is de productiecapaciteit van onderdelen voor kerncentrales te laag om aan de
+      (verwachte) wereldwijde plannen te voldoen. Ook zal er op korte termijn in veel
+      landen een tekort aan technici zijn voor deze energievorm.\r\n<br/><br/>
+      \r\nDe specificaties hieronder zijn voor een super moderne derde generatie kerncentrale."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 137
   key: costs_co2
   share_group: ''
@@ -575,6 +937,19 @@
   slide_id: 22
   position: 1
   dependent_on: ''
+  description:
+    content_en: This slider sets the future price (in €/tonne) of CO<sub>2</sub> emission
+      rights for companies covered by the European Emission Trading Scheme, such as
+      power companies. These rights can be traded in the form of certificates. The
+      certificates are auctioned to companies (among others) by national governments.
+    content_nl: Deze schuif stelt je de toe-of afname in die je verwacht voor de kosten
+      van CO<sub>2</sub> uitstootrechten (in €/ton) voor bedrijven die onder het Europese
+      'Emission Trading Scheme' (ETS) vallen. Denk aan energiecentrales en zware industrie.
+      De rechten kunnen verhandeld worden als certificaten. Deze certificaten worden
+      door de overheid geveild of toegekend aan bedrijven. Elk jaar worden er minder
+      uitgegeven.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 138
   key: costs_co2_free_allocation
   share_group: ''
@@ -598,6 +973,23 @@
   slide_id: 22
   position: 2
   dependent_on:
+  description:
+    content_en: This slider sets the percentage of CO<sub>2</sub> emission rights
+      that electricity production companies receive for free. With the start of the
+      third trading period of the Emissions Trading Scheme (ETC) in 2013 it is likely
+      that 50% of all emission permits will be auctioned. For the trading period starting
+      in 2020 it is uncertain what percentage of permits will be auctioned, but the
+      European Commission is aiming for 70%. In 2027 the goal is to auction 100% of
+      all the emission permits.
+    content_nl: Deze schuif stelt in hoeveel van de Europese uitstootrechten voor
+      CO<sub>2</sub> gratis worden verstrekt. Met ingang van de derde handelsfase
+      van het Emissions Trading Scheme (ETS) in 2013 zullen naar alle waarschijnlijkheid
+      zo'n 50% van alle rechten geveild worden, waarbij de andere helft dus vrije
+      rechten zijn. Voor de handelsperiode die in 2020 begint staat nog niet vast
+      hoeveel rechten er dan geveild worden, maar de Europese commissie zet nu in
+      op 70%. In 2027 is het doel om 100% van de rechten te veilen.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 139
   key: om_costs_co2_ccs
   share_group: ''
@@ -621,6 +1013,23 @@
   slide_id: 23
   position: 2
   dependent_on:
+  description:
+    content_en: "This slider sets the height of your assumed operational and maintenance
+      (O&M) costs for 'Carbon Capture and Storage' (CCS). This technology can be applied
+      with any combustion power plant, but is most efficient with coal as that produces
+      most CO<sub>2</sub>. \r\nCosts are compared to current costs.\r\n <br/><br/>\r\nCurrently,
+      this technology has only been applied experimentally at power plants. It is
+      expected that costs will decrease in the future.\r\n"
+    content_nl: "Deze schuif stelt je de toe-of afname in die je verwacht voor de
+      onderhouds- en beheerkosten voor 'Carbon Capture and Storage' (CCS, het afvangen
+      en ondergronds opslaan van CO<sub>2</sub>). De kosten worden vergeleken met
+      de kosten van vandaag de dag. Deze technologie kan in combinatie met elke verbrandingscentrale
+      gebruikt worden, maar is het meest effectief met een kolencentrale, omdat die
+      het meest uitstoot.\r\n<br/><br/>\r\nOp dit moment is deze technologie alleen
+      nog maar in experimentele centrales toegepast, maar men verwacht dat de kosten
+      af zullen nemen."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 140
   key: investment_costs_co2_ccs
   share_group: ''
@@ -644,6 +1053,18 @@
   slide_id: 23
   position: 1
   dependent_on:
+  description:
+    content_en: "This slider sets the height of your assumed investment costs for
+      ‘Carbon Capture and Storage’ (CCS). Costs are compared to current costs. Currently,
+      this technology has only been applied experimentally at power plants. It is
+      expected that costs will decrease in the future.\r\n<br/>"
+    content_nl: "Deze schuif stelt je de toe-of afname in die je verwacht voor de
+      investeringskosten voor 'Carbon Capture and Storage' (CCS, het afvangen en ondergronds
+      opslaan van CO<sub>2</sub>). De kosten worden vergeleken met de kosten van vandaag
+      de dag. Op dit moment is deze technologie alleen nog maar in experimentele centrales
+      toegepast, maar men verwacht dat de kosten af zullen nemen."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 141
   key: transport_cars_share
   share_group: passenger_transport
@@ -667,6 +1088,13 @@
   slide_id: 24
   position: 2
   dependent_on: ''
+  description:
+    content_en: Please indicate what percentage of the kilometres we travel is covered
+      by cars.
+    content_nl: Hier kun je aangeven hoeveel procent van de kilometers die we reizen
+      afgelegd wordt met de auto.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 142
   key: transport_trucks_share
   share_group: freight_transport
@@ -690,6 +1118,19 @@
   slide_id: 229
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Will transport by truck increase? Compared to rail or inland navigation,
+      truck transportation is relatively inefficient and polluting. Trucks are practical,
+      however, in that they can reach nearly any destination. They are most suited
+      for transporting goods over relatively short distances.\r\n<br/><br/>\r\nNote
+      that trucks also include the small vans used for delivery. "
+    content_nl: "Zal het goederenvervoer per vrachtwagen toenemen? In vergelijking
+      met de binnenvaart en het spoor zijn vrachtwagens relatief inefficiënt en vervuilend.
+      Ze zijn wel erg praktisch om goederen precies op hun bestemming te krijgen.
+      Ze zijn dan ook het best geschikt voor transport over korte afstanden.\r\n<br/><br/>\r\nMerk
+      op dat bestelbusjes ook vallen onder vrachtwagens. "
+    short_content_en: ''
+    short_content_nl: ''
 - id: 143
   key: transport_passenger_trains_share
   share_group: passenger_transport
@@ -713,6 +1154,13 @@
   slide_id: 24
   position: 3
   dependent_on: ''
+  description:
+    content_en: Please indicate what percentage of the kilometres we travel is covered
+      by trains.
+    content_nl: Hier kun je aangeven hoeveel procent van de kilometers die we reizen
+      afgelegd wordt met de trein.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 144
   key: transport_planes_share
   share_group: passenger_transport
@@ -736,6 +1184,17 @@
   slide_id: 24
   position: 8
   dependent_on: is_national_scenario
+  description:
+    content_en: Please indicate what percentage of the kilometres we travel is covered
+      by planes. Please note that this slider is about domestic flights only. For
+      international aviation, see <a href="/scenario/demand/transport_international_transport/international-transport">international
+      transport</a>.
+    content_nl: 'Hier kun je aangeven hoeveel procent van de kilometers die we reizen
+      afgelegd wordt met het vliegtuig. Let op: het gaat hier om binnenlandse vluchten.
+      Voor internationaal vliegverkeer, zie <a href="/scenario/demand/transport_international_transport/international-transport">internationaal
+      transport</a>.'
+    short_content_en: ''
+    short_content_nl: ''
 - id: 145
   key: transport_ships_share
   share_group: freight_transport
@@ -759,6 +1218,17 @@
   slide_id: 229
   position: 4
   dependent_on: ''
+  description:
+    content_en: What do you think will happen to transport by ship? Will this decrease
+      or increase? Ships are by far the most energy efficient mode of transport, but
+      they depend on high quality infrastructure for inland navigation and they are
+      relatively slow. They are ill-suited for transportation over short distances.
+    content_nl: Gaat goederenvervoer met de binnenvaart toenemen of afnemen? Schepen
+      zijn zeer efficiënt, maar afhankelijk van een goede infrastructuur. Daarnaast
+      zijn ze nogal langzaam. Ze zijn dan ook niet geschikt voor vervoer over korte
+      afstanden.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 146
   key: transport_car_using_electricity_share
   share_group: transport_car_tech
@@ -782,6 +1252,45 @@
   slide_id: 25
   position: 1
   dependent_on: ''
+  description:
+    content_en: "What percentage of all cars will be fully electric cars in the future?
+      \r\n<br/><br/>\r\nThese cars use less than half the energy from “well to wheels”
+      of good diesel cars and are even more efficient compared to gasoline engines.
+      The technology for electric cars is available, but the required infrastructure
+      (sufficient opportunities for charging or exchanging batteries) is not. A typical
+      electric family car has a range of 150 – 250 km on a full set of batteries,
+      which makes them quite suited for small and densely populated countries. Furthermore,
+      electric cars are the ideal mobile electricity storage at night, if they are
+      plugged in and the charge they hold is remote controlled.\r\n<br/><br/>\r\nIf
+      you want to include hybrid cars in your scenario, you could assume that one
+      fully electric car is equivalent to three plug-in hybrid cars with range extenders.
+      These are electric cars that can be charged from the grid, but have limited
+      battery capacity. A range extender is a small gasoline engine that re-charges
+      the battery after about 50 - 60 km. \r\n<br/><br/>\r\nDo not forget that the
+      electricity still needs to be generated. If this is done with wind power, electric
+      cars contribute strongly to a more sustainable society, but less so when coal
+      power is used. \r\n<br/><br/>\r\nSee the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used.\r\n"
+    content_nl: "Welk deel van de auto's rijdt in de toekomst volledig op elektriciteit?
+      \r\n<br/><br/>\r\nElektrische auto's gebruiken minder dan de helft van de energie
+      van een dieselauto, van de bron naar de wielen gemeten. De technologie voor
+      de auto's is beschikbaar, maar de benodigde infrastructuur (om op te kunnen
+      laden of accu's te wisselen) is er nog niet. Een typische elektrische sedan
+      heeft een bereik van ~150 - 250 km met een volle accu. Zo'n auto is dus geschikt
+      voor kleine en dichtbevolkte landen. Bovendien zijn elektrische auto's ook ideaal
+      voor elektriciteitsopslag 's nachts als ze staan te laden. Dan moet het laden
+      wel van een afstand gecontroleerd kunnen worden.\r\n<br/><br/>\r\nJe zou kunnen
+      zeggen dat één elektrische auto gelijk is aan 3 plug-in hybride auto's met 'range
+      extender'. Dit zijn elektrische auto's die aan het net opgeladen kunnen worden,
+      maar met een kleine batterij. Een 'range extender' is een kleine benzine motor,
+      die het bereik vergroot door de batterij weer op te laden na 50 - 60 km. \r\n<br/><br/>\r\nVergeet
+      niet dat de elektricteit voor de auto nog wel moet worden opgewekt. Als dat
+      met hernieuwbare stroom gebeurt, kunnen elektrische auto's sterk bijdragen aan
+      een hernieuwbare samenleving. Als kolenstroom wordt gebruikt is dat minder het
+      geval. \r\n<br/><br/>\r\nZie onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen.\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 147
   key: transport_car_using_diesel_mix_share
   share_group: transport_car_tech
@@ -805,6 +1314,19 @@
   slide_id: 25
   position: 3
   dependent_on: ''
+  description:
+    content_en: "What percentage of all cars will use conventional diesel fueled internal
+      combustion engine (ICE) technology? \r\n<br/><br/>\r\nSome people believe these
+      cars will become much more efficient once competition from electric vehicles
+      becomes fiercer.\r\n<br/><br/>\r\nSee the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used."
+    content_nl: "Welk percentage van alle auto's zal op diesel blijven rijden in de
+      toekomst? \r\n<br/><br/>\r\nHet is mogelijk dat de efficiëntie van deze auto's
+      sneller zal verbeteren als de concurrentie van elektrische auto's sterker wordt.
+      \r\n<br/><br/>\r\nZie onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 148
   key: transport_car_using_gasoline_mix_share
   share_group: transport_car_tech
@@ -828,6 +1350,19 @@
   slide_id: 25
   position: 4
   dependent_on: ''
+  description:
+    content_en: "What percentage of all cars will be use gasoline fuelled internal
+      combustion engine (ICE) technology? \r\n<br/><br/> \r\nTheir efficiency may
+      start improving faster once competition from electric cars is felt more keenly.
+      \r\n<br/><br/>\r\nSee the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used."
+    content_nl: "Welk percentage van alle auto's zal op benzine blijven rijden in
+      de toekomst? <br/><br/> \r\nHet is mogelijk dat de efficiëntie van deze auto's
+      sneller zal verbeteren als de concurrentie van elektrische auto's sterker wordt.
+      \r\n<br/><br/>\r\nZie onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 157
   key: transport_truck_using_gasoline_mix_share
   share_group: transport_truck_tech
@@ -851,6 +1386,15 @@
   slide_id: 26
   position: 3
   dependent_on: ''
+  description:
+    content_en: "What percentage of all trucks will use gasoline fueled internal combustion
+      engine (ICE) technology? \r\n<br/><br/>\r\nSee the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used."
+    content_nl: "Welk percentage van alle vrachtwagens zal op benzine rijden in de
+      toekomst? \r\n<br/><br/>\r\nZie onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 158
   key: transport_truck_using_diesel_mix_share
   share_group: transport_truck_tech
@@ -874,6 +1418,20 @@
   slide_id: 26
   position: 2
   dependent_on: ''
+  description:
+    content_en: "What percentage of all trucks will use conventional diesel fueled
+      internal combustion engine (ICE) technology? \r\n<br/><br/>\r\nSome people believe
+      trucks will use ICE technology for quite a while longer, as electric trucks
+      are a technological challenge.\r\n<br/><br/>\r\nSee the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used."
+    content_nl: "Welk percentage van alle vrachtwagens zal op diesel blijven rijden
+      in de toekomst? \r\n<br/><br/> \r\nVeel mensen denken dat dit type vrachtwagens
+      nog wel een tijdje gebruikt zullen worden, doordat elektrische vrachtwagens
+      met een goed bereik moeilijker te realiseren zijn dan elektrische auto's. \r\n<br/><br/>\r\nZie
+      onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 159
   key: transport_truck_using_electricity_share
   share_group: transport_truck_tech
@@ -897,6 +1455,20 @@
   slide_id: 26
   position: 1
   dependent_on: ''
+  description:
+    content_en: "What percentage of all trucks will be fully electric in the future
+      (not counting hybrids)? \r\n<br/><br/>\r\nSome people believe trucks will use
+      ICE technology for quite a while longer, as electric trucks are a technological
+      challenge.\r\n<br/><br/>\r\nSee the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used."
+    content_nl: "Welk percentage van alle vrachtwagens zal volledig elektrisch aangedreven
+      zijn in de toekomst?\r\n<br/><br/>\r\nVeel mensen denken dat dieselvrachtwagens
+      nog wel een tijdje gebruikt zullen worden, doordat elektrische vrachtwagens
+      met een goed bereik moeilijker te realiseren zijn dan elektrische auto's. \r\n<br/><br/>\r\nZie
+      onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 171
   key: transport_vehicle_using_electricity_efficiency
   share_group: ''
@@ -920,6 +1492,24 @@
   slide_id: 34
   position: 1
   dependent_on: ''
+  description:
+    content_en: "Here you can indicate how much more efficient future electric vehicles
+      will become every year. Electric vehicles include all vehicles that can possibly
+      run on electricity: cars, trains, trucks, trams, metros, busses, motorcycles,
+      bicycles.\r\n<br/><br/>\r\nMost efficiency improvement is expected to come from
+      battery improvements, since electric engines are inherently very efficient already.
+      Most losses occur in charge/discharge cycles.\r\n<br/><br/>\r\nSee the <a href=\\\"https://github.com/quintel/etdataset-public/tree/mast\r\ner/nodes_source_analyses/transport\\\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used."
+    content_nl: "Hier kun je aangeven hoeveel efficiënter jij denkt dat elektrische
+      voertuigen ieder jaar zullen worden. Elektrische voertuigen zijn alle voertuigen
+      die geëlektrificeerd kunnen worden: auto's, treinen, vrachtwagens, trams, metro's,
+      bussen, motorfietsen en e-bikes.\r\n<br/><br/>\r\nDe grootste efficiëntieverbeteringen
+      verwacht men voor de accu's, aangezien elektromotoren al heel efficiënt zijn
+      van nature. De meeste verliezen vinden dan ook plaats bij het laden en ontladen.\r\n<br/><br/>\r\nZie
+      onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 178
   key: policy_area_onshore_land
   share_group: ''
@@ -943,6 +1533,28 @@
   slide_id: 35
   position: 1
   dependent_on:
+  description:
+    content_en: "Wind turbines require some space. You cannot just build them right
+      next to each other, because each turbine produces a wake. In this wake, there
+      is considerably less wind energy available to be harnessed by another wind mill.
+      How far apart wind mills need to be placed, depends on their height and the
+      length of the turbine blades. Typically, wind turbines are placed at least 5
+      turbine rotor diameters apart along a frequently occurring wind direction.\r\n<br/><br/>\r\nThis
+      slider sets the total surface area on which wind turbines may be built. To see
+      what percentage of the total surface area of your country it represents, see
+      the graph on the right. The starting value is the current total land area used.\r\n"
+    content_nl: "Windmolens hebben nogal wat ruimte nodig. Je kunt ze niet zomaar
+      naast elkaar zetten, omdat iedere windmolen een 'windschaduw' heeft. Binnen
+      die windschaduw is er veel minder windenergie beschikbaar voor de volgende windmolen.
+      Hoe ver windmolens uit elkaar moeten staan is afhankelijk van de ashoogte en
+      rotordiameter. Meestal staan windmolens ten minste 5 rotordiameters uit elkaar
+      in de meest voorkomende windrichting.\r\n<br/><br/>\r\nDeze schuif stelt het
+      totale landoppervlak in dat bestemd wordt voor het bouwen van windmolens. In
+      de grafiek rechts is te zien welk percentage van het totale oppervlak van jouw
+      land dat is. De startwaarde is het huidige landoppervlak dat voor windparken
+      in gebruik is.\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 179
   key: policy_area_onshore_coast
   share_group: ''
@@ -966,6 +1578,27 @@
   slide_id: 35
   position: 2
   dependent_on: has_coastline
+  description:
+    content_en: "This slider sets the total length of coastline along which turbines
+      may be built. On the right, you can see which percentage of the total coastline
+      you have allocated to wind power generation. \r\n\r\n<br/><br/>\r\n\r\nWind
+      turbines require some space. You cannot just build them right next to each other,
+      because each turbine produces a wake. In this wake, there is considerably less
+      wind energy available to be harnessed by another wind mill. How far apart wind
+      mills need to be placed, depends on their height and the length of the turbine
+      blades. Typically, wind turbines are placed at least 5 turbine rotor diameters
+      apart along a frequently occurring wind direction.\r\n"
+    content_nl: "Deze schuif stelt de totale lengte van de kust in die bestemd wordt
+      voor het bouwen van windmolens. In de grafiek rechts is te zien welk percentage
+      van de totale kustlijn van jouw land dat is. De startwaarde is het de lengte
+      die nu voor windparken in gebruik is.\r\n\r\n<br/><br/>\r\nWindmolens hebben
+      nogal wat ruimte nodig. Je kunt ze niet zomaar naast elkaar zetten, omdat iedere
+      windmolen een 'windschaduw' heeft. Binnen die windschaduw is er veel minder
+      windenergie beschikbaar voor de volgende windmolen. Hoe ver windmolens uit elkaar
+      moeten staan is afhankelijk van de ashoogte en rotordiameter. Meestal staan
+      windmolens ten minste 5 rotordiameters uit elkaar in de meest voorkomende windrichting.\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 180
   key: om_costs_combustion_gas_plant
   share_group: ''
@@ -989,6 +1622,16 @@
   slide_id: 8
   position: 1
   dependent_on: ''
+  description:
+    content_en: "This slider sets the expected change in operational and maintenance
+      costs for a gas-fired power plant (excluding fuel). Costs are compared to current
+      costs.<br/><br/>\r\nThe specification below are for a CCGT plant: "
+    content_nl: "Deze schuif stelt je de toe-of afname in die je verwacht voor de
+      onderhouds- en beheerkosten van gascentrales (zonder brandstof). De kosten worden
+      vergeleken met de kosten van vandaag de dag. <br/><br/>\r\nDe specificaties
+      hieronder zijn voor een STEG centrale:"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 181
   key: om_costs_combustion_oil_plant
   share_group: ''
@@ -1012,6 +1655,15 @@
   slide_id: 8
   position: 2
   dependent_on:
+  description:
+    content_en: This slider sets the expected change in operational and maintenance
+      costs for an oil-fired power plant (excluding fuel). Costs are compared to current
+      costs.
+    content_nl: 'Deze schuif stelt je de toe-of afname in die je verwacht voor de
+      onderhouds- en beheerkosten van oliecentrales (zonder brandstof). De kosten
+      worden vergeleken met de kosten van vandaag de dag. '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 182
   key: om_costs_combustion_coal_plant
   share_group: ''
@@ -1035,6 +1687,17 @@
   slide_id: 8
   position: 3
   dependent_on:
+  description:
+    content_en: "This slider sets the expected change in operational and maintenance
+      costs for a coal-fired power plant (excluding fuel). Costs are compared to current
+      costs.<br/><br/>\r\nThe specifications below are for an ultra-supercritical
+      coal power plant:"
+    content_nl: "Deze schuif stelt je de toe-of afname in die je verwacht voor de
+      onderhouds- en beheerkosten van kolencentrales (zonder brandstof). De kosten
+      worden vergeleken met de kosten van vandaag de dag. <br/><br/>\r\nDe specificaties
+      hieronder zijn voor een ultra-supercritische kolencentrale:"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 183
   key: om_costs_combustion_biomass_plant
   share_group: ''
@@ -1058,6 +1721,17 @@
   slide_id: 8
   position: 4
   dependent_on:
+  description:
+    content_en: This slider sets the expected change in operational and maintenance
+      costs for a biomass-fired power plant (excluding fuel). Costs are compared to
+      current costs. These costs are likely to follow developments for coal-fired
+      power plants.
+    content_nl: Deze schuif stelt je de toe-of afname in die je verwacht voor de onderhouds-
+      en beheerkosten van biomassacentrales (zonder brandstof). De kosten worden vergeleken
+      met de kosten van vandaag de dag. Deze kosten zullen waarschijnlijk niet veel
+      afwijken van de kosten voor kolencentrales.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 185
   key: costs_uranium
   share_group: ''
@@ -1081,6 +1755,19 @@
   slide_id: 21
   position: 1
   dependent_on: ''
+  description:
+    content_en: This slider sets the height of your assumed future uranium price.
+      Costs are compared to current costs. The price you set is displayed next to
+      the slider. There is a global market for uranium, although demand for mined
+      uranium has slumped in the past decades, as power plants consumed the uranium
+      and plutonium of decommissioned nuclear warheads.
+    content_nl: Deze schuif stelt je aanname over de toekomstige uraniumprijs in,
+      uitgedrukt in aantal keren de prijs van vandaag. De prijs die je instelt, staat
+      naast de schuif. Er bestaat een wereldmarkt voor uranium, maar de vraag naar
+      uranium uit mijnen is de afgelopen decennia erg laag geweest, doordat oude kernkoppen
+      gebruikt werden voor brandstof.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 186
   key: transport_vehicle_combustion_engine_efficiency
   share_group: ''
@@ -1104,6 +1791,21 @@
   slide_id: 34
   position: 4
   dependent_on: ''
+  description:
+    content_en: "Here you can indicate how much more efficient future fossil-fuelled
+      vehicles will become every year. For example: new cars become almost 2% more
+      efficient every year. \r\n<br/><br/>\r\nSome people believe these vehicles will
+      become much more efficient once competition from electric vehicles becomes fiercer.\r\n<br/><br/>\r\nSee
+      the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used."
+    content_nl: "Hier kun je aangeven hoeveel efficiënter jij denkt dat voertuigen
+      die op fossiele brandstoffen rijden ieder jaar worden. Bijvoorbeeld: nieuwe
+      auto's worden elk jaar ongeveer 2% efficiënter. \r\n<br/><br/>\r\nSommige mensen
+      geloven dat deze voertuigen nog veel zuiniger gaan worden als de concurrentie
+      van elektrische voertuigen toeneemt.\r\n<br/><br/>\r\nZie onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen.\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 187
   key: transport_ships_efficiency
   share_group: ''
@@ -1127,6 +1829,15 @@
   slide_id: 34
   position: 6
   dependent_on: ''
+  description:
+    content_en: Here you can indicate how much more efficient future ships will become
+      every year. <br/><br/>Ships are already quite energy efficient, but there is
+      some room for improvement.
+    content_nl: "Geef hier aan hoeveel efficiënter schepen volgens jou ieder jaar
+      zullen worden. <br/><br/>\r\nSchepen zijn al een behoorlijk efficiënte vorm
+      van vervoer, maar er is nog ruimte voor verbetering. "
+    short_content_en: ''
+    short_content_nl: ''
 - id: 188
   key: transport_planes_efficiency
   share_group: ''
@@ -1150,6 +1861,15 @@
   slide_id: 34
   position: 7
   dependent_on: ''
+  description:
+    content_en: "Here you can indicate how much more efficient future airplanes will
+      become every year. <br/> <br/>\r\nThere is some room for improvement, but not
+      much."
+    content_nl: "Geef hier aan hoeveel efficienter jij denkt dat vliegtuigen ieder
+      jaar zullen worden. \r\n<br/> <br/>\r\nHier bestaat nog ruimte voor verbetering,
+      maar niet heel veel."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 193
   key: policy_area_roofs_for_solar_panels
   share_group: ''
@@ -1173,6 +1893,15 @@
   slide_id: 36
   position: 1
   dependent_on:
+  description:
+    content_en: "This slider sets the surface area of rooftops oriented southward
+      that have been assigned to solar panels. This is only a boundary condition.
+      You can choose to build these solar panels in section “Supply”. \r\n"
+    content_nl: 'Deze schuif stelt in hoeveel naar het zuiden gericht dakoppervlak
+      toegewezen moet worden aan zonnepanelen. Dit is slechts een randvoorwaarde.
+      Om zonnepanelen in te zetten, moet je bij het onderdeel ''Aanbod'' zijn.  '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 194
   key: policy_area_land_for_solar_panels
   share_group: ''
@@ -1196,6 +1925,16 @@
   slide_id: 36
   position: 2
   dependent_on:
+  description:
+    content_en: "This slider sets the surface area of the land you assign to building
+      photovoltaic solar power plants. On the right, you can see what percentage of
+      arable land you have allocated to these plants. \r\n"
+    content_nl: "Deze schuif stelt in hoeveel landoppervlak beschikbaar moet worden
+      gesteld voor parken met zonnepanelen. Rechts kun je zien, welk percentage van
+      het totale landbouwareaal je hebt toegekend. <br/>\r\nDit is slechts een randvoorwaarde.
+      Als je zonneparken wilt bouwen, moet je in het onderdeel 'Aanbod' zijn."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 195
   key: policy_area_land_for_csp
   share_group: ''
@@ -1219,6 +1958,17 @@
   slide_id: 36
   position: 3
   dependent_on: has_solar_csp
+  description:
+    content_en: "This slider sets the surface area of the land you assign to solar
+      power plants that use Concentrated Solar Power (CSP). On the right, you can
+      see how much of the available land has been allocated, as a result of your choices.\r\n"
+    content_nl: "Deze schuif stelt in hoeveel landoppervlak beschikbaar moet worden
+      gesteld voor parken met zonnewarmte centrales. Rechts kun je zien, welk percentage
+      van het totale landbouwareaal je hebt toegekend. <br/>\r\nDit is slechts een
+      randvoorwaarde. Als je zonneparken wilt bouwen, moet je in het onderdeel 'Aanbod'
+      zijn."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 198
   key: policy_sustainability_co2_emissions
   share_group: ''
@@ -1242,6 +1992,15 @@
   slide_id: 38
   position: 1
   dependent_on:
+  description:
+    content_en: "This slider sets the total CO<sub>2</sub> emissions target w.r.t.
+      1990. \r\n<br/>\r\nThe EU want to curb emissions by 80% by 2050. These reduction
+      targets have no binding legal status yet, though.\r\n"
+    content_nl: "Deze schuif stelt de doelstelling in voor totale CO<sub>2</sub> emissiereductie.
+      Het percentage is in vergelijking met 1990. \r\n<br/>\r\nDe EU will de uitstoot
+      met 80% gereduceerd hebben in 2050. Dit is nog geen wettelijk bindende doelstelling.\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 204
   key: households_useful_demand_for_cooling
   share_group: ''
@@ -1265,6 +2024,21 @@
   slide_id: 43
   position: 6
   dependent_on: ''
+  description:
+    content_en: "Note: these changes in energy demand do <strong>not</strong> depend
+      on the technologies chosen below (Cooling).\r\n<br/><br/>\r\n\r\nPlease indicate
+      how you expect the demand for cooling per residence to change. This is mainly
+      determined by growth in prosperity. As people become richer, their energy consumption
+      inevitably increases as they live in larger houses, install airconditioning,
+      etc.\r\n"
+    content_nl: "Let op: deze verandering van energiegebruik is <strong>onafhankelijk</strong>
+      van de technologieën die je hieronder kunt kiezen (Koeling). \r\n<br/><br/>\r\nHoe
+      denk jij dat de koudevraag per huishouden zich gaat ontwikkelen? Dit hangt vooral
+      af van de welvaartsgroei. Als mensen rijker worden, gaat hun energiegebruik
+      onvermijdelijk omhoog, doordat ze in steeds grotere huizen wonen, airconditioning
+      aanschaffen, etc."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 206
   key: policy_dependence_max_dependence
   share_group: ''
@@ -1288,6 +2062,16 @@
   slide_id: 40
   position: 1
   dependent_on: ''
+  description:
+    content_en: "This slider sets the desired level of net energy imports, i.e. imports
+      minus exports of energy. <br />\r\nNote: this concerns all forms of energy and
+      not only electricity. A separate slider sets maximum electricity imports allowed."
+    content_nl: "Deze schuif stelt in hoeveel buitenlandse energie je netto maximaal
+      wilt importeren. Netto import is alle import minus alle export van energie.<br
+      />\r\nLet op: het gaat hier om alle vormen van energie en niet alleen elektriciteit.
+      Voor elektriciteit is er een aparte schuif."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 207
   key: policy_cost_electricity_cost
   share_group: ''
@@ -1311,6 +2095,17 @@
   slide_id: 99
   position: 1
   dependent_on: ''
+  description:
+    content_en: This slider sets the percentage by which electricity costs are allowed
+      to increase (or decrease).  These costs depend on your assumptions in section
+      <a href="/scenario/costs">Costs</a> and the composition of the electricity and
+      heat production parks you will design in section <a href="/scenario/supply">Supply</a>.
+    content_nl: Met dit schuifje stel je het percentage in waarmee de kosten van elektriciteit
+      mogen toe- of afnemen. Deze kosten hangen af van je aannames in het onderdeel
+      <a href="/scenario/costs">Kosten</a> en hoe elektriciteit en warmte worden gemaakt
+      in het onderdeel <a href="/scenario/supply">Aanbod</a>.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 208
   key: policy_cost_total_energy_cost
   share_group: ''
@@ -1334,6 +2129,17 @@
   slide_id: 41
   position: 1
   dependent_on: ''
+  description:
+    content_en: "This slider sets the percentage by which energy costs are allowed
+      to increase (or decrease). These costs depend on your assumptions in section
+      <a href=\"/scenario/costs\">Costs</a> and the composition of the electricity
+      and heat production parks you will design in section <a href=\"/scenario/supply\">Supply</a>.\r\n"
+    content_nl: 'Deze schuif stelt het percentage in waarmee de kosten van energie
+      mogen toe- of afnemen. Deze kosten hangen af van je aannames in het onderdeel
+      <a href="/scenario/costs">Kosten</a> en hoe elektriciteit en warmte worden gemaakt
+      in het onderdeel <a href="/scenario/supply">Aanbod</a>. '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 212
   key: policy_dependence_max_electricity_dependence
   share_group: ''
@@ -1357,6 +2163,15 @@
   slide_id: 40
   position: 2
   dependent_on: ''
+  description:
+    content_en: "This slider sets the maximum net electricity imports allowed in this
+      country. For the grid it is often more important how much import capacity exists.
+      \r\n"
+    content_nl: Met deze schuif stel je de maximale netto import van elektriciteit
+      in. Voor het netwerk is het wellicht nog belangrijker hoeveel import capaciteit
+      bestaat.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 220
   key: agriculture_useful_demand_electricity
   share_group: ''
@@ -1380,6 +2195,19 @@
   slide_id: 30
   position: 1
   dependent_on: ''
+  description:
+    content_en: "Note: these changes in energy demand do <strong>not</strong> depend
+      on the technologies chosen below.\r\n<br/><br/>\r\nWhat do you expect the development
+      of agricultural electricity demand will be like? This depends primarily on the
+      growth of the number of greenhouses (determined by economic growth, but also
+      conditions for investment etc.)."
+    content_nl: "Let op: deze verandering van energiegebruik is <strong>onafhankelijk</strong>
+      van de technologieën die je hieronder kunt kiezen.\r\n<br/><br/>\r\nHoe denk
+      jij dat de elektriciteitsvraag in de land- en tuinbouw zich gaat ontwikkelen?
+      Dat hangt vooral af van de groei van het aantal broeikassen, dus zijn economische
+      groeiverwachtingen en investeringscondities van belang. "
+    short_content_en: ''
+    short_content_nl: ''
 - id: 221
   key: agriculture_useful_demand_useable_heat
   share_group: ''
@@ -1403,6 +2231,19 @@
   slide_id: 30
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Note:these changes in energy demand do not depend on the technologies
+      chosen below.\r\n<br/> <br/>\r\nWhat do you expect the development of agricultural
+      heat demand will be like? This parameter depends primarily on the number of
+      greenhouses (determined by economic growth, but also conditions for investment
+      etc.). "
+    content_nl: "Let op: deze verandering van energiegebruik is onafhankelijk van
+      de technologieën die je hieronder kunt kiezen.\r\n<br/><br/>\r\nHoe denk jij
+      dat de warmtevraag in de land- en tuinbouw zich gaat ontwikkelen? Dat hangt
+      vooral af van de groei van het aantal broeikassen en dus van economische groei
+      en inversteringscondities. "
+    short_content_en: ''
+    short_content_nl: ''
 - id: 223
   key: agriculture_burner_crude_oil_share
   share_group: agri_heat
@@ -1426,6 +2267,19 @@
   slide_id: 31
   position: 2
   dependent_on: ''
+  description:
+    content_en: "What percentage of heat demand in agriculture (greenhouses) is met
+      by oil-fired heaters? \r\n<br/><br/>\r\nFor agricultural heating needs, gas
+      is more attractive than the strongly polluting solid and liquid fuels, more
+      than in industry. How cleanly such fuels can be applied is a mostly matter of
+      scale."
+    content_nl: "Welk percentage van de warmtevraag in de landbouw (broeikassen) wordt
+      ingevuld door oliegestookte ketels?\r\n<br/><br/>\r\nVoor kassen is gas interessanter
+      dan sterk vervuilende vloeibare of vaste brandstoffen, anders dan in de industrie.
+      De mate waarin men zulke brandstoffen relatief schoon kan gebruiken hangt namelijk
+      mede af van de schaalgrootte. "
+    short_content_en: ''
+    short_content_nl: ''
 - id: 225
   key: agriculture_burner_wood_pellets_share
   share_group: agri_heat
@@ -1449,6 +2303,15 @@
   slide_id: 31
   position: 3
   dependent_on: ''
+  description:
+    content_en: What percentage of heat demand in agriculture (greenhouses) is met
+      by biomass-fired heaters? <br><br>Burning locally available biomass is usually
+      quite efficient.
+    content_nl: 'Welk percentage van de warmte die nodig is in de land- en tuinbouw
+      komt van het verbranden van biomassa? Het verbranden van lokaal beschikbare
+      biomassa is energetisch vrij efficiënt. '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 227
   key: agriculture_heatpump_water_water_ts_electricity_share
   share_group: agri_heat
@@ -1472,6 +2335,25 @@
   slide_id: 31
   position: 4
   dependent_on: ''
+  description:
+    content_en: "Thermal storage works by storing a building's heat underground by
+      cooling it with water from a water basin or aquifer in summer and using that
+      heat in winter for heating the building. Alternatively the natural heat of cold
+      of ground water or roads, for example, can be used.\r\n<br/><br/>\r\nHeat pumps
+      are more efficient when used in combination with thermal storage, because less
+      energy has to be added to cool or heat water to the right temperature. It is
+      difficult to realize underground thermal storage in densely populated areas."
+    content_nl: "Bij Warmte Koude Opslag (WKO) wordt de warmte van een gebouw ondergronds
+      opgeslagen door het te koelen met water en die warmte op te slaan in een ondergronds
+      bassin of waterlaag. Die opgeslagen warmte gebruikt men dan in de winter om
+      het huis mee te verwarmen. Als alternatief kan ook de natuurlijke warmte of
+      koude van oppervlaktewater of wegen gebruikt worden.\r\n<br/><br/>\r\nWarmtepompen
+      zijn zeer efficiënt als ze met WKO gecombineerd worden, omdat minder energie
+      hoeft te worden toegevoegd om een gebouw te koelen of te verwarmen. Het is helaas
+      praktisch niet altijd mogelijk om de ondergrondse opslag te realiseren (bijvoorbeeld
+      in stedelijk gebied)."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 228
   key: agriculture_geothermal_share
   share_group: agri_heat
@@ -1495,6 +2377,14 @@
   slide_id: 31
   position: 5
   dependent_on:
+  description:
+    content_en: "Geothermal heat’s potential is theoretically huge. This slider provides
+      low grade heat (< 100 &#176;C) from several kilometers underground.\r\n"
+    content_nl: "Het warmtepotentieel  van aardwarmte is in theorie gigantisch. Deze
+      schuif geeft aan hoeveel lage temperatuurswarmte (< 100 &#176;C) van enkele
+      kilometers diepte je wilt inzetten."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 229
   key: other_useful_demand_electricity
   share_group: ''
@@ -1518,6 +2408,18 @@
   slide_id: 32
   position: 1
   dependent_on: ''
+  description:
+    content_en: "Note: these changes in energy demand do <strong>not</strong> depend
+      on the technologies chosen below.\r\n<br/><br/>\r\nWhat do you expect the development
+      of electricity demand in the building sector will be like? This depends primarily
+      on the growth of the this sector (determined by economic growth, but also conditions
+      for investment etc.)."
+    content_nl: "Let op: deze verandering van energiegebruik is <strong>onafhankelijk</strong>
+      van de technologieën die je hieronder kunt kiezen.\r\n<br/><br/>\r\nHoe denk
+      jij dat de elektriciteitsvraag voor de bouwsector zich gaat ontwikkelen? Dat
+      hangt vooral af van economische groeiverwachtingen en bevolkingsgroei."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 230
   key: other_useful_demand_useable_heat
   share_group: ''
@@ -1541,6 +2443,18 @@
   slide_id: 32
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Note: these changes in energy demand do not depend on the technologies
+      chosen below.\r\n<br/><br/>\r\nWhat do you expect the development of heat demand
+      for the building sector will be like? This parameter depends primarily on the
+      growth of this sector (determined by economic growth, but also conditions for
+      investment etc.). "
+    content_nl: "Let op: deze verandering van energiegebruik is onafhankelijk van
+      de technologieën die je hieronder kunt kiezen.\r\n<br/><br/>\r\nHoe denk jij
+      dat de warmtevraag voor de bouwsector zich gaat ontwikkelen? Dat hangt vooral
+      af van economische groeiverwachtingen en bevolkingsgroei.\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 231
   key: investment_costs_combustion_waste_incinerator
   share_group: ''
@@ -1564,6 +2478,16 @@
   slide_id: 7
   position: 5
   dependent_on:
+  description:
+    content_en: "This slider sets the expected change in investment costs for a waste-incinerator
+      plant. Costs are compared to current costs.\r\n<br/>\r\n<br/>\r\nWaste-incinerators
+      are often used to generate both heat and electricity."
+    content_nl: "Deze schuif stelt je de toe-of afname in die je verwacht voor de
+      investeringskosten van afvalverbrandingscentrales. De kosten worden vergeleken
+      met de kosten van vandaag de dag. \r\n<br/><br/>\r\nDeze centrales worden vaak
+      ingezet voor de productie van zowel warmte als elektriciteit."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 232
   key: om_costs_combustion_waste_incinerator
   share_group: ''
@@ -1587,6 +2511,15 @@
   slide_id: 8
   position: 5
   dependent_on:
+  description:
+    content_en: This slider sets the expected change in operational and maintenance
+      costs for a waste incinerator that generates electricity (excluding fuel). Costs
+      are compared to current costs.
+    content_nl: 'Deze schuif stelt je de toe-of afname in die je verwacht voor de
+      onderhouds- en beheerkosten van afvalverbrandingscentrales (zonder brandstof).
+      De kosten worden vergeleken met de kosten van vandaag de dag. '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 233
   key: policy_area_offshore
   share_group: ''
@@ -1610,6 +2543,29 @@
   slide_id: 35
   position: 3
   dependent_on: has_coastline
+  description:
+    content_en: "This slider sets the total sea surface area in which wind turbines
+      may be placed. On the right, you can see how large the total suitable area is
+      for wind turbines in your country's territorial waters. The percentage of this
+      area that has been allotted to offshore wind power is also shown here.\r\n<br/><br/>\r\nWind
+      turbines require some space. You cannot just build them right next to each other,
+      because each turbine produces a wake. In this wake, there is considerably less
+      wind energy available to be harnessed by another wind mill. How far apart wind
+      mills need to be placed, depends on their height and the length of the turbine
+      blades. Typically, wind turbines are placed at least 5 turbine rotor diameters
+      apart along a frequently occurring wind direction."
+    content_nl: "Deze schuif stelt het totale zeeoppervlak in dat bestemd wordt voor
+      het bouwen van windmolens. In de grafiek rechts is te zien welk percentage van
+      de territoriale wateren van jouw land dat is. De startwaarde is het huidige
+      zeeoppervlak dat voor windparken in gebruik is.\r\n\r\n<br/><br/>\r\n\r\nWindmolens
+      hebben nogal wat ruimte nodig. Je kunt ze niet zomaar naast elkaar zetten, omdat
+      iedere windmolen een 'windschaduw' heeft. Binnen die windschaduw is er veel
+      minder windenergie beschikbaar voor de volgende windmolen. Hoe ver windmolens
+      uit elkaar moeten staan is afhankelijk van de ashoogte en rotordiameter. Meestal
+      staan windmolens ten minste 5 rotordiameters uit elkaar in de meest voorkomende
+      windrichting.\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 234
   key: policy_sustainability_renewable_percentage
   share_group: ''
@@ -1633,6 +2589,26 @@
   slide_id: 39
   position: 1
   dependent_on: ''
+  description:
+    content_en: "This slider sets the sustainable energy target as a percentage of
+      all final energy use.\r\n<br/><br/>\r\nThe EU has passed binding legislation
+      that in 2020 20% of all energy consumption should be sustainable.\r\n<br/><br/>\r\nPlease
+      note: The value that is calculated by the ETM for the current year may be different
+      from the number in official statistics due to a different definition. This is
+      also the reason for a possible gap between historic and  current value. More
+      information is available in our <a href=\"https://github.com/quintel/documentation/blob/master/general/renewability.md\"
+      target=\"blank\">documentation</a>."
+    content_nl: "Deze schuif stelt de hernieuwbare energiedoelstelling in, uitgedrukt
+      als percentage van het totale finale energiegebruik.\r\n<br/><br/>\r\nDe EU
+      heeft bindende wetgeving aangenomen dat in 2020 20% van al het energiegebruik
+      hernieuwbaar moet zijn. \r\n<br/><br/>\r\nOpmerking: De waarde die het ETM uitrekent
+      voor het huidige jaar kan afwijken van het getal in officiële statistieken (CBS)
+      vanwege een verschillende definitie. Dit is ook de oorzaak van een (mogelijk)
+      gat tussen historische gegevens en de waarde voor het huidige jaar. Meer informatie
+      is beschikbaar in onze <a href=\"https://github.com/quintel/documentation/blob/master/general/renewability.md\"
+      target=\"blank\">documentatie</a>."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 238
   key: transport_car_using_lpg_share
   share_group: transport_car_tech
@@ -1656,6 +2632,17 @@
   slide_id: 25
   position: 5
   dependent_on: ''
+  description:
+    content_en: "What percentage of all cars will be use LPG fueled internal combustion
+      engine (ICE) technology? These cars also use gasoline as a back up fuel.\r\n<br/><br/>\r\nSee
+      the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used."
+    content_nl: "Welk percentage van alle auto's zal op LPG rijden in de toekomst?\r\nDeze
+      auto's rijden ook op benzine als 'back up' brandstof. \r\n<br/><br/>\r\nZie
+      onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 239
   key: transport_car_using_compressed_natural_gas_share
   share_group: transport_car_tech
@@ -1679,6 +2666,36 @@
   slide_id: 25
   position: 6
   dependent_on: ''
+  description:
+    content_en: "What percentage of all cars will use compressed gas fueled internal
+      combustion engine (ICE) technology? \r\n<br/><br/>\r\nGas-fueled cars are relatively
+      clean compared to gasoline or diesel fueled ones. In terms of efficiency, one
+      might say that gas is better used for generating heat and electricity (co-generation)
+      at the location it is needed. ICE technology is likely to progress, but will
+      never rival the efficiency of such a process. In terms of pollution, one might
+      say that it is better to use gas to generate electricity at a central location
+      (where exhaust gases can be cleaned or even captured and stored) and to use
+      the electricity to power electric cars.\r\n<br/><br/>\r\nCompressed natural
+      gas in these cars comes from the gas network. This means it can contain green
+      gas if in the current scenario this is mixed in with natural gas on the gas
+      network.\r\n<br/><br/>\r\nSee the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used."
+    content_nl: "Welk percentage van alle auto's zal op aardgas onder druk rijden
+      in de toekomst? \r\n<br/><br/>\r\nAardgasauto's zijn schoner dan benzine of
+      dieselauto's. Wat energie-efficiëntie betreft, zou je kunnen zeggen dat gas
+      het best kan worden gebruikt om warmte en elektriciteit te maken (WKK) op de
+      plaats waar het gebruikt wordt, dan voor auto's. Verbrandingsmotoren zullen
+      nog wel wat efficiënter worden, maar kunnen nooit zo efficiënt worden als WKK's.
+      Wat vervuiling betreft, zou je kunnen zeggen dat gas het beste gebruikt kan
+      worden om centraal elektriciteit te maken, zodat verbrandingsgassen kunnen worden
+      gezuiverd of zelf afgevangen. De geproduceerde elektriciteit kan dan gebruikt
+      worden om auto's aan te drijven.\r\n<br/><br/>\r\nAardgas onder druk komt van
+      het gasnetwerk. Als in dit scenario groengas wordt bijgemengd in het gasnetwerk
+      dan zullen deze voertuigen ook deels op groengas rijden.\r\n<br/><br/>\r\nZie
+      onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 240
   key: transport_truck_using_compressed_natural_gas_share
   share_group: transport_truck_tech
@@ -1702,6 +2719,23 @@
   slide_id: 26
   position: 4
   dependent_on: ''
+  description:
+    content_en: "What percentage of all trucks will use compressed natural gas fueled
+      internal combustion engine (ICE) technology?\r\nNatural gas fueled engines already
+      exist and are currently mostly used for public transport buses. \r\n<br/><br/>\r\nCompressed
+      natural gas in these trucks comes from the gas network. This means it can contain
+      green gas if in the current scenario this is mixed in with natural gas on the
+      gas network.\r\n<br/><br/>\r\nSee the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used."
+    content_nl: "Welk percentage van alle vrachtwagens zal op aardgas onder druk rijden
+      in de toekomst? Op dit moment rijden in deze categorie vooral bussen voor openbaar
+      vervoer op deze brandstof.\r\n<br/><br/>\r\nAardgas onder druk komt van het
+      gasnetwerk. Als in dit scenario groengas wordt bijgemengd in het gasnetwerk
+      dan zullen deze voertuigen ook deels op groengas rijden.\r\n<br/><br/>\r\nZie
+      onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 241
   key: transport_trains_efficiency
   share_group: ''
@@ -1725,6 +2759,13 @@
   slide_id: 34
   position: 5
   dependent_on: ''
+  description:
+    content_en: Here you can indicate how much more efficient future trains will become
+      every year. Trains are already quite energy efficient.
+    content_nl: Hier kun je aangeven hoeveel efficiënter treinen in de toekomst volgens
+      jou zullen zijn. Treinen hebben nu al een zeer goede energie-efficiëntie.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 245
   key: households_lighting_incandescent_electricity_share
   share_group: household_light
@@ -1748,6 +2789,21 @@
   slide_id: 2
   position: 1
   dependent_on: ''
+  description:
+    content_en: "Many EU countries will ban the incandescent light bulb in the future.
+      They only convert about 2-3% of the energy used into visible light. The rest
+      is radiated as heat. They also do not live very long compared to newer technologies.
+      An advantage is that they tend to give off a 'warm' light. \r\n<br/><br/>\r\nLifetime
+      comparison:\r\n<br/>• LED-light:      ~50.000 hours\r\n<br/>• ESLB:             ~7.500
+      hours\r\n<br/>• Incandescent:  ~1.000 hours"
+    content_nl: "Veel EU landen gaan de gloeilamp verbieden in de toekomst. Ze zetten
+      maar 2-3% van de energie die ze gebruiken om in licht. De rest wordt als warmte
+      afgegeven. Hoewel ze mooi warm licht geven leven ze minder lang dan hun concurrenten
+      de LED en spaarlampen.\r\n<br/><br/>\r\nVergelijking levensduren:\r\n<br/>•
+      LED-lamp: ~50.000 uur\r\n<br/>• Spaarlamp: ~7.500 uur\r\n<br/>• Gloeilamp: ~1.000
+      uur"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 246
   key: agriculture_burner_network_gas_share
   share_group: agri_heat
@@ -1771,6 +2827,13 @@
   slide_id: 31
   position: 1
   dependent_on: ''
+  description:
+    content_en: These are gas-fired central heating systems. These systems are quite
+      energy efficient, but emit CO<sub>2</sub>.
+    content_nl: Dit zijn gasgestookte ketels. Dit zijn behoorlijk efficiënte systemen,
+      maar ze stoten wel CO<sub>2</sub> uit.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 247
   key: investment_costs_geothermal
   share_group: ''
@@ -1794,6 +2857,20 @@
   slide_id: 13
   position: 1
   dependent_on: ''
+  description:
+    content_en: "This slider sets the change in future investment costs for geothermal
+      energy. Costs are compared to current costs.\r\n<br/>\r\n<br/>\r\nThese plants
+      require rather large investments for drilling deep wells as water of a high
+      enough temperature tends to be found at depths greater than 3 km in most non-volcanic
+      countries."
+    content_nl: "Met deze schuif stel je de toe-of afname in die je verwacht voor
+      de investeringskosten van aardwarmte. De kosten worden vergeleken met de kosten
+      van vandaag de dag.\r\n<br/><br/>\r\nDe kosten voor geothermie zijn overwegend
+      investeringskosten. Of die worden terugverdiend hangt af van het aantal draaiuren
+      van de centrale, de levensduur van de bron en hoe snel het water ondergronds
+      van de koude naar de warme put kan 'stromen'."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 248
   key: households_heater_crude_oil_share
   share_group: heating_households
@@ -1817,6 +2894,21 @@
   slide_id: 4
   position: 11
   dependent_on: has_coal_oil_for_heating_built_environment
+  description:
+    content_en: This shows what part of heating is produced by oil-fired heaters.
+      These are still quite common in many countries. Their advantage is that under
+      normal circumstances fuel oil burns slowly and completely, producing no air
+      pollutants other than CO<sub>2</sub>. A considerable disadvantage is the fact
+      that oil tanks tend to start leaking after a few decades and this can cause
+      significant pollution of soil and drinking water.
+    content_nl: Hier zie je welk deel van de verwarming door oliegestookte ketels
+      wordt ingevuld. Deze hebben als voordeel dat onder normale omstandigheden de
+      stookolie langzaam en volledig verbrandt, waardoor geen luchtvervuiling wordt
+      geproduceerd (behalve CO<sub>2</sub>). Een groot nadeel is dat de olietanks
+      na een paar decennia in de grond vaak gaan lekken en daarbij behoorlijke schade
+      kunnen doen aan het milieu of de kwaliteit van het drinkwater.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 250
   key: capacity_of_energy_power_ultra_supercritical_coal
   share_group: ''
@@ -1840,6 +2932,27 @@
   slide_id: 45
   position: 1
   dependent_on: ''
+  description:
+    content_en: "800 megawatt electric (MWe) ultra-supercritical pulverized coal-fired
+      plant. Of all types of power plants, coal and lignite-fired ones contribute
+      most to pollution of the environment. This is the most common type of modern
+      coal-fired power plant in rich countries with relatively strict regulations
+      for air pollution. Also see information in section \"Costs\". \r\n\r\n<br/><br/>\r\nA
+      coal-fired power plant is a baseload power plant, meaning it is producing at
+      maximum capacity more than 75% of the time.\r\n\r\n<br/><br/>\r\nThe input of
+      the slider (in MW) is converted to a (partial) number of the plant described
+      above."
+    content_nl: "Ultra-superkritische poederkolencentrale van 800 megawatt elektrisch
+      (MWe). Dit is de meest voorkomende kolencentrale in landen met relatief strenge
+      milieuwetgeving. Van alle typen elektriciteitsopwek geven kolen- en bruinkoolcentrales
+      wel de grootste luchtvervuiling. De CO<sub>2</sub> uitstoot van een kolencentrale
+      is ongeveer 2x zo groot als die van een gascentrale per opgewekte megawattuur
+      (MWh). Zie verder ook de informatie bij onderdeel 'Kosten'. \r\n\r\n<br/><br/>\r\nEen
+      kolencentrale is een basislast-centrale, en daarom draait hij meer dan 75% van
+      de tijd op vol vermogen.\r\n\r\n<br/><br/>\r\nDe schuifjesinstelling wordt omgezet
+      naar (deel)aantallen van de centrale zoals hierboven omschreven."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 251
   key: capacity_of_energy_power_ultra_supercritical_ccs_coal
   share_group: ''
@@ -1863,6 +2976,30 @@
   slide_id: 45
   position: 3
   dependent_on: ''
+  description:
+    content_en: "The same pulverized coal-fired plant as above. This one uses capture
+      and storage of most of the produced CO<sub>2</sub>. This technology is called
+      'Carbon Capture and Storage' (CCS). Because CCS costs energy, this power plant
+      has a lower effective production capacity than a standard coal-fired power plant.
+      To make the same amount of electricity, more fuel is burnt. <br/>\r\nThe CCS
+      plant contributes less to air pollution by CO<sub>2</sub> and other materials
+      than its non-CCS counterpart. Also see information in section 'Costs'. \r\n<br/><br/>\r\nA
+      coal-fired power plant is a baseload power plant, meaning it is producing at
+      maximum capacity more than 75% of the time.\r\n\r\n<br/><br/> \r\nThe input
+      of the slider (in MW) is converted to a (partial) number of the plant described
+      above."
+    content_nl: "Dezelfde soort kolencentrale als hierboven (Poederkolencentrale).
+      Deze past daarnaast ook afvang en opslag van de meeste geproduceerde CO<sub>2</sub>
+      toe. Deze technologie wordt 'Carbon Capture and Storage' (CCS) genoemd. Deze
+      centrale heeft niet hetzelfde productievermogen als een gewone poederkolencentrale,
+      omdat CCS energie kost. Er worden dus meer kolen verbrand om dezelfde hoeveelheid
+      stroom te maken. <br/>\r\nDe CCS centrale is minder vervuilend voor de lucht
+      dan de gewone centrale. Zie ook informatie onder 'Kosten'.  \r\n<br/><br/>\r\nEen
+      kolencentrale is een basislast-centrale, en daarom draait hij meer dan 75% van
+      de tijd op vol vermogen.\r\n\r\n<br/><br/>\r\nDe schuifjesinstelling wordt omgezet
+      naar (deel)aantallen van de centrale zoals hierboven omschreven.\r\n\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 253
   key: capacity_of_energy_power_combined_cycle_coal
   share_group: ''
@@ -1886,6 +3023,26 @@
   slide_id: 45
   position: 4
   dependent_on: ''
+  description:
+    content_en: "Integrated Gasification Combined Cycle (IGCC) plant. This is an 800
+      MWe coal gasification plant. In theory, this type of plant can also burn gasified
+      biomass and even some forms of waste. These plants are less polluting than pulverized
+      coal-fired ones. <br/>Also see information in section 'Costs'.\r\n\r\n<br/><br/>\r\nA
+      coal-fired power plant is a baseload power plant, meaning it is producing at
+      maximum capacity more than 75% of the time. Coal-gasification does make this
+      plant more flexible than its solid coal-fired counterparts.\r\n\r\n<br/><br/>
+      \r\nThe input of the slider (in MW) is converted to a (partial) number of the
+      plant described above.\r\n "
+    content_nl: "Een 800 MWe kolenvergassingscentrale. In theorie kan deze centrale
+      ook allerlei soorten biogas en sommige vormen van afval vergassen. Deze centrales
+      vervuilen minder dan poederkolencentrales en zijn bijna even efficiënt. De techniek
+      is in een vroeg commercieel stadium. <br> Zie ook informatie onder 'Kosten'.
+      \ \r\n<br/><br/>\r\nEen kolencentrale is een basislast-centrale, en daarom draait
+      hij meer dan 75% van de tijd op vol vermogen. Kolenvergassing maakt deze centrale
+      flexibeler dan de gewone kolencentrales. \r\n\r\n\r\n<br/><br/>\r\nDe schuifjesinstelling
+      wordt omgezet naar (deel)aantallen van de centrale zoals hierboven omschreven.\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 254
   key: capacity_of_energy_power_combined_cycle_ccs_coal
   share_group: ''
@@ -1909,6 +3066,26 @@
   slide_id: 45
   position: 5
   dependent_on: ''
+  description:
+    content_en: "This is the same IGCC plant as above, except that it captures and
+      stores most of the produced CO<sub>2</sub>. This is called Carbon Capture and
+      Storage (CCS). Because CCS costs energy, this power plant has a lower effective
+      production capacity than a standard IGCC power plant. To make the same amount
+      of electricity, more fuel is burnt. \r\n<br/> Also see information in section
+      'Costs'. \r\n\r\n<br/><br/> \r\n\r\nThe input of the slider (in MW) is converted
+      to a (partial) number of the plant described above."
+    content_nl: "Dit is dezelfde kolenvergassingscentrale als hierboven. Deze past
+      daarnaast ook afvang en opslag van de meeste geproduceerde CO<sub>2</sub> toe.
+      Deze technologie wordt 'Carbon Capture and Storage' (CCS) genoemd. Deze centrale
+      heeft niet hetzelfde productievermogen als een gewone kolenvergassingscentrale,
+      omdat CCS energie kost. Er worden dus meer kolen verbrand om dezelfde hoeveelheid
+      stroom te maken. <br/>\r\nDe CCS centrale is minder vervuilend voor de lucht
+      dan de gewone centrale. Zie ook informatie onder 'Kosten'. \r\n<br/><br/>\r\nEen
+      kolencentrale is een basislast-centrale, en daarom draait hij meer dan 75% van
+      de tijd op vol vermogen. \r\n\r\n<br/><br/>\r\nDe schuifjesinstelling wordt
+      omgezet naar (deel)aantallen van de centrale zoals hierboven omschreven.\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 255
   key: capacity_of_energy_power_ultra_supercritical_oxyfuel_ccs_lignite
   share_group: ''
@@ -1932,6 +3109,32 @@
   slide_id: 45
   position: 6
   dependent_on: has_lignite
+  description:
+    content_en: "800 MWe coal or lignite power plant using capture and underground
+      storage of CO<sub>2</sub>. This plant burns fuel in the presence of 100% oxygen,
+      making the fuel burn better. The exhaust fumes therefore contain higher concentrations
+      of CO<sub>2</sub>, making it cheaper to capture and store it underground. \r\nThis
+      experimental technology is called oxyfuel 'Carbon Capture and Storage' (CCS).
+      Because CCS costs energy, this power plant has a lower effective production
+      capacity than a standard coal-fired power plant. To make the same amount of
+      electricity, more fuel is burnt.\r\n<br/> Also see information in section 'Costs'.
+      \r\n\r\n<br/><br/> \r\nThe input of the slider (in MW) is converted to a (partial)
+      number of the plant described above."
+    content_nl: "800 MWe kolen- of bruinkolencentrale die daarnaast ook afvang en
+      opslag van de meeste geproduceerde CO<sub>2</sub> toepast. Deze technologie
+      wordt 'Carbon Capture and Storage' (CCS) genoemd. De centrale verbrandt kolen
+      onder 100% zuurstof en daardoor wordt het goedkoper om CO<sub>2</sub> af te
+      vangen. Deze techniek heet 'Oxyfuel Carbon Capture and Storage (CCS)'. Deze
+      centrale heeft niet hetzelfde productievermogen als een gewone kolencentrale,
+      omdat CCS energie kost. Er worden dus meer kolen verbrand om dezelfde hoeveelheid
+      stroom te maken. <br/>\r\nDe CCS centrale is minder vervuilend voor de lucht
+      dan de gewone centrale. Zie ook informatie onder 'Kosten'. \r\n<br/><br/>\r\nEen
+      kolencentrale is een basislast-centrale, en daarom draait hij meer dan 75% van
+      de tijd op vol vermogen.\r\n\r\n<br/><br/>\r\nDe schuifjesinstelling wordt omgezet
+      naar (deel)aantallen van de centrale zoals hierboven omschreven.\r\n\r\n<br/><br/>\r\n<a
+      href=\"/units\">Meer informatie over eenheden...</a>\r\n\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 256
   key: capacity_of_energy_power_ultra_supercritical_network_gas
   share_group: ''
@@ -1955,6 +3158,23 @@
   slide_id: 46
   position: 4
   dependent_on: ''
+  description:
+    content_en: "A conventional steam turbine gas-fired power plant. \r\n<br/> <br/>
+      \r\nNote: Most new gas-fired plants are combined cycle units (see below) as
+      these are more efficient.\r\n<br/> <br/> \r\nFlexible gas-fired plants are often
+      used for meeting daily electricity demand peaks and therefore produce less electricity
+      per year than coal-fired plants of the same production capacity.\r\n\r\n<br/><br/>
+      \r\nThe input of the slider (in MW) is converted to a (partial) number of the
+      plant described above."
+    content_nl: "Hier bouw je een conventionele stoomturbine gascentrale van 800 MWe.\r\n<br/>
+      <br/> \r\nDe meeste nieuwe gascentrales zijn STEG-centrales, aangezien die efficiënter
+      zijn.\r\n\r\n<br/><br/>\r\nGascentrales zijn flexibel en worden daarom vaak
+      ingezet om dagelijkse pieken in de elektriciteitsvraag op te vangen (vooral
+      gasturbines) en daarom produceren ze minder stroom per jaar dan kolencentrales
+      met een vergelijkbaar vermogen.\r\n\r\n<br/><br/>\r\nDe schuifjesinstelling
+      wordt omgezet naar (deel)aantallen van de centrale zoals hierboven omschreven.\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 257
   key: capacity_of_energy_power_combined_cycle_network_gas
   share_group: ''
@@ -1978,6 +3198,22 @@
   slide_id: 46
   position: 1
   dependent_on: ''
+  description:
+    content_en: "Here you can build Combined Cycle Gas Turbine (CCGT) power plants
+      consisting of 800 MWe. For more information, see the 'Costs' section.<br/> <br/>
+      \r\nFlexible gas-fired plants are often used for meeting daily electricity demand
+      peaks and therefore produce less electricity per year than coal-fired plants
+      of the same production capacity.\r\n\r\n<br/><br/> \r\nThe input of the slider
+      (in MW) is converted to a (partial) number of the plant described above."
+    content_nl: "Hier kun je Stoom en Gas (STEG) gascentrales bouwen van 800 MWe.
+      Voor meer informatie, zie het onderdeel 'Kosten'. <br/><br/>\r\n\r\nGascentrales
+      zijn flexibel en worden daarom vaak ingezet om dagelijkse pieken in de elektriciteitsvraag
+      op te vangen (vooral gasturbines) en daarom produceren ze minder stroom per
+      jaar dan kolencentrales met een vergelijkbaar vermogen. \r\n\r\n<br/><br/>\r\nDe
+      schuifjesinstelling wordt omgezet naar (deel)aantallen van de centrale zoals
+      hierboven omschreven."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 258
   key: capacity_of_energy_power_ultra_supercritical_crude_oil
   share_group: ''
@@ -2001,6 +3237,22 @@
   slide_id: 47
   position: 1
   dependent_on: ''
+  description:
+    content_en: "Here you can build oil plants. It is often possible to burn natural
+      gas in these plants as well. \r\n<br/><br/>\r\nIt is more profitable to refine
+      crude oil into many different products than it is to burn it directly, especially
+      since cheaper fossil fuels exist (e.g. coal). For that reason these plants are
+      relatively rare.\r\n<br/><br/> \r\nThe input of the slider (in MW) is converted
+      to a (partial) number of the plant described above.\r\n"
+    content_nl: "Hier bouw je (delen van) 800 MWe oliegestookte centrales. Vaak is
+      het ook mogelijk om gas te verbranden in deze centrales.\r\n<br/><br/>\r\nHet
+      levert meer geld op om olie te raffineren, of als transportbrandstof te gebruiken,
+      dan om het voor elektriciteitsproductie te verbranden. Bovendien zijn fossiele
+      brandstoffen als kolen goedkoper. Daarom zijn dit soort centrales nogal zeldzaam
+      in Europa.\r\n\r\n<br/><br/>\r\nDe schuifjesinstelling wordt omgezet naar (deel)aantallen
+      van de centrale zoals hierboven omschreven."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 259
   key: capacity_of_energy_power_nuclear_gen3_uranium_oxide
   share_group: ''
@@ -2024,6 +3276,37 @@
   slide_id: 48
   position: 3
   dependent_on: ''
+  description:
+    content_en: "This builds nuclear power plants of the latest type (3rd generation,
+      EPR). <br/>\r\nOf all power plants, obtaining the necessary permits and building
+      a nuclear power plant takes the longest (11-12 years on average). It is questionable
+      if it is possible to build more than a few nuclear power plants per country
+      in the coming three decades. This becomes even more evident when you factor
+      in public opinion, an imminent shortage of technicians with the required expertise
+      and a shortage of production capacity for nuclear reactor vessels on a mid-term
+      basis. <br/><br/>\r\n\r\nEnvironmental groups argue that producing nuclear fuel
+      (enriched uranium) results in CO<sub>2</sub> emissions. This is true, of course,
+      but the same can be said of coal mining and the production of steel and concrete
+      for wind turbines. For now, CO<sub>2</sub> emissions from such activities are
+      not consided.\r\n\r\n<br/><br/> \r\nThe input of the slider (in MW) is converted
+      to a (partial) number of the plant described above.\r\n<br/><br/> \r\nNuclear
+      plants are expensive to build and relatively cheap to run, so they tend to run
+      at maximum capacity as much as possible (more than 80% of the time).\r\n"
+    content_nl: "Hier bouw je kerncentrales van het meest moderne type (EPR, 3e generatie).
+      <br/>\r\nVan alle centrales, duurt het bouwen en verkrijgen van alle vergunningen
+      voor een kerncentrale het langst (gemiddeld 11-12 jaar). het is dan ook de vraag
+      of het mogelijk is om per land meer dan een paar extra kerncentrales te bouwen
+      de komende drie decennia. Vooral als je de publieke opinie, een gebrek aan geschoolde
+      technici en tekort aan productiecapaciteit van centrale-onderdelen meeneemt.\r\n<br/><br/>\r\nDe
+      bouw van kerncentrales zorgt voor CO<sub>2</sub> emissies. Datzelfde geldt voor
+      windmolens en kolencentrales. Daarom neemt het model voorlopig geen CO<sub>2</sub>
+      uitstoot mee voor centrales die geen fossiele brandstoffen verbranden.\r\n<br/><br/>\r\nDe
+      schuifjesinstelling wordt omgezet naar (deel)aantallen van de centrale zoals
+      hierboven omschreven.\r\n<br/><br/>\r\nKerncentrales zijn duur om te bouwen
+      en goedkoop om te laten draaien. Daarom draaien ze zoveel mogelijk op vol vermogen
+      (meer dan 80% van de tijd). "
+    short_content_en: ''
+    short_content_nl: ''
 - id: 260
   key: energy_mixer_for_gas_power_fuel_bio_oil_share
   share_group: energy_sector_gas
@@ -2047,6 +3330,28 @@
   slide_id: 140
   position: 4
   dependent_on: ''
+  description:
+    content_en: "This slider sets what percentage of fuel for industry CHPs is bio-oil
+      . The oil is injected into the furnace as a fine mist together with the gas.
+      In theory, it is possible to substitute 100% of the gas in this way without
+      losing efficiency. In practice, considerably less than 100% is co-fired in such
+      plants.<br/>\r\nThe sustainability of bio-oil has been in dispute for a couple
+      of years now, and its popularity has declined strongly. Future international
+      regulation of bio-oil production may mean bio-oil will be used more often.  \r\n<br/><br/>
+      \r\nAt the bottom of each page, you can see how much arable land you need world-wide
+      to grow all the required biomass.\r\n"
+    content_nl: "Met dit schuifje geef je aan hoeveel procent van de brandstof in
+      industriële WKK's bestaat uit bijgemengde bio-olie. De olie wordt verneveld
+      en ingespoten met het gas. In theorie kan zo 100% van het gas vervangen worden
+      door olie, zonder dat daarbij de efficiëntie van verbranding achteruit gaat.
+      In de praktijk zal het veel minder zijn. <br/>\r\nDe hernieuwbaarheid van veel
+      soorten bio-olie is omstreden en daarom is de populariteit sterk gedaald. Wellicht
+      dat wereldwijde regulering van bio-olieproductie daar verandering in zal brengen.
+      \r\n<br/><br/>\r\nOnderaan de pagina kun je zien wat de bio-voetafdruk is van
+      je scenario, oftewel hoeveel landbouwareaal je wereldwijd nodig hebt om alle
+      biomassa te telen."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 263
   key: capacity_of_energy_power_wind_turbine_inland
   share_group: ''
@@ -2070,6 +3375,56 @@
   slide_id: 51
   position: 1
   dependent_on: ''
+  description:
+    content_en: "This slider builds wind turbines on land. The capacity you set is
+      converted to a number of 3 MWe wind turbines.</br>\r\nWind turbines produce
+      less electricity per MWe than fossil fired plants do, because of varying wind
+      conditions (so called intermitency). Inland wind turbines produce at maximum
+      capacity around 25% of the time. \r\n<br/><br/>\r\nPower fluctuations caused
+      by varying wind conditions can destabilize the electricity grid, if wind power
+      is a substantial part of your production park. Wind also requires back-up or
+      import capacity, for windless periods. Gas-fired power plants may serve this
+      purpose, although storage in electric car batteries may also be an option. An
+      alternative for back-up capacity is making demand for power more flexible. Flexible
+      demand and storage capacity also come in handy when wind production peaks in
+      periods of low demand.\r\n<br/><br/>\r\nPlease note that the installed capacity
+      in the starting scenario may be lower than the actual installed capacity. This
+      is due to two reasons. First, the wind market is growing quite rapidly, which
+      means that a number of turbines came online somewhere during the start year
+      of the scenario, these turbines can only count for the time that they were actually
+      producing electricity. The second reason is that this slider concerns state-of-the-art
+      wind turbines, which are a lot larger and more efficient than the older wind
+      parks that are included in the actual installed capacity. Even though the installed
+      capacity may not be exactly as expected, the actual electricity production from
+      wind turbines in the start scenario is equal to that reported in the country's
+      energy statistics.\r\n<br/><br/>"
+    content_nl: "Met deze schuif bouw je op land. De ingevulde waarde wordt omgezet
+      in windmolens van 3 MWe.</br>Windmolens produceren minder stroom per MWe vermogen
+      dan kolencentrales, omdat het niet altijd even hard waait. Windmolens op land
+      produceren ~25% van de tijd op maximaal vermogen.\r\n<br/><br/>\r\nSpanningsfluctuaties
+      die veroorzaakt worden door veranderende windcondities, kunnen het elektriciteitsnet
+      instabiel maken als windmolens een substantieel deel van het productiepark vormen.
+      Wind heeft daarnaast back-up vermogen nodig voor als het niet waait. Gascentrales
+      kunnen deze rol vervullen, maar opslag van elektriciteit in de accu's van elektrische
+      auto's wordt ook als mogelijkheid genoemd. Een meer flexibele vraag naar stroom
+      is een alternatief voor back-up vermogen. Flexibele vraag en opslag komen ook
+      mooi van pas in periodes met veel wind en weinig vraag naar stroom. \r\n\r\n<br/><br/>\r\n<object
+      width=\"640\" height=\"385\"><param name=\"movie\" value=\"http://www.youtube.com/v/kmLVmhpSiTA?fs=1&amp;hl=en_US&amp;rel=0\"></param><param
+      name=\"allowFullScreen\" value=\"true\"></param><param name=\"allowscriptaccess\"
+      value=\"always\"></param><embed src=\"http://www.youtube.com/v/kmLVmhpSiTA?fs=1&amp;hl=en_US&amp;rel=0\"
+      type=\"application/x-shockwave-flash\" allowscriptaccess=\"always\" allowfullscreen=\"true\"
+      \ width=\"425\" height=\"300\"></embed></object>\r\n<br/><br/>\r\nHet geïnstalleerde
+      vermogen in het startscenario kan afwijken van het daadwerkelijk geïnstalleerd
+      vermogen in de regio waarvoor u het model invult. Dit heeft twee redenen. Allereerst
+      groeit de markt voor windturbines vrij snel. Hierdoor is er altijd een deel
+      van de windturbines pas dit jaar geïnstalleerd. Deze windturbines kunnen niet
+      het hele jaar meetellen. Daarnaast rekenen we in dit schuifje met de meest moderne
+      windturbines. Deze zijn veel groter en efficiënter dan sommige van de oude windturbines
+      die bij het geïnstalleerd vermogen zitten. Hierdoor kan het aantal windturbines
+      in het startscenario lager uitvallen. Het scenario rekent wel met de elektriciteitsproductie
+      zoals die in de nationale statistieken wordt gerapporteerd.\r\n<br/><br/>"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 264
   key: capacity_of_energy_power_wind_turbine_coastal
   share_group: ''
@@ -2093,6 +3448,54 @@
   slide_id: 51
   position: 2
   dependent_on: has_coastline
+  description:
+    content_en: "Here you choose how mucht capacity of wind turbines to build on land
+      at the coastline. The capacity you set is converted to a number of 3 MWe wind
+      turbines.\r\n<br/><br/>\r\nThese wind turbines are built on dikes or just next
+      to them in the water. Wind turbines produce less electricity per MWe than fossil-fired
+      or nuclear plants do, because of varying wind conditions. \r\nCoastal wind turbines
+      produce at maximum capacity ~27% of the time.\r\n<br/><br/>\r\nIf wind power
+      is a substantial part of your production park, power fluctuations caused by
+      varying wind conditions can destabilize the electricity grid. Wind also requires
+      back-up or import capacity, for windless periods. Gas-fired power plants may
+      serve this purpose, although storage in electric car batteries may also be an
+      option. An alternative for back-up capacity is making demand for power more
+      flexible. Flexible demand and storage capacity also come in handy when wind
+      production peaks in periods of low demand.\r\n<br/><br/>\r\nPlease note that
+      the installed capacity in the starting scenario may be lower than the actual
+      installed capacity. This is due to two reasons. First, the wind market is growing
+      quite rapidly, which means that a number of turbines came online somewhere during
+      the start year of the scenario, these turbines can only count for the time that
+      they were actually producing electricity. The second reason is that this slider
+      concerns state-of-the-art wind turbines, which are a lot larger and more efficient
+      than the older wind parks that are included in the actual installed capacity.
+      Even though the installed capacity may not be exactly as expected, the actual
+      electricity production from wind turbines in the start scenario is equal to
+      that reported in the country's energy statistics.\r\n<br/><br/>"
+    content_nl: "Met deze schuif bouw je windmolens aan de kust. De ingevulde waarde
+      wordt omgezet in windmolens van 3 MWe.<br/>\r\nDeze windmolens worden op dijken
+      of net in het water neergezet. Windmolens produceren minder stroom per MWe vermogen
+      dan kolencentrales, omdat het niet altijd even hard waait. Windmolens op land
+      produceren ~27% van de tijd op maximaal vermogen.\r\n<br/><br/>\r\nSpanningsfluctuaties
+      die veroorzaakt worden door veranderende windcondities, kunnen het elektriciteitsnet
+      instabiel maken als windmolens een substantieel deel van het productiepark vormen.
+      Wind heeft daarnaast back-up vermogen nodig voor als het niet waait. Gascentrales
+      kunnen deze rol vervullen, maar opslag van elektriciteit in de accu's van elektrische
+      auto's wordt ook als mogelijkheid genoemd. Een meer flexibele vraag naar stroom
+      is een alternatief voor back-up vermogen. Flexibele vraag en opslag komen ook
+      mooi van pas in periodes met veel wind en weinig vraag naar stroom. \r\n<br/><br/>\r\nHet
+      geïnstalleerde vermogen in het startscenario kan afwijken van het daadwerkelijk
+      geïnstalleerd vermogen in de regio waarvoor u het model invult. Dit heeft twee
+      redenen. Allereerst groeit de markt voor windturbines vrij snel. Hierdoor is
+      er altijd een deel van de windturbines pas dit jaar geïnstalleerd. Deze windturbines
+      kunnen niet het hele jaar meetellen. Daarnaast rekenen we in dit schuifje met
+      de meest moderne windturbines. Deze zijn veel groter en efficiënter dan sommige
+      van de oude windturbines die bij het geïnstalleerd vermogen zitten. Hierdoor
+      kan het aantal windturbines in het startscenario lager uitvallen. Het scenario
+      rekent wel met de elektriciteitsproductie zoals die in de nationale statistieken
+      wordt gerapporteerd.\r\n <br/><br/>"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 265
   key: capacity_of_energy_power_wind_turbine_offshore
   share_group: ''
@@ -2116,6 +3519,53 @@
   slide_id: 51
   position: 3
   dependent_on: ''
+  description:
+    content_en: "Here you choose how much capacity of wind turbines to build at sea.\r\nThe
+      capacity you set is converted to a number of 3 MWe wind turbines.\r\n<br/><br/>\r\nWind
+      turbines produce less electricity per MWe than fossil-fired or nuclear plants
+      do because of varying wind conditions. Offshore wind turbines produce at maximum
+      capacity ~40% of the time, if there is not too much need for maintenance. \r\n<br/><br/>\r\nIf
+      wind power is a substantial part of your production park, power fluctuations
+      caused by varying wind conditions can destabilize the electricity grid. Wind
+      also requires back-up or import capacity, for windless periods. Gas-fired power
+      plants may serve this purpose, although storage in electric car batteries may
+      also be an option. An alternative for back-up capacity is making demand for
+      power more flexible. Flexible demand and storage capacity also come in handy
+      when wind production peaks in periods of low demand.\r\n<br/><br/>\r\nPlease
+      note that the installed capacity in the starting scenario may be lower than
+      the actual installed capacity. This is due to two reasons. First, the wind market
+      is growing quite rapidly, which means that a number of turbines came online
+      somewhere during the start year of the scenario, these turbines can only count
+      for the time that they were actually producing electricity. The second reason
+      is that this slider concerns state-of-the-art wind turbines, which are a lot
+      larger and more efficient than the older wind parks that are included in the
+      actual installed capacity. Even though the installed capacity may not be exactly
+      as expected, the actual electricity production from wind turbines in the start
+      scenario is equal to that reported in the country's energy statistics.\r\n<br/><br/>"
+    content_nl: "Met deze schuif bouw je windmolens op zee. De ingevulde waarde wordt
+      omgezet in windmolens van 3 MWe. Windmolens produceren minder stroom per MWe
+      vermogen dan kolencentrales, omdat het niet altijd even hard waait. Windmolens
+      op land produceren ~40% van de tijd op maximaal vermogen, als er tenminste niet
+      teveel onderhoud nodig is.\r\n<br/><br/>\r\nSpanningsfluctuaties die veroorzaakt
+      worden door veranderende windcondities, kunnen het elektriciteitsnet instabiel
+      maken als windmolens een substantieel deel van het productiepark vormen. Wind
+      heeft daarnaast back-up vermogen nodig voor als het niet waait. Gascentrales
+      kunnen deze rol vervullen, maar opslag van elektriciteit in de accu's van elektrische
+      auto's wordt ook als mogelijkheid genoemd. Een meer flexibele vraag naar stroom
+      is een alternatief voor back-up vermogen. Flexibele vraag en opslag komen ook
+      mooi van pas in periodes met veel wind en weinig vraag naar stroom. \r\n<br/><br/>\r\nHet
+      geïnstalleerde vermogen in het startscenario kan afwijken van het daadwerkelijk
+      geïnstalleerd vermogen in de regio waarvoor u het model invult. Dit heeft twee
+      redenen. Allereerst groeit de markt voor windturbines vrij snel. Hierdoor is
+      er altijd een deel van de windturbines pas dit jaar geïnstalleerd. Deze windturbines
+      kunnen niet het hele jaar meetellen. Daarnaast rekenen we in dit schuifje met
+      de meest moderne windturbines. Deze zijn veel groter en efficiënter dan sommige
+      van de oude windturbines die bij het geïnstalleerd vermogen zitten. Hierdoor
+      kan het aantal windturbines in het startscenario lager uitvallen. Het scenario
+      rekent wel met de elektriciteitsproductie zoals die in de nationale statistieken
+      wordt gerapporteerd.\r\n<br/><br/>"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 266
   key: capacity_of_energy_power_hydro_river
   share_group: ''
@@ -2139,6 +3589,20 @@
   slide_id: 52
   position: 1
   dependent_on: ''
+  description:
+    content_en: This builds capacity of small run-of-the-river hydro-electric plant
+      in a large river. The slidersetting is converted to relatively small plants
+      (with production capacity ~10 MWe). The limited slope causes the small capacity.
+      The total production potential for any country tends to be limited, therefore.
+      Still, because of their relatively long life and reliability, these plants are
+      an interesting option.
+    content_nl: "Met deze schuif bouw je een kleine waterkrachtcentrale in een grote
+      rivier. \r\nDe instelling wordt omgezet in centrales met een relatief klein
+      vermogen (~10 MWe). Dit vermogen is laag door het geringe verval in een rivier.
+      Het totale productiepotentieel is dan ook beperkt. Toch zijn deze centrales
+      niet onaantrekkelijk vanwege hun relatief lange levensduur en de betrouwbaarheid. "
+    short_content_en: ''
+    short_content_nl: ''
 - id: 267
   key: capacity_of_energy_power_hydro_mountain
   share_group: ''
@@ -2162,6 +3626,25 @@
   slide_id: 52
   position: 2
   dependent_on: has_mountains
+  description:
+    content_en: This builds large hydro-electric power plants in mountain reservoir.
+      The slidersetting is converted to (parts of) plants of 500 MWe. These plants
+      require huge investments and flooding valleys can have a strongly negative environmental
+      impact. These plants can often be significantly bigger than 500 MWe and they
+      can be built as pumped-storage plants, using surplus electricity to pump water
+      from a lower reservoir to a higher one. Because of their relatively long life
+      and their ability to follow electricity demand, these plants are an interesting
+      option.
+    content_nl: 'Hiermee bouw je grote waterkrachtcentrales met een stuwmeer in de
+      bergen. De instelling wordt omgezet in (delen van) centrales van 500 MWe. Deze
+      centrales vergen grote investeringen en het onder water zetten van dalen kan
+      een zeer negatieve uitwerking hebben op het milieu. Vaak zijn dit soort centrales
+      groter dan 500 MWe en worden ze zo gebouwd dat overtollige elektriciteit kan
+      worden opgeslagen door water naar het stuwmeer toe te pompen. Omdat deze centrales
+      relatief lang leven en ideaal zijn om pieken en dalen in de stroomvraag te volgen,
+      kunnen deze centrales erg aantrekkelijk zijn. '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 270
   key: capacity_of_energy_power_geothermal
   share_group: ''
@@ -2185,6 +3668,19 @@
   slide_id: 53
   position: 1
   dependent_on: ''
+  description:
+    content_en: "This builds electric power plants. Electricity is generated using
+      heat from more than 3 km underground. \r\n<br/><br/>\r\nGenerating electricity
+      requires much higher temperatures than geothermal heat for used in buildings
+      or greenhouses. Whether it is an attractive option is partly determined by how
+      far underground these high temperatures are found."
+    content_nl: "Hiermee bouw elektriciteitscentrales op aardwarmte. Met warmte van
+      meer dan 3 km diep wordt stroom opgewekt.\r\n<br/><br/>\r\nHet opwekken van
+      stroom vereist hogere temperaturen dan het verwarmen van gebouwen en broeikassen.
+      Of het nu een aantrekkelijke optie is, wordt deels bepaald door hoe diep ondergronds
+      het water zich bevindt, met temperaturen die hoog genoeg zijn."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 271
   key: capacity_of_energy_power_supercritical_waste_mix
   share_group: ''
@@ -2208,6 +3704,25 @@
   slide_id: 55
   position: 1
   dependent_on: ''
+  description:
+    content_en: "This builds high energy yield waste-incineration plants. The slidersetting
+      is converted to (a part of) of 55 MWe plants. Waste that can be safely burnt
+      is used to generate electricity. By incinerating waste under the right conditions,
+      it can be processed in a relatively clean way. Rotting or decomposing waste
+      produces strong greenhouse gasses, so incineration is often preferable from
+      an environmental point of view.<br/><br/>\r\nThe maximum potential for these
+      power plants is limited by available domestic waste. We assume no waste will
+      be imported."
+    content_nl: "Hiermee bouw je hoogrendment afvalverbrandingscentrale. De instelling
+      wordt omgezet in (delen van) centrales van 55 MWe. Brandbaar afval (huishoudelijk-
+      en sloop-afval) wordt gebruikt om elektriciteit op te wekken. Door het onder
+      de juiste omstandigheden te verbranden, kan afval op een relatief schone manier
+      verwerkt worden. Rottend afval produceert methaan, een sterker broeikasgas dan
+      CO<sub>2</sub>, daarom is verbranden vaak beter. <br/><br/>\r\nHet model importeert
+      geen afval, dus de beschikbare hoeveelheid afval bepaalt het potentieel voor
+      deze technologie."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 276
   key: capacity_of_energy_chp_combined_cycle_network_gas
   share_group: ''
@@ -2231,6 +3746,25 @@
   slide_id: 46
   position: 5
   dependent_on: ''
+  description:
+    content_en: "This builds a Combined Heat and Power (CHP) unit (~120 MWe and ~120
+      MWth) that runs on gas. The power generated is shown in the graph on the right
+      as 'gas-fired' power production. The heat produced is supplied to the central
+      heating grid.\r\n<br/><br/>\r\nThis large facility typically supplies a large
+      city heating grid and combines a gas turbine with a steam turbine. The CHP is
+      partly used to supply heat to the grid and partly driven by electricity prices.
+      It supplies electricity for ~6000 hours per year and heat for ~4500 hours per
+      year."
+    content_nl: "Hiermee bouw je een grote warmte-kracht koppeling (WKK's) (~120 MWe
+      and ~120 MWth) op gas. De stroom die de grote WKK's produceren staat in de grafiek
+      hiernaast als stroom uit 'Gas'. \r\n<br/><br/>\r\nDeze grote WKK levert typisch
+      aan een groot stadswarmtenet en bestaat uit een gasturbine met afgasketel en
+      stoomturbine. De WKK zal deels ingezet worden voor warmteproductie aan het stadswarmtenet
+      (4500 uren/jaar) en deels gestuurd worden door de elektriciteitsprijs (6000
+      uren/jaar e-productie). Een installatie van vergelijkbare grootte staat bijvoorbeeld
+      in Rotterdam (RoCa)."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 292
   key: transport_road_mixer_diesel_diesel_share
   share_group: transport_diesel
@@ -2254,6 +3788,16 @@
   slide_id: 156
   position: 1
   dependent_on:
+  description:
+    content_en: Diesel has a higher energy content than gasoline, and diesel engines
+      tend to be more energy efficient than gasoline engines. Due to emissions of
+      fine particulate matter, filters are becoming mandatory in most parts of the
+      world.
+    content_nl: Diesel heeft een hogere energie-inhoud dan benzine, en dieselmotoren
+      zijn vaak efficiënter dan benzinemotoren. Wel stoten dieselvoertuigen meer fijnstof
+      uit en daarom worden in veel delen van de wereld roetfilters verplicht gesteld.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 293
   key: transport_road_mixer_diesel_biodiesel_share
   share_group: transport_diesel
@@ -2277,6 +3821,30 @@
   slide_id: 156
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Biodiesel can be made from a range of vegetable or animals fats.
+      Seed oils are particularly popular. Diesel produced from algae has captured
+      people's imagination, since growing crops for biodiesel often still competes
+      for space with growing food. So far, it accounts for only a small percentage
+      of the total production of bio-diesel.\r\n<br/><br/>\r\nEngines can run on bio-diesel
+      without modifications, but the vegetable-based diesels tend to be rather corrosive
+      to the engine.\r\n<br/><br/>\r\nSee the <a href=\"https://github.com/quintel/etdataset-public/tree/master/carriers_source_analyses\">documentation
+      on GitHub</a> for more information on the numbers used.\r\n"
+    content_nl: "Biodiesel kun je maken van verschillende plantaardige en dierlijke
+      vetten. Vooral zaadoliën zijn erg populair. Tegenwoordig is men nogal gecharmeerd
+      door diesel uit algen, omdat daarvoor geen landbouwgrond hoeft te worden opgegeven.
+      Op dit moment is algen-diesel maar een klein deel van de totale bio-diesel productie.
+      \r\n<br/><br/>\r\nMotoren kunnen bio-diesel verbranden zonder anders afgesteld
+      te worden, maar de plantaardige varianten zijn wel vrij corrosief voor de motor.
+      \r\n<br/><br/>\r\nZie onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/carriers_source_analyses\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen.\r\n<br/><br/>\r\n<object
+      width=\"640\" height=\"385\"><param name=\"movie\" value=\"http://www.youtube.com/v/Rt8G0bujc-A?fs=1&amp;hl=en_US&amp;rel=0\"></param><param
+      name=\"allowFullScreen\" value=\"true\"></param><param name=\"allowscriptaccess\"
+      value=\"always\"></param><embed src=\"http://www.youtube.com/v/Rt8G0bujc-A?fs=1&amp;hl=en_US&amp;rel=0\"
+      type=\"application/x-shockwave-flash\" allowscriptaccess=\"always\" allowfullscreen=\"true\"
+      width=\"425\" height=\"300\"></embed></object>"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 294
   key: transport_road_mixer_gasoline_gasoline_share
   share_group: transport_gasoline
@@ -2300,6 +3868,15 @@
   slide_id: 156
   position: 3
   dependent_on:
+  description:
+    content_en: Gasoline started out as a refinery waste product! Nowadays it is the
+      most common fuel for cars, even though it is neither particularly clean, nor
+      very efficient.
+    content_nl: Ooit was benzine een afvalproduct van het raffinageproces! Nu is het
+      nog net de meest gebruikte brandstof voor personenauto's, terwijl de motoren
+      relatief eigenlijk noch zeer schoon, noch zeer efficiënt zijn.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 295
   key: transport_road_mixer_gasoline_ethanol_share
   share_group: transport_gasoline
@@ -2323,6 +3900,25 @@
   slide_id: 156
   position: 4
   dependent_on: ''
+  description:
+    content_en: "Bio-ethanol is a partial replacement for gasoline. Engines can run
+      on bio-ethanol without needing re-tuning if not too much bio-ethanol is mixed
+      with gasoline. High percentages of bio-ethanol require minor modifications to
+      engines in order to retain efficiency.\r\n<br/><br/>\r\nSee the <a href=\"https://github.com/quintel/etdataset-public/tree/master/carriers_source_analyses\">documentation
+      on GitHub</a> for more information on the numbers used."
+    content_nl: "Bio-ethanol kan gebruikt worden om een deel van het benzinegebruik
+      te vervangen. Motoren kunnen het verbranden zonder dat ze anders afgesteld hoeven
+      worden, mits het aandeel in het brandstofmengsel niet al te hoog is. Als bio-ethanol
+      het hoofdbestanddeel van de brandstof wordt, moet de motor anders worden afgesteld,
+      om even efficiënt te blijven.\r\n<br/><br/>\r\nZie onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/carriers_source_analyses\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen.\r\n<br/><br/>\r\n<object
+      width=\"640\" height=\"385\"><param name=\"movie\" value=\"http://www.youtube.com/v/FO0q0hb0QuA?fs=1&amp;hl=en_US&amp;rel=0\"></param><param
+      name=\"allowFullScreen\" value=\"true\"></param><param name=\"allowscriptaccess\"
+      value=\"always\"></param><embed src=\"http://www.youtube.com/v/FO0q0hb0QuA?fs=1&amp;hl=en_US&amp;rel=0\"
+      type=\"application/x-shockwave-flash\" allowscriptaccess=\"always\" allowfullscreen=\"true\"
+      width=\"425\" height=\"300\"></embed></object>"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 298
   key: capacity_of_energy_power_solar_pv_solar_radiation
   share_group: ''
@@ -2346,6 +3942,24 @@
   slide_id: 54
   position: 1
   dependent_on: ''
+  description:
+    content_en: "This builds centralized plants of photovoltaic solar power panels.
+      These are not mounted on roofs, but are usually placed in a field.<br/><br/>\r\nSince
+      Northern Europe receives relatively little sun, solar power is still much more
+      expensive than other renewable technologies. Like wind power, solar power output
+      fluctuates over time, but in a more predictable way, making it easier to keep
+      the electricity grid in balance. Still, the impact of installing large numbers
+      of solar panels can be large, because electricity is fed back into the local
+      grid. This may require balancing solutions at the local level for the grid."
+    content_nl: "Hiermee bouw je een centrale van zonnepanelen. Deze panelen zijn
+      in een veld opgesteld, of maken gebruik van daken van zeer grote gebouwen. <br/>\r\nIn
+      Noord Europa is zonnestroom nog veel duurder dan wind bijvoorbeeld, doordat
+      er relatief weinig zonuren zijn. Net als windstroom, is zonnestroom fluctuerend.
+      Toch is de variatie van zonnestroom beter te voorspellen. Als zeer veel zonnepanelen
+      geïnstalleerd worden, kan het nodig zijn om oplossingen te vinden voor onbalans
+      op het laagspanningsnet.\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 299
   key: capacity_of_energy_power_solar_csp_solar_radiation
   share_group: ''
@@ -2369,6 +3983,38 @@
   slide_id: 54
   position: 2
   dependent_on: has_solar_csp
+  description:
+    content_en: "This builds a 50 MWe concentrated solar power (CSP) plant with heat
+      storage. Such a plant is very attractive in sunny desert-like areas, but less
+      so in Northern Europe. It needs direct sunlight, which is concentrated by concave
+      mirrors to produce heat and generate electricity. A plan called 'Desertec' has
+      been launched to build a huge number of CSP plants in northern Africa and the
+      Middle East, which are to export a lot of their power to Europe. This requires
+      vast investments in infrastructure, but could potentially supply a huge amount
+      of power. \r\n\r\n<br/><br/>\r\nThis type of plant stores the heat, allowing
+      it to keep on producing electricity until several hours after sundown.\r\n\r\n<br/><br/>
+      \r\n<a href=\"/units\">More information on units...</a>\r\n\r\n<br/><br/> \r\n<object
+      style=\"height: 344px; width: 425px\"><param name=\"movie\" value=\"http://www.youtube.com/v/QXURvISjh2A\"><param
+      name=\"allowFullScreen\" value=\"true\"><param name=\"allowScriptAccess\" value=\"always\"><embed
+      src=\"http://www.youtube.com/v/QXURvISjh2A\" type=\"application/x-shockwave-flash\"
+      allowfullscreen=\"true\" allowScriptAccess=\"always\" width=\"425\" height=\"300\"></object>"
+    content_nl: "Hiermee bouw je 50 MWe geconcentreerde zonnewarmte centrales (Concentrated
+      Solar Power, oftewel CSP). \r\nCSP centrales maken elektriciteit door de warmte
+      van de zon te focusseren met holle spiegels. Zonnige, woestijnachtige delen
+      van de wereld zijn dus bij uitstek geschikt, maar Noordwest Europa absoluut
+      niet. Er bestaat een plan (genaamd Desertec) om CSP centrales te bouwen in Noord
+      Afrika en het Midden Oosten, om een deel van de stroom van daar naar Europa
+      te transporteren. Hiervoor zijn gigantische investeringen nodig in infrastructuur,
+      maar het potentieel is ook zeer groot.<br/><br/>\r\n\r\nZonnewarmte kan worden
+      opgeslagen (door zout te smelten bijvoorbeeld) en dus kunnen deze centrales
+      zonodig ook een deel van de nacht nog stroom maken.\r\n\r\n<br/><br/>\r\n<a
+      href=\"/units\">Meer informatie over eenheden...</a>\r\n\r\n<br/><br/>\r\n<object
+      style=\"height: 344px; width: 425px\"><param name=\"movie\" value=\"http://www.youtube.com/v/QXURvISjh2A\"><param
+      name=\"allowFullScreen\" value=\"true\"><param name=\"allowScriptAccess\" value=\"always\"><embed
+      src=\"http://www.youtube.com/v/QXURvISjh2A\" type=\"application/x-shockwave-flash\"
+      allowfullscreen=\"true\" allowScriptAccess=\"always\" width=\"425\" height=\"300\"></object>"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 315
   key: capacity_of_energy_power_supercritical_coal
   share_group: ''
@@ -2392,6 +4038,22 @@
   slide_id: 45
   position: 7
   dependent_on: ''
+  description:
+    content_en: "Here you can build conventional coal-fired plants of 800 MWe. These
+      plants are not built anymore in rich countries, due to environmental restrictions.
+      The power generated is shown in the graph on the right as coal-fired electricity
+      production.\r\n<br/><br/>\r\nA coal-fired power plant is a baseload power plant,
+      meaning it is producing at maximum capacity more than 75% of the time.\r\n\r\n<br/><br/>
+      \r\nThe input of the slider (in MW) is converted to a (partial) number of the
+      plant described above."
+    content_nl: "Hier kun je ouderwetse kolencentrales bouwen van 800 MWe. Deze centrales
+      worden in rijke landen niet meer gebouwd, vanwege milieuwetgeving. De stroom
+      die wordt opgewekt staat in de grafiek rechts als kolenstroom.\r\n<br/><br/>\r\nEen
+      kolencentrale is een basislast-centrale, en daarom draait hij meer dan 75% van
+      de tijd op vol vermogen.\r\n\r\n<br/><br/>\r\nDe schuifjesinstelling wordt omgezet
+      naar (deel)aantallen van de centrale zoals hierboven omschreven.\r\n\r\n "
+    short_content_en: ''
+    short_content_nl: ''
 - id: 316
   key: capacity_of_energy_power_ultra_supercritical_lignite
   share_group: ''
@@ -2415,6 +4077,23 @@
   slide_id: 45
   position: 8
   dependent_on: has_lignite
+  description:
+    content_en: "Here you can build coal lignite-fired plants of 800 MWe. These plants
+      can only be built if there is a local supply of lignite (brown coal). This is
+      the most polluting kind of power plant.The power generated is shown in the graph
+      on the right as coal-fired electricity production.\r\n<br/><br/>\r\nA coal-fired
+      power plant is a baseload power plant, meaning it is producing at maximum capacity
+      more than 75% of the time.\r\n\r\n<br/><br/> \r\nThe input of the slider (in
+      MW) is converted to a (partial) number of the plant described above."
+    content_nl: "Hier kun je bruinkoolcentrales bouwen van 800 MWe. Deze centrales
+      kunnen alleen gebouwd worden als er een lokale bruinkoolvoorraad beschikbaar
+      is. Dit is de meest vervuilende soort van elektriciteitscentrale. De stroom
+      die wordt opgewekt staat in de grafiek als kolenstroom. \r\n<br/><br/>\r\nEen
+      kolencentrale is een basislast-centrale, en daarom draait hij meer dan 75% van
+      de tijd op vol vermogen.\r\n\r\n<br/><br/>\r\nDe schuifjesinstelling wordt omgezet
+      naar (deel)aantallen van de centrale zoals hierboven omschreven."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 321
   key: capacity_of_other_chp_engine_network_gas
   share_group: ''
@@ -2441,6 +4120,24 @@
   slide_id: 102
   position: 1
   dependent_on: ''
+  description:
+    content_en: "Small Combined heat and power (CHP) engines like these (~2 MWe and
+      ~2 MWth) are gas-fired engines that generate both heat and electricity. The
+      combination of heat and electricity makes this option quite energy efficient.
+      Also, locally producing and using heat and electricity reduces transportation
+      losses and saves energy. CHPs are primarily used at sites with a predictable
+      demand for heat.\r\n<br/><br/>\r\nA gas-fired CHP uses more natural gas to make
+      heat than a good gas-fired boiler, and is only attractive if the electricity
+      is used or can be sold over the grid.\r\n"
+    content_nl: "Kleine warmtekrachtkoppelingen (WKK’s) als deze (~2 MWe and ~2 MWth)
+      maken warmte en elektriciteit. Deze combinatie maakt WKK's vrij energie-efficiënt.
+      Lokaal produceren en gebruiken van warmte en elektriciteit vermijdt transportverliezen
+      en dat bespaart weer energie. WKK's worden vooral gebouwd op locaties met een
+      voorspelbare warmtevraag.\r\n<br/<br/>\r\nEen gas-WKK gebruikt meer aardgas
+      om warmte te maken, dan een HR CV-ketel. Daarom is deze optie pas aantrekkelijk
+      als de elektriciteit kan worden benut of kan worden verkocht over het net."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 322
   key: capacity_of_industry_chp_combined_cycle_gas_power_fuelmix
   share_group: ''
@@ -2467,6 +4164,27 @@
   slide_id: 44
   position: 1
   dependent_on: ''
+  description:
+    content_en: "Combined heat and power (CHP) engines are (mostly) gas-fired engines
+      that generate both heat and electricity. The combination of heat and electricity
+      makes this option quite energy efficient. Also, locally producing and using
+      heat and electricity reduces transportation losses and saves energy. CHPs are
+      primarily used at sites with a predictable demand for heat, such as chemical
+      factories for example.\r\n<br/><br/>\r\nThis plant combines a gas turbine with
+      a steam turbine and is located on a typical large-sized industrial park. It
+      typically supplies several customers and is runs 8000 hours a year, of which
+      6000 hours to supply heat as steam.  "
+    content_nl: "Warmtekrachtkoppelingen (WKK’s) maken warmte en elektriciteit. Deze
+      combinatie maakt WKK's vrij energie-efficiënt. Lokaal produceren en gebruiken
+      van warmte en elektriciteit vermijdt transportverliezen en dat bespaart weer
+      energie. WKK's worden vooral gebouwd op locaties met een voorspelbare warmtevraag,
+      zoals bijvoorbeeld chemische fabrieken.\r\n<br/><br/>\r\nDeze installatie is
+      een combinatie van een gasturbine met afgasketel en stoomturbine. Op de grotere
+      industriële parken wordt centraal elektriciteit en stoom opgewekt en geleverd
+      aan de bedrijven op het park. Deze installatie draait 8000 uur per jaar, waarvan
+      6000 vollasturen warmte (stoomlevering).\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 327
   key: agriculture_final_demand_steam_hot_water_share
   share_group: agri_heat
@@ -2492,6 +4210,17 @@
   slide_id: 31
   position: 6
   dependent_on: ''
+  description:
+    content_en: District heating is heat supplied by a heat network. The heat can
+      be produced by local heat plants / large-scale burners or the heat can be imported
+      from outside your region. You can set the heat sources in the Supply-section
+      under the header <a href="/scenario/supply/heat" >"Heat networks"</a>.
+    content_nl: Warmte uit een warmtenet kan geproduceerd worden door lokale warmtecentrales
+      / grootschalige warmteketels óf de warmte kan worden geïmporteerd van buiten
+      jouw gebied. Kies de warmtebronnen in het Aanbod-gedeelte onder het kopje <a
+      href="/scenario/supply/heat" >"Warmtenetten"</a>.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 333
   key: households_heater_combined_network_gas_share
   share_group: heating_households
@@ -2515,6 +4244,23 @@
   slide_id: 4
   position: 1
   dependent_on: ''
+  description:
+    content_en: "This is a condensing gas-fired heater for a central heating system.
+      These systems are quite energy efficient, but not the most efficient heaters
+      use gas. To see which are more efficient, try some sliders below.<br/>\r\nThese
+      boilers also produce hot water for showering and other uses. Hot water production
+      is slightly less efficient than producing heat for the central heating system.<br/>\r\nThese
+      boilers emit CO<sub>2</sub>. The latter is a problem if you wish to reduce emissions
+      significantly."
+    content_nl: "Dit zijn gasgestookte HR-ketels. Dit zijn zeer efficiënte systemen,
+      maar er zijn efficiëntere manieren om met  gas te verwarmen. Om te zien welke
+      systemen efficiënter zijn, kun je enkele schuifjes hieronder instellen. \r\n<br/>\r\nHR
+      combiketels maken ook warm water om te douchen enz. Warmwaterproductie is iets
+      minder efficiënt dan de productie van warmte voor het CV-systeem.<br/>\r\nDeze
+      ketels stoten CO<sub>2</sub> uit. Dat kan een probleem zijn als je hele grote
+      reducties van broeikasgasemissies wilt halen."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 335
   key: households_number_of_inhabitants
   share_group: ''
@@ -2538,6 +4284,16 @@
   slide_id: 171
   position: 0
   dependent_on: ''
+  description:
+    content_en: How do you expect the population to grow? Apart from increasing prosperity,
+      this is one of the most important drivers for the energy demand growth.
+    content_nl: "Hoe verwacht je dat de bevolking zich gaat ontwikkelen? Naast welvaartsgroei
+      is dit een van de belangrijkste factoren die de energievraag beïnvloeden.\r\n\r\n<br/><br/>\r\n\r\nNederland
+      telt bijvoorbeeld circa 16.5 miljoen inwoners. Het bevolkingsaantal zal volgens
+      het Centraal Bureau voor de Statistiek (CBS) toenemen tot 17.7 miljoen in het
+      jaar 2040. Daarna zet een afname in."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 338
   key: households_heater_heatpump_ground_water_electricity_share
   share_group: heating_households
@@ -2561,6 +4317,30 @@
   slide_id: 4
   position: 4
   dependent_on: ''
+  description:
+    content_en: "A heat pump moves heat from one place to another. Heat pumps are
+      used in refrigerators, but buildings can use them for heating and cooling. This
+      saves energy compared to a gas-fired central heating boiler, for example. For
+      optimal application, it does often require installation of under-floor and wall
+      heating instead of radiators. Currently, their use in newly constructed houses
+      is becoming quite popular, since European legislation dictates that domestic
+      energy consumption must decrease.\r\n<br/><br/>\r\nHeat pumps can run on gas
+      or electricity. This is an electric heat pump, as it draws its heat from the
+      ground. Gas-fired heat pumps are more often used to draw their heat from the
+      air.\r\n<br/>"
+    content_nl: "Een warmtepomp is een apparaat dat warmte verplaatst. De meest bekende
+      toepassing is een koelkast, maar in een gebouw kan een warmtepomp ook zorgen
+      voor verwarming en koeling. Dat kost minder energie dan gasverwarming met een
+      HR CV-ketel, maar het werkt vaak alleen als vloer- en muurverwarming worden
+      geïnstalleerd, in plaats van radiatoren. Nu worden warmtepompen daarom vooral
+      nog ingezet bij nieuwbouw van huizen. Europese wetgeving schrijft namelijk voor
+      dat het energiegebruik van huizen per 2020 tot nul moet zijn toegebracht (gemeten
+      over een heel jaar). \r\n<br/><br/>\r\nJe spaart energie, maar er is wel extra
+      elektriciteit of gas nodig voor de warmtepomp. Deze warmtepomp gebruikt elektriciteit,
+      omdat de warmte uit de grond gehaald wordt. Een gaswarmtepomp wordt vaker toegepast
+      als warmte uit de lucht wordt gehaald. <br/>"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 340
   key: households_heater_wood_pellets_share
   share_group: heating_households
@@ -2584,6 +4364,21 @@
   slide_id: 4
   position: 8
   dependent_on: ''
+  description:
+    content_en: "This is a wood pellet-fired stove. These are quite efficient and
+      fully automated in that they draw their fuel from an attached silo. \r\n<br/><br/>\r\nIt
+      is assumed the biomass used has been produced sustainably. Still, transporting
+      biomass consumes fuel and the smaller the scale at which it is used, the less
+      'green' this option becomes.\r\n<br/><br/>\r\nConventional stoves or fireplaces
+      have not been included separately."
+    content_nl: "Dit is een kachel die kleine houtpellets verbrandt. Deze ketels zijn
+      vrij efficiënt en geheel geautomatiseerd. De pellets worden automatisch uit
+      een silo gehaald. \r\n<br/><br/>\r\nHier is aangenomen dat de pellets hernieuwbaar
+      zijn geproduceerd. Het transport van biomassa kost brandstof en hoe kleiner
+      de schaal waarop het wordt toegepast, hoe minder 'groen' het wordt.\r\n<br/><br/>\r\nOuderwetse
+      houtkachels en open haarden zijn niet als aparte opties in het model opgenomen."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 341
   key: households_heat_network_connection_steam_hot_water_share
   share_group: households_district_heating
@@ -2607,6 +4402,23 @@
   slide_id:
   position: 8
   dependent_on: ''
+  description:
+    content_en: Heat for district heating can be produced by local burners, but also
+      by large-scale heat plants. You can choose to build large-scale plants in a
+      the <a href="/scenario/supply/fossil_heat/fossil-fired-heaters" >fossil heat</a>
+      and <a href="/scenario/supply/renewable_heat/biomass" >renewable heat</a> slides
+      in the supply section. You can also choose to use waste heat from power plants
+      and waste CHPs (see the <a href="/scenario/supply/electricity/coal-plants" >electricity
+      production</a> slide).
+    content_nl: Warmte uit een warmtenet kan geproduceerd worden door lokale warmteketels,
+      maar kan ook komen van grootschalige  een grootschalige centrales. Bij <a href="/scenario/supply/fossil_heat/fossil-fired-heaters"
+      >'fossiele warmte'</a> en <a href="/scenario/supply/renewable_heat/biomass"
+      >'hernieuwbare warmte'</a> in de Aanbodsectie kun je hiervoor een aantal opties
+      kiezen. Ook kun je gebruik maken van restwarmte van elektriciteitscentrales
+      en afvalverbranders (zie de slide <a href="/scenario/supply/electricity/coal-plants"
+      >'Elektriciteit'</a>).
+    short_content_en: ''
+    short_content_nl: ''
 - id: 348
   key: households_water_heater_solar_thermal_share
   share_group: ''
@@ -2630,6 +4442,20 @@
   slide_id: 5
   position: 2
   dependent_on: ''
+  description:
+    content_en: 'Solar water heaters (SWH) use solar thermal panels to produce warm
+      water using heat from the sun. This heat can be used to heat shower or do the
+      dishes, for example. SWHs are installed on rooftops or in asphalt for parking
+      lots, for example. A SWH is often combined with a gas-fired central heating
+      boiler that heats water further if necessary (especially in winter). It can
+      also be combined with a heat pump. '
+    content_nl: "Een zonneboiler maakt warm water via zonthermische panelen. Deze
+      warmte kan gebruikt worden om te douchen, af te wassen enz. Zonneboilers worden
+      vaak op daken of in het asfalt van parkeerterreinen geplaatst. Een zonneboiler
+      wordt vaak met een gas CV-ketel gecombineerd om het water (in de winter) verder
+      op te warmen. Ook met een warmtepomp gaat het goed samen.\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 351
   key: households_cooling_heatpump_ground_water_electricity_share
   share_group: cooling_households
@@ -2653,6 +4479,40 @@
   slide_id: 108
   position: 1
   dependent_on: ''
+  description:
+    content_en: "A heat pump moves heat from one place to another. Heat pumps are
+      used in refrigerators, but buildings can use them for heating and cooling. For
+      optimal application, it does often require installation of under-floor and wall
+      heating instead of radiators. Currently, their use in newly constructed houses
+      is becoming quite popular, since European legislation dictates that domestic
+      energy consumption must decrease.\r\n<br/><br/>\r\nThis heat pump uses a ground
+      source on one side and a wall or floor delivery system on the other. Not all
+      residences are suitable for using a heat pump as they cannot all be fitted with
+      wall or floor delivery systems at acceptable costs. Considering the high investment
+      costs for such delivery systems, it is realistic to assume that no more than
+      ~20% of all residences could be equipped with such a heat pump. For the other
+      80%, the costs would probably outweigh the benefits.\r\n<br/><br/>\r\nNote that
+      for heat pump shares above 20%, the ETM will considerably underestimate the
+      associated investment costs. This is caused by the fact that the additional
+      investment costs are unknown for installation in residences that would normally
+      not qualify."
+    content_nl: "Een warmtepomp is een apparaat dat warmte verplaatst. De meest bekende
+      toepassing is een koelkast, maar in een gebouw kan een warmtepomp ook zorgen
+      voor verwarming en koeling. Het werkt vaak alleen als vloer- en muurverwarming
+      worden geïnstalleerd, in plaats van radiatoren. Nu worden warmtepompen daarom
+      vooral nog ingezet bij nieuwbouw van huizen. Europese wetgeving schrijft namelijk
+      voor dat het energiegebruik van huizen per 2020 tot nul moet zijn toegebracht
+      (gemeten over een heel jaar). \r\n<br/><br/>\r\nDeze warmtepomp gebruikt een
+      grondbron aan de ene kant en muur- of vloer- verwarming/koeling aan de andere.
+      Omdat dit niet in alle huizen te realiseren is tegen acceptabele investeringskosten,
+      is een realistische schatting van het aantal huizen waarin een warmtepomp kan
+      worden geïnstalleerd 20%. In de overige 80% wegen de kosten waarschijnlijk niet
+      op tegen de baten.\r\n<br><br/>\r\nLet er op dat het ETM de investeringskosten
+      significant onderschat voor een aandeel van warmtepompen van boven de 20%. Dit
+      komt omdat de extra investeringskosten voor huizen die eigenlijk niet geschikt
+      zijn voor installatie van een warmtepomp, niet bekend zijn."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 353
   key: households_cooling_airconditioning_electricity_share
   share_group: cooling_households
@@ -2676,6 +4536,15 @@
   slide_id: 108
   position: 4
   dependent_on: ''
+  description:
+    content_en: This indicates the extent to which air conditioning is used to cool
+      houses and apartments. Currently, in most countries cooling is provided mainly
+      by air conditioning.
+    content_nl: "Hier staat aangegeven hoeveel van de koeling van huizen en appartementen
+      met airconditioners gebeurd. In de meeste landen gebeurt de meeste koeling op
+      dit moment gebeurt nog met airconditioners.\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 354
   key: households_cooker_network_gas_share
   share_group: cooking
@@ -2699,6 +4568,27 @@
   slide_id: 109
   position: 1
   dependent_on:
+  description:
+    content_en: "Gas cooking is popular in countries where there is an abundance of
+      natural gas and a gas distribution network. The efficiency of a gas stove is
+      40% and is lower than the electric alternatives since a lot of heat is lost
+      to the environment. Although electric cooking may therefore appear more efficient,
+      it is important to take the entire 'well-to-potato' chain into account, meaning
+      that in some cases gas cooking might be advantageous. Electricity production
+      in power plants also leads to losses.\r\n<br/><br/>\r\nOnly the costs due to
+      the difference in energy demand are considered. The costs of the stove are not
+      taken into account in the Energy Transition Model."
+    content_nl: "Koken op gas is populair in landen waar er een overvloed van aardgas
+      is en een gasdistributienet aanwezig is. De efficiëntie van een gasfornuis is
+      40%. Omdat veel warmte naar de omgeving verloren gaat, zijn gasfornuizen minder
+      efficiënt dan elektrische uitvoeringen. Hoewel elektrisch koken dus efficiënter
+      lijkt, is dit niet altijd het geval omdat de hele keten meegenomen moet worden.
+      \ Door verliezen in elektriciteitsproductie en -transport kan het zijn dat gaskoken
+      uiteindelijk voordeliger is.\r\n<br/><br/>\r\nUitsluitend de kosten door het
+      verschil in energievraag worden meegenomen. De kosten van het kooktoestel zelf
+      worden niet meegenomen in het Energietransitiemodel.\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 355
   key: households_cooker_resistive_electricity_share
   share_group: cooking
@@ -2722,6 +4612,25 @@
   slide_id: 109
   position: 2
   dependent_on:
+  description:
+    content_en: "Electric cookers are a popular in urban and suburban areas where
+      there is no access to a natural gas network. Electric stoves use resistive heating
+      coils to produce heat and have an efficiency of approximately 55% (excluding
+      electricity production and transport losses). \r\n<br/>\r\nThe disadvantage
+      of electric stoves is the time required to warm the stove and the inability
+      to quickly change the cooking temperature.\r\n<br/><br/>\r\nOnly the costs due
+      to the difference in energy demand are considered. The costs of the stove are
+      not taken into account in the Energy Transition Model."
+    content_nl: "Elektrische fornuizen zijn populair in dichtbevolkte regio's en waar
+      er geen toegang is tot een aardgasnetwerk. Een elektrisch fornuis zet elektriciteit
+      om in warmte. En elektrisch fornuis is ongeveer 55% efficiënt (exclusief elektriciteitsproductie
+      en transportverliezen).\r\n<br/>\r\nHet nadeel van een elektrisch fornuis is
+      dat het tijd nodig heeft om op te warmen en het is onmogelijk om snel de temperatuur
+      te veranderen.\r\n<br/><br/>\r\nUitsluitend de kosten door het verschil in energievraag
+      worden meegenomen. De kosten van het kooktoestel zelf worden niet meegenomen
+      in het Energietransitiemodel."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 356
   key: households_cooker_halogen_electricity_share
   share_group: cooking
@@ -2745,6 +4654,24 @@
   slide_id: 109
   position: 3
   dependent_on:
+  description:
+    content_en: "Halogen stoves use electricity to produce infrared radiation and
+      red light to heat food. Halogen stoves can be identified by the special toughened
+      ceramic glass stove tops. Compared to electric stoves, halogen stoves heat up
+      and cool down quicker offering more flexibility during cooking and improved
+      efficiency. The efficiency of a halogen stove is approximately 60% (excluding
+      losses that occur when electricity is produced).\r\n<br/><br/>\r\nOnly the costs
+      due to the difference in energy demand are considered. The costs of the stove
+      are not taken into account in the Energy Transition Model."
+    content_nl: "Halogeen fornuizen produceren infraroodstraling en rood licht om
+      eten te verwarmen. Halogeen fornuizen zijn herkendbaar aan de speciale keramische
+      glasplaat. Deze fornuizen kunnen sneller opwarmen en afkoelen dan elektrische
+      fornuizen. De efficiëntie van een halogeen fornuis is ongeveer 60% (exclusief
+      elektriciteitsproductie en transportverliezen).\r\n<br/><br/>\r\nUitsluitend
+      de kosten door het verschil in energievraag worden meegenomen. De kosten van
+      het kooktoestel zelf worden niet meegenomen in het Energietransitiemodel.\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 357
   key: households_cooker_induction_electricity_share
   share_group: cooking
@@ -2768,6 +4695,25 @@
   slide_id: 109
   position: 4
   dependent_on:
+  description:
+    content_en: "An induction cooker uses a type of induction heating for cooking.
+      What sets it apart from other common forms of stovetop cooking, is the fact
+      that the heat is generated directly in the cooking vessel, as opposed to being
+      transferred from the stovetop to the pan by electrical coils or burning gas.
+      Because of this, special pans are required for induction cookers. The efficiency
+      of an induction stove is very high, approximately 83-90%. \r\n<br/><br/>\r\nOnly
+      the costs due to the difference in energy demand are considered. The costs of
+      the stove are not taken into account in the Energy Transition Model."
+    content_nl: "Een inductiekookplaat is een type kookplaat dat gebruikmaakt van
+      het principe van inductieverhitting. In tegenstelling tot andere kookplaten,
+      wordt warmte gecreëerd in de pan zelf en wordt het niet overgebracht van het
+      fornuis via een kookplaat of brandend gas. Voor inductiekoken zijn wel speciale
+      inductiepannen nodig. De efficiëntie van een inductiekookplaat is hoog, ongeveer
+      83-90% (exclusief elektriciteitsproductie en transportverliezen).\r\n<br/><br/>\r\nUitsluitend
+      de kosten door het verschil in energievraag worden meegenomen. De kosten van
+      het kooktoestel zelf worden niet meegenomen in het Energietransitiemodel.\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 359
   key: households_appliances_dishwasher_electricity_efficiency
   share_group: ''
@@ -2791,6 +4737,25 @@
   slide_id: 3
   position: 1
   dependent_on: ''
+  description:
+    content_en: "How much more efficient do you think dish washers will be in the
+      future?\r\n<br/><br/>\r\nNational and European legislation is forcing household
+      appliances to use ever less energy. The energy labels that are mandatory nowadays
+      in all European countries give a good indication of the energy efficiency of
+      household appliances. \r\n<br/><br/>\r\nThe starting value of this slider is
+      the current average label of dish washers. Use the slider to give an estimation
+      of the average label of dish washers in the future. The A+++ label corresponds
+      to an energy reduction of 35% compared to today. "
+    content_nl: "Hoeveel efficiënter zullen afwasmachines in de toekomst zijn? \r\n<br/><br/>\r\nNationale
+      en Europese wetgeving dwingt producenten om huishoudelijke apparaten ieder jaar
+      zuiniger te maken. De energielabels die tegenwoordig in alle Europese landen
+      verplicht zijn geven een goede indicatie van de efficiëntie van huishoudelijke
+      apparaten.\r\n<br/><br/>\r\nDe startwaarde van dit schuifje is het gemiddelde
+      label van afwasmachines die nu geïnstalleerd zijn. Zet het schuifje op het label
+      dat jij denkt dat de gemiddelde afwasmachine heeft in de toekomst. Het A+++
+      label komt overeen met een besparing van 35% ten opzichte van vandaag."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 360
   key: households_appliances_vacuum_cleaner_electricity_efficiency
   share_group: ''
@@ -2814,6 +4779,25 @@
   slide_id: 3
   position: 7
   dependent_on: ''
+  description:
+    content_en: "How much more efficient do you think vacuum cleaners will be in the
+      future?\r\n<br/><br/>\r\nNational and European legislation is forcing household
+      appliances to use ever less energy. The energy labels that are mandatory nowadays
+      in all European countries give a good indication of the energy efficiency of
+      household appliances. \r\n<br/><br/>\r\nThe starting value of this slider is
+      the current average label of vacuum cleaners. Use the slider to give an estimation
+      of the average label of vacuum cleaners in the future. The A+++ label corresponds
+      to an energy reduction of 75% compared to today. "
+    content_nl: "Hoeveel efficiënter zullen stofzuigers in de toekomst zijn? \r\n<br/><br/>\r\nNationale
+      en Europese wetgeving dwingt producenten om huishoudelijke apparaten ieder jaar
+      zuiniger te maken. De energielabels die tegenwoordig in alle Europese landen
+      verplicht zijn geven een goede indicatie van de efficiëntie van huishoudelijke
+      apparaten.\r\n<br/><br/>\r\nDe startwaarde van dit schuifje is het gemiddelde
+      label van stofzuigers die nu geïnstalleerd zijn. Zet het schuifje op het label
+      dat jij denkt dat de gemiddelde stofzuigers hebben in de toekomst. Het A+++
+      label komt overeen met een besparing van 75% ten opzichte van vandaag.\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 361
   key: households_appliances_washing_machine_electricity_efficiency
   share_group: ''
@@ -2837,6 +4821,25 @@
   slide_id: 3
   position: 3
   dependent_on: ''
+  description:
+    content_en: "How much more efficient do you think washing machines will be in
+      the future?\r\n<br/><br/>\r\nNational and European legislation is forcing household
+      appliances to use ever less energy. The energy labels that are mandatory nowadays
+      in all European countries give a good indication of the energy efficiency of
+      household appliances. \r\n<br/><br/>\r\nThe starting value of this slider is
+      the current average label of washing machines. Use the slider to give an estimation
+      of the average label of washing machines in the future. The A+++ label corresponds
+      to an energy reduction of 28% compared to today. \r\n"
+    content_nl: "Hoeveel efficiënter zullen wasmachines in de toekomst zijn? \r\n<br/><br/>\r\nNationale
+      en Europese wetgeving dwingt producenten om wasmachines ieder jaar zuiniger
+      te maken. De energielabels die tegenwoordig in alle Europese landen verplicht
+      zijn geven een goede indicatie van de efficiëntie van huishoudelijke apparaten.\r\n<br/><br/>\r\nDe
+      startwaarde van dit schuifje is het gemiddelde label van wasmachines die nu
+      geïnstalleerd zijn. Zet het schuifje op het label dat jij denkt dat de gemiddelde
+      wasmachine heeft in de toekomst. Het A+++ label komt overeen met een besparing
+      van 28% ten opzichte van vandaag.\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 362
   key: households_appliances_clothes_dryer_electricity_efficiency
   share_group: ''
@@ -2860,6 +4863,24 @@
   slide_id: 3
   position: 4
   dependent_on: ''
+  description:
+    content_en: "How much more efficient do you think wash dryers will be in the future?\r\n<br/><br/>\r\nNational
+      and European legislation is forcing household appliances to use ever less energy.
+      The energy labels that are mandatory nowadays in all European countries give
+      a good indication of the energy efficiency of household appliances. \r\n<br/><br/>\r\nThe
+      starting value of this slider is the current average label of dryers. Use the
+      slider to give an estimation of the average label of dryers in the future. The
+      A+++ label corresponds to an energy reduction of 69% compared to today."
+    content_nl: "Hoeveel efficiënter zullen wasdrogers in de toekomst zijn? \r\n<br/><br/>\r\nNationale
+      en Europese wetgeving dwingt producenten om huishoudelijke apparaten ieder jaar
+      zuiniger te maken. De energielabels die tegenwoordig in alle Europese landen
+      verplicht zijn geven een goede indicatie van de efficiëntie van huishoudelijke
+      apparaten.\r\n<br/><br/>\r\nDe startwaarde van dit schuifje is het gemiddelde
+      label van wasdrogers die nu geïnstalleerd zijn. Zet het schuifje op het label
+      dat jij denkt dat de gemiddelde wasdroger heeft in de toekomst. Het A+++ label
+      komt overeen met een besparing van 69% ten opzichte van vandaag.\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 363
   key: households_appliances_television_electricity_efficiency
   share_group: ''
@@ -2883,6 +4904,25 @@
   slide_id: 3
   position: 5
   dependent_on: ''
+  description:
+    content_en: "How much more efficient do you think televisions will be in the future?\r\n<br/><br/>\r\nNew
+      technologies such as LED displays reduce energy consumption. But keep in mind
+      that large televisions of course consume more energy than small ones using the
+      same technology. As a result, each television uses more energy today than it
+      did several years ago.\r\n<br/><br/>\r\nThe starting value of this slider is
+      the current average label of televisions. Use the slider to give an estimation
+      of the average label of televisions in the future. The A+++ label corresponds
+      to an energy reduction of 92% compared to today. "
+    content_nl: "Hoeveel efficiënter zullen televisies in de toekomst zijn? \r\n<br/><br/>\r\nNieuwe
+      technologieën zoals LED televisies reduceren de energie consumptie. Maar vergeet
+      niet dat grotere televisies natuurlijk meer energie verbruiken dan kleinere
+      met dezelfde technologie. Daardoor gebruikt één televisie nu meer energie dan
+      enkele jaren geleden.\r\n<br/><br/>\r\nDe startwaarde van dit schuifje is het
+      gemiddelde label van televisies die nu geïnstalleerd zijn. Zet het schuifje
+      op het label dat jij denkt dat de gemiddelde televisies hebben in de toekomst.
+      Het A+++ label komt overeen met een besparing van 92% ten opzichte van vandaag."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 364
   key: households_appliances_computer_media_electricity_efficiency
   share_group: ''
@@ -2906,6 +4946,13 @@
   slide_id: 3
   position: 6
   dependent_on:
+  description:
+    content_en: How much more efficient do you think computers and other audio/video
+      appliances (excluding television) will be in the future?
+    content_nl: 'Hoeveel efficiënter zullen computers en andere audio/video apparatuur
+      (exclusief televisies) in de toekomst zijn? '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 366
   key: households_behavior_standby_killer_turn_off_appliances
   share_group: ''
@@ -2929,6 +4976,39 @@
   slide_id: 110
   position: 1
   dependent_on: ''
+  description:
+    content_en: "How many people will change their behavior to save energy?\r\n<br/><br/>\r\nMany
+      electric appliances use electricity even if they are switched off. In this \"standby\"
+      mode appliances like televisions can still use between 10 to 15 W of electricity.
+      Computers can even use up to 60 W when they are \"switched off\". Physically
+      unplugging the device from the socket, or installing a standby killer or on/off
+      switch on the wall socket can eliminate this <em>\"phantom load\"</em>.\r\n<br/><br/>\r\nEstimates
+      vary on the total impact of this type of energy leaking, but it can be up to
+      20% of total power used for these kind of appliances. It is important to note
+      that the total electricity use of these media appliances is very small compared
+      to the total demand of power and heat in households. That is why this slider
+      does not show a big decrease in the graph, even if 100% of the population changes
+      their behavior in this way. On the other hand, a behavioral change in this area
+      might also lead to behavioral changes that do matter, like taking the bicycle
+      or public transport to work instead of the car."
+    content_nl: "Hoeveel mensen zullen hun gedrag veranderen om energie te besparen?\r\n<br/><br/>\r\nVeel
+      elektrische apparaten gebruiken nog steeds elektriciteit als ze uitstaan. In
+      \"standby\" modus gebruiken apparaten gemiddeld nog 10 tot 15 W aan elektriciteit.
+      Een computer kan zelfs tot 60 W gebruiken terwijl hij \"uit\" staat. De stekker
+      uit het stopcontact trekken en een standby killer of aan/uit-schakelaar op het
+      stopcontact installeren kunnen ervoor zorgen dat deze stroom niet meer verloren
+      gaat.\r\n<br/><br/>\r\nEr zijn verschillende schattingen over de totale impact
+      van deze \"standby stroom\", maar het kan tot 20% zijn van het totale stroomgebruik
+      van dit soort apparaten. Het is daarbij wel belangrijk om te bedenken dat het
+      elektriciteitsgebruik van deze apparaten erg klein is vergeleken met de totale
+      vraag naar elektriciteit en warmte in huishoudens. Daarom toont dit schuifje
+      bij het aanpassen ook geen groot verschil, zelfs als 100% van de bevolking een
+      standby killer installeert. Aan de andere kant, kan een gedragsverandering hier
+      ook leiden tot veranderd gedrag op andere punten waar het wel uitmaakt. Als
+      mensen bijvoorbeeld in plaats van de auto, de trein of de fiets naar het werk
+      nemen zet dit wel zoden aan de dijk."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 368
   key: households_behavior_turn_off_the_light
   share_group: ''
@@ -2952,6 +5032,27 @@
   slide_id: 110
   position: 2
   dependent_on:
+  description:
+    content_en: "How many people will change their behavior to save energy?\r\n<br/><br/>\r\nMany
+      lights in the house are still switched on even if no one is there in the house,
+      or when it is light outside. Switching of these lights can save some energy.\r\n<br/><br/>\r\nThe
+      total amount of electricity used for lighting in households is small compared
+      to the total demand for electricity and heat in households, so the effects of
+      this behavioral change are not that high. In the buildings sector however, lighting
+      makes up a significant portion of the total elektricity demand. Here making
+      sure less light is used can lead to significant savings."
+    content_nl: "Hoeveel mensen zullen hun gedrag veranderen om energie te sparen?\r\n<br/><br/>\r\nVeel
+      mensen hebben thuis lampen aan staan die niet gebruikt worden. Deze lichten
+      uitzetten kan wat elektriciteit besparen. Denkt u dat meer of minder mensen
+      zich bewust zullen zijn van de lichten die nog aan staan in hun huis?\r\n<br/><br/>\r\nHet
+      totale gebruik van elektriciteit voor verlichting is huishoudens is niet zo
+      groot vergeleken met de totale vraag naar elektriciteit en warmte in huishoudens.
+      Daarom laat deze verandering in gedrag niet zo'n heel groot verschil zijn. In
+      gebouwen is het bijvoorbeeld wel heel nuttig om minder verlichting te gebruiken,
+      omdat daar de vraag naar verlichting een groot deel van de totale vraag naar
+      energie is."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 370
   key: households_behavior_close_windows_turn_off_heating
   share_group: ''
@@ -2975,6 +5076,19 @@
   slide_id: 110
   position: 3
   dependent_on:
+  description:
+    content_en: "How many people will change their behavior to save energy?\r\n<br/><br/>\r\nHeating
+      your home to a lower temperature (and wearing a sweater) or turning off the
+      heating in rooms which are not currently being used can save a lot of energy
+      used for heating.\r\n<br/><br/>\r\nWhat percentage of the people do you think
+      will turn down the heating of their home?"
+    content_nl: "Hoeveel mensen zullen hun gedrag veranderen om energie te besparen?\r\n<br/><br/>\r\nDe
+      verwarming van je huis een graadje lager zetten (en een trui aantrekken) of
+      de verwarming uitzetten in kamers die niet gebruikt worden kan een hoop energie
+      besparen.\r\n<br/><br/>\r\nWelk percentage van de bevolking gaat zijn huis minder
+      warm stoken?"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 371
   key: households_behavior_low_temperature_washing
   share_group: ''
@@ -2998,6 +5112,17 @@
   slide_id: 110
   position: 4
   dependent_on: ''
+  description:
+    content_en: "How many people will change their behavior to save energy?\r\n<br/><br/>\r\nWashing
+      your laundry at 40 degrees Celcius instead of 60 degrees can save up to 50%
+      of the electricity.\r\n<br/><br/>\r\nWhat percentage of the people do you think
+      will start washing their laundry at lower temperatures?"
+    content_nl: "Hoeveel mensen zullen hun gedrag veranderen om energie te besparen?\r\n<br/><br/>\r\nKleding
+      wassen op 40 graden Celcius kan 50% elektriciteit besparen ten opzichte van
+      wassen op 60 graden.\r\n<br/><br/>\r\nWelk percentage van de bevolking gaat
+      wassen met lagere temperaturen?"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 372
   key: households_useful_demand_heat_per_person
   share_group: ''
@@ -3021,6 +5146,19 @@
   slide_id: 43
   position: 5
   dependent_on: ''
+  description:
+    content_en: "Note: these changes in energy demand do <strong>not</strong> depend
+      on the technologies chosen below (Space heating slide). \r\n<br/>\r\n<br/>\r\nHere
+      you indicate how you expect heat demand per residence to change. As people become
+      wealthier, they start living in larger houses which increases the energy demand
+      for space heating. "
+    content_nl: "Let op: deze verandering van energiegebruik is <strong>onafhankelijk</strong>
+      van de technologieën die je in hieronder kunt kiezen (Ruimteverwarming slide).\r\n<br/>\r\n<br/>\r\nHier
+      kun je aangeven hoe jij denkt dat de warmtevraag per huishouden zich gaat ontwikkelen.
+      Als mensen rijker worden, gaan ze in grotere huizen wonen waardoor de energievraag
+      voor ruimteverwarming toeneemt."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 373
   key: households_useful_demand_hot_water_share
   share_group: ''
@@ -3044,6 +5182,16 @@
   slide_id: 43
   position: 1
   dependent_on: ''
+  description:
+    content_en: "Note: these changes in energy demand do <strong>not</strong> depend
+      on the technologies chosen below (Hot water slide). \r\n<br/>\r\n<br/>\r\nHere
+      you indicate how you expect demand for hot water per person to change. This
+      is mainly determined by growth in prosperity."
+    content_nl: "Let op: deze verandering van energiegebruik is <strong>onafhankelijk</strong>
+      van de technologieën die je hieronder kunt kiezen (Warmwaterslide).\r\n<br/>\r\n<br/>\r\nHier
+      kun je aangeven hoe jij denkt dat de warmwatervraag per persoon zich gaat ontwikkelen."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 374
   key: households_cooling_heatpump_air_water_electricity_share
   share_group: cooling_households
@@ -3067,6 +5215,39 @@
   slide_id: 108
   position: 2
   dependent_on: ''
+  description:
+    content_en: "A heat pump moves heat from one place to another. Buildings can use
+      them for heating and cooling, but they are also used in refrigerators. Currently,
+      their use in newly constructed houses is becoming quite popular, since European
+      legislation dictates that domestic energy consumption must decrease.\r\n<br/><br/>\r\nThis
+      is an electric heat pump that draws cold/heat from the air outside and uses
+      a wall or floor delivery system. Not all residences are suitable for using a
+      heat pump as they cannot all be fitted with wall or floor delivery systems at
+      acceptable costs. Considering the high investment costs for such delivery systems,
+      it is realistic to assume that no more than ~20% of all residences could be
+      equipped with such a heat pump. For the other 80%, the costs would probably
+      outweigh the benefits.\r\n<br/><br/>\r\nNote that for heat pump shares above
+      20%, the ETM will considerably underestimate the associated investment costs.
+      This is caused by the fact that the additional investment costs are unknown
+      for installation in residences that would normally not qualify.  "
+    content_nl: "Een warmtepomp is een apparaat dat warmte verplaatst. De meest bekende
+      toepassing is een koelkast, maar in een gebouw kan een warmtepomp ook zorgen
+      voor verwarming en koeling. Het werkt vaak alleen als vloer- en muurverwarming
+      worden geïnstalleerd, in plaats van radiatoren. Nu worden warmtepompen vooral
+      nog ingezet bij nieuwbouw van huizen. Europese wetgeving schrijft namelijk voor
+      dat het energiegebruik van huizen per 2020 tot nul moet zijn toegebracht (gemeten
+      over een heel jaar). \r\n<br/><br/>\r\nDeze warmtepomp gebruikt elektriciteit,
+      haalt de omgevingskoude uit de buitenlucht en geeft het af aan de vloer- en
+      muurverwarming. Omdat dit niet in alle huizen te realiseren is tegen acceptabele
+      investeringskosten, is een realistische schatting van het aantal huizen waarin
+      een warmtepomp kan worden geïnstalleerd 20%. In de overige 80% wegen de kosten
+      waarschijnlijk niet op tegen de baten.\r\n<br><br/>\r\nLet er op dat het ETM
+      de investeringskosten significant onderschat voor een aandeel van warmtepompen
+      van boven de 20%. Dit komt omdat de extra investeringskosten voor huizen die
+      eigenlijk niet geschikt zijn voor installatie van een warmtepomp, niet bekend
+      zijn."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 375
   key: households_heater_heatpump_air_water_electricity_share
   share_group: heating_households
@@ -3090,6 +5271,28 @@
   slide_id: 4
   position: 3
   dependent_on: ''
+  description:
+    content_en: "Heat pumps can run on gas or electricity. This is an electric heat
+      pump, draws its heat from the outside air and uses under-floor heating. \r\n<br/><br/>\r\nA
+      heat pump moves heat from one place to another. Heat pumps are used in refrigerators,
+      but buildings can use them for heating and cooling. This saves energy compared
+      to a gas-fired central heating boiler, for example. For optimal application,
+      it does often require installation of under-floor and wall heating instead of
+      radiators. Currently, their use in newly constructed houses is becoming quite
+      popular, since European legislation dictates that domestic energy consumption
+      must decrease. "
+    content_nl: "Een warmtepomp kan op elektriciteit of gas werken. Deze warmtepomp
+      gebruikt elektriciteit, haalt de omgevingswarmte uit de buitenlucht en maakt
+      gebruik van vloer- en muurverwarming.\r\n<br/><br/>\r\nEen warmtepomp is een
+      apparaat dat warmte verplaatst. De meest bekende toepassing is een koelkast,
+      maar in een gebouw kan een warmtepomp ook zorgen voor verwarming en koeling.
+      Dat kost minder energie dan gasverwarming met een HR CV-ketel, maar het kan
+      niet zomaar in ieder huis. Nu worden warmtepompen daarom vooral nog ingezet
+      bij nieuwbouw van huizen. Europese wetgeving schrijft namelijk voor dat het
+      energiegebruik van huizen per 2020 tot nul moet zijn toegebracht (gemeten over
+      een heel jaar). \r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 376
   key: number_of_buildings
   share_group: ''
@@ -3113,6 +5316,17 @@
   slide_id: 113
   position: 1
   dependent_on:
+  description:
+    content_en: How do you expect the number of non-residential buildings to grow?
+      This concerns all buildings that fall into categories like offices, hospitals,
+      swimming pools, restaurants, etc. Apart from increasing prosperity, this is
+      one of the most important drivers for the energy demand growth.
+    content_nl: 'Hoe verwacht je dat het aantal gebouwen zich gaat ontwikkelen? Het
+      gaat hier om alle gebouwen waar niet in gewoond wordt, zoals kantoren, ziekenhuizen,
+      zwembaden, restaurants, etc. Naast welvaartsgroei is dit een van de belangrijkste
+      factoren die de energievraag beïnvloeden. '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 377
   key: buildings_useful_demand_electricity
   share_group: ''
@@ -3136,6 +5350,21 @@
   slide_id: 113
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Note: these changes in energy use <strong>exclude</strong> the use
+      of the efficient technologies that you can choose below (Appliances, Lighting,
+      Heating & Cooling). \r\n<br/>\r\n<br/>\r\nHere you indicate how you expect demand
+      for electricity per building to change. This is mainly determined by growth
+      in prosperity. As people become richer, they become accustomed to ever more
+      convenience from ICT and other other office or school appliances."
+    content_nl: "Let op: deze verandering van energiegebruik is <strong>exclusief</strong>
+      de efficiëntere technologieën die je in dit gedeelte kunt kiezen (Apparaten,
+      Verlichting, Verwarming & Koeling).\r\n<br/><br/>\r\nHier kun je aangeven hoe
+      jij denkt dat de elektriciteitsvraag per gebouw zich gaat ontwikkelen. Dit hangt
+      vooral af van de welvaartsgroei. Als mensen rijker worden, raken ze gewend aan
+      steeds meer gemak van ICT apparatuur en overige apparaten op hun werk of opleiding.\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 378
   key: buildings_useful_demand_for_space_heating
   share_group: ''
@@ -3159,6 +5388,22 @@
   slide_id: 113
   position: 3
   dependent_on: ''
+  description:
+    content_en: "Note: these changes in energy demand do <strong>not</strong> depend
+      on the technologies chosen below (Heating & Cooling). \r\n<br/>\r\n<br/>\r\nHere
+      you indicate how you expect heat demand per building to change. This is likely
+      to change as buildings become ever more filled with electric appliances producing
+      heat. In fact, especially offices need cooling for more hours per year than
+      before everyone started using computers, copiers, faxes and printers. "
+    content_nl: "Let op: deze verandering van energiegebruik is <strong>onafhankelijk</strong>
+      van de technologieën die je in hieronder kunt kiezen (Verwarming & Koeling).\r\n<br/>\r\n<br/>\r\nHier
+      kun je aangeven hoe jij denkt dat de warmtevraag per gebouw zich gaat ontwikkelen.
+      Dit verandert onder meer doordat gebouwen steeds voller komen te staan met elektrische
+      apparaten die warmte produceren. Het is zelfs zo dat gebouwen steeds meer uren
+      per jaar gekoeld moeten worden dan voordat iedereen ging werken met computers,
+      faxen, kopieerapparaten en printers."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 381
   key: buildings_insulation_level
   share_group: ''
@@ -3182,6 +5427,40 @@
   slide_id: 114
   position: 1
   dependent_on: has_buildings
+  description:
+    content_en: "The heat demand reduction is the percentage by which the heat demand
+      is reduced compared to a badly insulated building (characterised by label E),
+      i.e. the slider indicates how much of the potential savings has been achieved.
+      The current settings are based on the energy labels that are present within
+      your region, for the Netherlands this data is derived from <a href=\"https://bagviewer.kadaster.nl/lvbag/bag-viewer/index.html#?geometry.x=160000&geometry.y=455000&zoomlevel=0)\">\"Basisregistratie
+      Adressen en Gebouwen (BAG)\"</a>. These labels have been converted into heat
+      demand reduction percentages. The relationship between heat demand reduction
+      and energy labels can be found in our <a href=\"https://github.com/quintel/documentation/blob/master/general/insulation.md\">documentation</a>.
+      However, the mapping is ambiguous since there is no direct relationship between
+      energy labels and the insulation level.  \r\n<br><br>\r\nFor the current situation
+      no insulation costs are taken into account, only when insulation measures are
+      taken. The insulation costs are based on the energy model <a href=\"https://www.pbl.nl/vesta\">Vesta</a>,
+      see the <a href=\"https://github.com/quintel/documentation/blob/master/general/insulation.md\">documentation</a>
+      for the exact modelling. The insulation costs for buildings are modelled as
+      a fixed amount per % heat demand reduction: € 606 per % for existing buildings
+      and € 479 per % for new buildings."
+    content_nl: "De warmtevraag-reductie is het percentage waarmee de warmtevraag
+      lager is ten opzichte van een slecht geïsoleerd  gebouw (met label E). Oftewel:
+      welk aandeel van het besparingspotentieel is al benut? Het huidige percentage
+      van de slider is gebaseerd op de energielabels die aanwezig zijn in jouw regio;
+      voor Nederland komt deze data van <a href=\"https://bagviewer.kadaster.nl/lvbag/bag-viewer/index.html#?geometry.x=160000&geometry.y=455000&zoomlevel=0)\">Basisregistratie
+      Adressen en Gebouwen (BAG)</a>. De energielabels zijn vervolgens omgezet in
+      een warmtevraag-reductie, deze berekening is terug te vinden in onze <a href=\"https://github.com/quintel/documentation/blob/master/general/insulation.md\">documentatie</a>.
+      De koppeling tussen energielabel en warmtevraag is echter moeilijk te leggen
+      omdat er geen direct verband is tussen energielabels en isolatie van de schil
+      van een gebouw.\r\n<br><br>\r\nVoor de huidige situatie rekenen we geen isolatiekosten,
+      deze nemen we enkel mee als er wordt geïsoleerd. De isolatiekosten komen uit
+      het energiemodel <a href=\"https://www.pbl.nl/vesta\">Vesta</a>, zie de <a href=\"https://github.com/quintel/documentation/blob/master/general/insulation.md\">documentatie</a>
+      voor de precieze berekening. De isolatiekosten voor gebouwen zijn gemodelleerd
+      als een vast bedrag per % warmtevraag-reductie: € 606 per % voor bestaande gebouwen
+      en € 479 per % voor nieuwe gebouwen. "
+    short_content_en: ''
+    short_content_nl: ''
 - id: 383
   key: buildings_space_heater_network_gas_share
   share_group: heating_buildings
@@ -3205,6 +5484,14 @@
   slide_id: 115
   position: 1
   dependent_on: ''
+  description:
+    content_en: These heaters are part of a gas-fired high efficiency central heating
+      system running on natural gas. These systems are quite energy efficient, but
+      emit CO<sub>2</sub>.
+    content_nl: Deze ketels zijn gasgestookte HR-ketels. Dit zijn zeer efficiënte
+      systemen, maar ze stoten wel CO<sub>2</sub> uit.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 386
   key: buildings_collective_chp_network_gas_share
   share_group: district_heating_buildings
@@ -3228,6 +5515,30 @@
   slide_id:
   position: 3
   dependent_on: ''
+  description:
+    content_en: "Small Combined heat and power (CHP) engines like these (~2 MWe and
+      ~2 MWth) are gas-fired engines that generate both heat and electricity. The
+      combination of heat and electricity makes this option quite energy efficient.
+      Also, locally producing and using heat and electricity reduces transportation
+      losses and saves energy. CHPs are primarily used at sites with a predictable
+      demand for heat, such as hospitals or swimming pools.\r\n<br/><br/>\r\nA gas-fired
+      CHP uses more natural gas to make heat than a good gas-fired boiler, and is
+      only attractive if the electricity is used or can be sold over the grid.\r\n"
+    content_nl: "Kleine warmtekrachtkoppelingen (WKK’s) als deze (~2 MWe en ~2 MWth)
+      maken warmte en elektriciteit. Deze combinatie maakt WKK's vrij energie-efficiënt.
+      Lokaal produceren en gebruiken van warmte en elektriciteit vermijdt transportverliezen
+      en dat bespaart weer energie. WKK's worden vooral gebouwd op locaties met een
+      voorspelbare warmtevraag, zoals bijvoorbeeld zwembaden en ziekenhuizen.\r\n<br/<br/>\r\nEen
+      gas-WKK gebruikt meer aardgas om warmte te maken, dan een HR CV-ketel. Daarom
+      is deze optie pas aantrekkelijk als de elektriciteit kan worden benut of kan
+      worden verkocht over het net.\r\n\r\n<br/><br/>\r\n<object width=\"640\" height=\"385\"><param
+      name=\"movie\" value=\"http://www.youtube.com/v/HjVqJPqR0IU?fs=1&amp;hl=en_US&amp;rel=0\"></param><param
+      name=\"allowFullScreen\" value=\"true\"></param><param name=\"allowscriptaccess\"
+      value=\"always\"></param><embed src=\"http://www.youtube.com/v/HjVqJPqR0IU?fs=1&amp;hl=en_US&amp;rel=0\"
+      type=\"application/x-shockwave-flash\" allowscriptaccess=\"always\" allowfullscreen=\"true\"
+      width=\"425\" height=\"300\"></embed></object>"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 387
   key: buildings_space_heater_electricity_share
   share_group: heating_buildings
@@ -3251,6 +5562,30 @@
   slide_id: 115
   position: 4
   dependent_on: ''
+  description:
+    content_en: "Electric heaters directly convert electricity back to heat.\r\n<br/>\r\nSome
+      people believe this is a waste of energy. Electricity is a very versatile form
+      of energy and low-grade heat can only be used to heat buildings or make hot
+      water. The waste is even bigger if the electricity is generated using fossil
+      fuels.\r\n<br/><br/>\r\nElectric heaters need to be able to produce a lot of
+      heat quickly, so they can have a large impact on the energy grid. Especially
+      if they are added to electric heat pumps as extra heating capacity during cold
+      days, impact on the local electricity grid can be extreme. If you want to see
+      what will happen to the grid you can set the electric heater slider to the same
+      percentage as electric heat pumps (ground). "
+    content_nl: "Electrische kachels zetten elektriciteit direct om in warmte. Op
+      zich is dat een zeer efficiënt proces.\r\n<br/>\r\nToch denken veel mensen dat
+      dit energieverspilling is. Elektriciteit kun je op veel verschillende manieren
+      nuttig inzetten en laagwaardige warmte kun je alleen gebruiken om warm water
+      te maken, of huizen te verwarmen. Uiteraard is de verspilling nog groter als
+      je de  stroom opwekt door kostbare fossiele brandstoffen te verbranden.\r\n<br/><br/>\r\nElektrische
+      kachels of bijstook moeten snel veel warmte kunnen leveren en hebben daarom
+      een groot vermogen. Dit betekent dat ze het elektriciteitsnet sterk belasten.
+      \ Als je wilt zien wat de impact van elektrische bijstook bij warmtepompen is,
+      kun je deze schuif op hetzelfde percentage zetten als de elektrische warmtepomp
+      (bodem) schuif."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 388
   key: buildings_heat_network_connection_steam_hot_water_share
   share_group: district_heating_buildings
@@ -3274,6 +5609,23 @@
   slide_id:
   position: 8
   dependent_on: ''
+  description:
+    content_en: Heat for district heating can be produced by local burners, but also
+      by large-scale heat plants. You can choose to build large-scale plants in a
+      the <a href="/scenario/supply/fossil_heat/fossil-fired-heaters" >fossil heat</a>
+      and <a href="/scenario/supply/renewable_heat/biomass" >renewable heat</a> slides
+      in the supply section. You can also choose to use waste heat from power plants
+      and waste CHPs (see the <a href="/scenario/supply/electricity/coal-plants" >electricity
+      production</a> slide).
+    content_nl: Warmte uit een warmtenet kan geproduceerd worden door lokale warmteketels,
+      maar kan ook komen van grootschalige  een grootschalige centrales. Bij <a href="/scenario/supply/fossil_heat/fossil-fired-heaters"
+      >'fossiele warmte'</a> en <a href="/scenario/supply/renewable_heat/biomass"
+      >'hernieuwbare warmte'</a> in de Aanbodsectie kun je hiervoor een aantal opties
+      kiezen. Ook kun je gebruik maken van restwarmte van elektriciteitscentrales
+      en afvalverbranders (zie de slide <a href="/scenario/supply/electricity/coal-plants"
+      >'Elektriciteit'</a>).
+    short_content_en: ''
+    short_content_nl: ''
 - id: 389
   key: buildings_space_heater_solar_thermal_share
   share_group: ''
@@ -3297,6 +5649,20 @@
   slide_id: 121
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Solar water heaters (SWH) use solar thermal panels to produce warm
+      water using heat from the sun. This heat can be used to heat a building. SWHs
+      are installed on rooftops or in asphalt for parking lots, for example. A SWH
+      is often combined with a gas-fired central heating boiler that heats water further
+      if necessary (especially in winter). It can also be combined with a heat pump.
+      \r\n<br/>"
+    content_nl: "Een zonneboiler maakt warm water via zonthermische panelen op je
+      dak. Deze warmte kan gebruikt worden om een gebouw te verwarmen. Zonneboilers
+      worden vaak op daken of in het asfalt van parkeerterreinen geplaatst. Een zonneboiler
+      wordt vaak met een gas CV-ketel gecombineerd om het water (in de winter) verder
+      op te warmen. Ook met een warmtepomp gaat het goed samen."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 390
   key: buildings_space_heater_heatpump_air_water_network_gas_share
   share_group: heating_buildings
@@ -3320,6 +5686,36 @@
   slide_id: 115
   position: 3
   dependent_on: ''
+  description:
+    content_en: "A gas-fired heat pump is similar to an electric heat pump except
+      that the energy driving the process comes from gas, not electricity. This heat
+      pump takes its heat from the outside air, which makes it easier and cheaper
+      to install than the heat pump that takes its heat from the ground or underground
+      water. Depending on how the electricity for electric heat pumps is produced,
+      gas-fired heat pumps are roughly as efficient as electric ones.\r\n<br/><br/>\r\nOn
+      cold winter days, gas-fired heat pumps in effect turn into gas-fired heaters,
+      since little ambient heat is available. This is vastly preferable to electric
+      heat pumps that draw their heat from the outside air (not found in this model)
+      and require additional electric heating capacity for cold days. The latter will
+      require large investments to reinforce electricity grids."
+    content_nl: "Een gaswarmtepomp lijkt op een elektrische warmtepomp, behalve dat
+      de energie voor het proces komt van gas en niet van elektriciteit. Deze warmtepomp
+      gebruikt als bron warmte uit de buitenlucht en niet uit de bodem of het grondwater.
+      Uiteindelijk is deze gaswarmtepomp ongeveer even efficiënt als een warmtepomp
+      op (centraal opgewekte) electriciteit.\r\n<br/><br/>\r\nOp koude winterdagen,
+      als er weinig omgevingswarmte uit de lucht te halen is, kunnen gaswarmtepompen
+      alleen met gas het gebouw verwarmen. Dat is een groot voordeel ten opzichte
+      van elektrische warmtepompen die hun warmte uit de lucht halen (zitten niet
+      in dit model). De laatste hebben extra elektrische bijstook nodig om voldoende
+      warmte te maken en dat zou sterke verzwaring van het elektriciteitsnet nodig
+      maken.\r\n<br/><br/>\r\n<object width=\"640\" height=\"385\"><param name=\"movie\"
+      value=\"http://www.youtube.com/v/L2EA69MTNU4?fs=1&amp;hl=en_US&amp;rel=0\"></param><param
+      name=\"allowFullScreen\" value=\"true\"></param><param name=\"allowscriptaccess\"
+      value=\"always\"></param><embed src=\"http://www.youtube.com/v/L2EA69MTNU4?fs=1&amp;hl=en_US&amp;rel=0\"
+      type=\"application/x-shockwave-flash\" allowscriptaccess=\"always\" allowfullscreen=\"true\"
+      width=\"425\" height=\"300\"></embed></object>"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 391
   key: buildings_cooling_heatpump_air_water_network_gas_share
   share_group: cooling_buildings
@@ -3343,6 +5739,21 @@
   slide_id: 116
   position: 2
   dependent_on: ''
+  description:
+    content_en: A gas-fired heat pump is similar to an electric heat pump except that
+      the energy driving the process comes from gas, not electricity. This heat pump
+      takes its heat from the outside air, which makes it easier and cheaper to install
+      than the heat pump that takes its heat from the ground or underground water.
+      Depending on how the electricity for electric heat pumps is produced, gas-fired
+      heat pumps are roughly as efficient as electric ones for heating, and less efficient
+      for cooling.
+    content_nl: Een gaswarmtepomp lijkt op een elektrische warmtepomp, behalve dat
+      de energie voor het proces komt van gas en niet van elektriciteit. Deze warmtepomp
+      gebruikt als bron warmte uit de buitenlucht en niet uit de bodem of het grondwater.
+      Uiteindelijk is hij voor verwarmen ongeveer even efficiënt als je de stroom
+      opwekt met het centrale park van vandaag de dag. Voor koelen is hij minder efficiënt.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 392
   key: buildings_cooling_collective_heatpump_water_water_ts_electricity_share
   share_group: cooling_buildings
@@ -3366,6 +5777,28 @@
   slide_id: 116
   position: 1
   dependent_on: ''
+  description:
+    content_en: "Thermal storage works by storing a building's heat underground by
+      cooling it with water from a water basin or aquifer in summer. This heat can
+      be used again in winter for heating the building. Alternatively the natural
+      heat of cold of ground water or roads, for example, can be used.\r\n<br/><br/>\r\nHeat
+      pumps are more efficient when used in combination with thermal storage, because
+      less energy has to be added to cool or heat water to the right temperature.
+      It is difficult to realize underground thermal storage in densely populated
+      areas so this is only lucrative for large projects supplying heat and cold to
+      larger office buildings, for example. "
+    content_nl: "Bij Warmte Koude Opslag (WKO) wordt de warmte van een gebouw ondergronds
+      opgeslagen door het te koelen met water en die warmte op te slaan in een ondergronds
+      bassin of waterlaag. Die opgeslagen warmte gebruikt men dan in de winter om
+      het huis mee te verwarmen. Als alternatief kan ook de natuurlijke warmte of
+      koude van oppervlaktewater of wegen gebruikt worden.\r\n<br/><br/>\r\nWarmtepompen
+      zijn zeer efficiënt als ze met WKO gecombineerd worden, omdat minder energie
+      hoeft te worden toegevoegd om een gebouw te koelen of te verwarmen. Het is helaas
+      praktisch niet altijd mogelijk om de ondergrondse opslag te realiseren (bijvoorbeeld
+      in stedelijk gebied). Daarom is WKO alleen lucratief op grote schaal, zoals
+      voor grote kantoorpanden bijvoorbeeld."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 393
   key: buildings_cooling_airconditioning_share
   share_group: cooling_buildings
@@ -3389,6 +5822,15 @@
   slide_id: 116
   position: 3
   dependent_on: ''
+  description:
+    content_en: This indicates the extent to which air conditioning is used to cool
+      buildings like offices, schools, hostpitals, hotels, restaurants etc. Currently,
+      most cooling is provided by air conditioning in most countries.
+    content_nl: Hier staat aangegeven hoeveel van de koeling van kantoren, ziekenhuizen,
+      hotels, restaurants, enz door airconditioners gebeurt. Op dit moment gebeurt
+      de meeste koeling in de meeste landen nog met airconditioners.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 394
   key: buildings_space_heater_collective_heatpump_water_water_ts_electricity_share
   share_group: heating_buildings
@@ -3412,6 +5854,28 @@
   slide_id: 115
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Thermal storage works by storing a building's heat underground by
+      cooling it with water from a water basin or aquifer in summer. This heat can
+      be used again in winter for heating the building. Alternatively the natural
+      heat of cold of ground water or roads, for example, can be used.\r\n<br/><br/>\r\nHeat
+      pumps are more efficient when used in combination with thermal storage, because
+      less energy has to be added to cool or heat water to the right temperature.
+      It is difficult to realize underground thermal storage in densely populated
+      areas so this is only lucrative for large projects supplying heat and cold to
+      larger office buildings, for example. "
+    content_nl: "Bij Warmte Koude Opslag (WKO) wordt de warmte van een gebouw ondergronds
+      opgeslagen door het te koelen met water en die warmte op te slaan in een ondergronds
+      bassin of waterlaag. Die opgeslagen warmte gebruikt men dan in de winter om
+      het huis mee te verwarmen. Als alternatief kan ook de natuurlijke warmte of
+      koude van oppervlaktewater of wegen gebruikt worden.\r\n<br/><br/>\r\nWarmtepompen
+      zijn zeer efficiënt als ze met WKO gecombineerd worden, omdat minder energie
+      hoeft te worden toegevoegd om een gebouw te koelen of te verwarmen. Het is helaas
+      praktisch niet altijd mogelijk om de ondergrondse opslag te realiseren (bijvoorbeeld
+      in stedelijk gebied). Daarom is WKO alleen lucratief op grote schaal, zoals
+      voor grote kantoorpanden bijvoorbeeld."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 395
   key: buildings_ventilation_rate
   share_group: ''
@@ -3435,6 +5899,31 @@
   slide_id: 117
   position: 1
   dependent_on:
+  description:
+    content_en: "This slider sets the amount of times air gets refreshed per hour
+      in an average building. There are two sources of refreshed air. One is air that
+      flows in from the outside in a natural fashion (through open windows and doors,
+      small seams etc), the other is air that gets refreshed through a mechanical
+      ventilation system. As isolation of buildings gets better natural ventilation
+      rate goes down and it becomes more important to have good mechanical ventilation,
+      because otherwise the air can get contaminated with bacteria and pollution and
+      oxygen in the air will be depleted.\r\n<br/><br/>\r\nThe default value of the
+      slider is the current average refreshment rate of air in buildings. The trend
+      over the years is that the ventilation rate has gone down a bit. Do you think
+      this will change in the future?"
+    content_nl: "Dit schuifje verandert het aantal keer dat de lucht in een gebouw
+      per uur vervangen wordt. Er zijn twee manieren waarop deze lucht vervangen wordt.
+      De eerste is via natuurlijke ventilatie, hierbij komt nieuwe lucht binnen via
+      open deuren en ramen, kiertjes etc. De tweede manier waarop nieuwe lucht aangevoerd
+      wordt is via mechanische ventilatie door het ventilatiesysteem van een gebouw.
+      Met de toenemende mate van isolatie in gebouwen wordt het ook belangrijker om
+      goed te ventileren. De lucht kan anders vervuild raken met bacteriën en schadelijke
+      stoffen, terwijl het zuurstofgehalte naar beneden gaat.\r\n<br/><br/>\r\nDe
+      standaardwaarde van dit schuifje is de huidige gemiddelde verversingsgraad van
+      de lucht in gebouwen. De trend over de afgelopen jaren is dat deze ventilatievoud
+      iets daalt. Denk je dat dit verandert in de toekomst?"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 396
   key: buildings_recirculation
   share_group: ''
@@ -3458,6 +5947,28 @@
   slide_id: 117
   position: 2
   dependent_on:
+  description:
+    content_en: "Recirculation is a technology that reuses the air in a building by
+      using filters to clean the air and re-supplying it through the ventilation system.
+      This technology saves energy by maintaining the heated air, instead of releasing
+      it into the open air. Please note that the cost of these ventilation systems
+      is not used in the cost calculations in the Energy Transition Model.\r\n<br/><br/>\r\nWhat
+      percentage of air will be recirculated in buildings through their ventilation
+      system? Note that this cannot be 100%, because not all air flows through the
+      ventilation system (dependent on the level of insulation) and that air cannot
+      be recirculated indefinitely; at one point new air has to flow into the system."
+    content_nl: "Recirculatie is een technologie die de lucht in een gebouw hergebruikt
+      door filters toe te passen op de lucht en het via het ventilatiesysteem weer
+      het gebouw in te brengen. Op deze manier wordt energie bespaard doordat de warme
+      lucht hergebruikt wordt, in plaats van de buitenlucht in te worden gestuurd.
+      Let op: de kosten van deze ventilatiesystemen wordt niet meegenomen in de kostenberekening
+      van het model.\r\n<br/><br/>\r\nHoeveel procent van de lucht in gebouwen wordt
+      gerecirculeerd door hun ventilatiesysteem? Dit getal kan geen 100% zijn, omdat
+      via natuurlijke weg een deel van de lucht in het gebouw wegstroomt (afhankelijk
+      van isolatie) en de lucht in het recirculatiesysteem ook niet voor eeuwig gerecirculeerd
+      kan worden; op een gegeven moment moet het ververst worden."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 397
   key: buildings_waste_heat_recovery
   share_group: ''
@@ -3481,6 +5992,29 @@
   slide_id: 117
   position: 3
   dependent_on:
+  description:
+    content_en: "Heat recovery is a technology that keeps drawing in new air from
+      outside, but it uses a system to recover the heat from the outgoing air and
+      supply it to the outgoing air. In this way there is a supply of clean air in
+      the building, while still saving the heat that would otherwise be wasted by
+      releasing it into the outside. Please note that the cost of these ventilation
+      systems is not used in the cost calculations in the Energy Transition Model.\r\n<br/><br/>\r\nWhat
+      percentage of air in buildings will have their heat recovered through the their
+      ventilation system? Note that this cannot be 100%, because not all air flows
+      through the ventilation system (dependent on the level of insulation) and that
+      not all heat in the air can be recovered."
+    content_nl: "Warmte terugwinning is een technologie die wel nieuwe lucht blijft
+      aanvoeren via het ventilatiestysteem, maar waarbij de warmte uit de uitgaande
+      lucht wordt teruggewonnen en doorgegeven aan de inkomende lucht. Zo komt er
+      dus continue schone lucht het gebouw in, maar wordt de warmte, die anders aan
+      de buitenlucht verloren zou gaan, opnieuw gebruikt. Let op: de kosten van deze
+      ventilatiesystemen wordt niet meegenomen in de kostenberekening van het model.\r\n<br/><br/>\r\nHoeveel
+      procent van de gebouwen gebruiken warmte terugwinning in hun ventilatiesysteem?
+      Dit getal kan geen 100% zijn, omdat via natuurlijke weg een deel van de lucht
+      in het gebouw wegstroomt (afhankelijk van isolatie) en niet alle warmte uit
+      de lucht teruggewonnen kan worden."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 398
   key: buildings_useful_demand_for_appliances
   share_group: ''
@@ -3504,6 +6038,32 @@
   slide_id: 118
   position: 1
   dependent_on:
+  description:
+    content_en: "How much more efficient do you think appliances in non-residential
+      buildings will be in the future? Use the slider to give an estimation of yearly
+      increase in the overall efficiency of appliances.\r\n<br/><br/>\r\nAppliances
+      in offices, hotels, restaurants, hospitals and swimming pools account for a
+      considerable share of energy use. Typical office appliances are computers and
+      screens, printers, faxes, photocopiers etc. Hotels, restaurants, swimming pools
+      and especially hospitals use more specialized equipment, of course, for which
+      reliability may be more important than energy consumption. \r\n<br/><br/>\r\nNew
+      technologies often reduce energy consumption per individual device, but not
+      if devices simply become bigger. Computer screens have become much more efficient,
+      for example, but also larger. This means they do not always use less energy
+      than the smaller screens used before.  \r\n"
+    content_nl: "Hoeveel efficiënter zullen apparaten in de utiliteitsbouw in de toekomst
+      zijn? Geef met de schuif een inschatting van de jaarlijkse toename van de energie-efficiëntie.
+      \r\n<br/><br/>\r\nApparaten in kantoren, hotels, restaurants, ziekenhuizen en
+      zwembaden zorgen voor een flink deel van het energiegebruik. Typische apparaten
+      voor kantoren zijn natuurlijk computers en schermen, printers, faxen, kopieermachines,
+      etc. In hotels, restaurants, zwembaden en met name ziekenhuizen staat meer gespecialiseerde
+      apparatuur, waarvan de betrouwbaarheid mogelijk belangrijker is dan het energiegebruik.
+      \r\n<br/><br/>\r\nNieuwe technologieën reduceren vaak de energieconsumptie.
+      Als apparaten steeds groter worden helpt dat niet altijd. Computerschermen zijn
+      een stuk efficiënter geworden, maar ook een stuk groter en daardoor gebruiken
+      ze niet altijd minder energie dan de kleinere schermen van vroeger."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 400
   key: buildings_lighting_standard_fluorescent_electricity_share
   share_group: lighting_buildings
@@ -3527,6 +6087,33 @@
   slide_id: 119
   position: 1
   dependent_on:
+  description:
+    content_en: "What share of lighting in buildings comes from conventional fluorescent
+      tubes? This concerns all buildings that fall into categories like offices, hospitals,
+      swimming pools, restaurants, etc. \r\n<br/><br/>\r\nFluorescent tubes produce
+      light by sending an electric charge through a gas that is contained in the tube.
+      A typical fluorescent tube converts electricity into visible light 10 times
+      more efficiently than the traditional incandescent lamp still used in many homes.
+      The tubes are usually also more expensive, but the initial higher investment
+      costs are offset by its much longer lifetime and lower electricity use.\r\n<br/><br/>\r\nNot
+      all fluorescent tubes can be thrown away without danger of polluting the environment,
+      as they contain toxic substances such as mercury. LED-tubes do not. A fluorescent
+      tube's lifetime is shortened when its switched on and off very often."
+    content_nl: "Welk deel van verlichting in gebouwen komt van TL-buizen? Het gaat
+      hier om alle gebouwen waar niet in gewoond wordt, zoals kantoren, ziekenhuizen,
+      zwembaden, restaurants, etc. \r\n<br/><br/>\r\nTL-buizen produceren licht doordat
+      een elektrische lading door een gas wordt gestuurd dat in de buis zit. Het gas
+      gaat hierdoor licht geven. Een gemiddelde TL-buis zet elektriciteit 10 keer
+      zo efficiënt om in zichtbaar licht dan de traditionele gloeilamp die nog veel
+      in woonhuizen wordt gebruikt. TL-buizen zijn vaak ook duurder dan gloeilampen,
+      maar de aanschafkosten kunnen snel terugverdiend worden door de veel langere
+      levensduur en het verminderde elektriciteitsgebruik.\r\n<br/><br/>\r\nJe kunt
+      een TL-buis niet altijd weggooien zonder het milieu te vervuilen, omdat er vaak
+      kwik en andere schadelijke stoffen zoals kwik in zitten. LED-buizen hebben dit
+      probleem niet. Verder kunnen TL-buizen er niet goed tegen als ze heel vaak aan
+      en uitgezet worden."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 401
   key: buildings_lighting_efficient_fluorescent_electricity_share
   share_group: lighting_buildings
@@ -3550,6 +6137,40 @@
   slide_id: 119
   position: 2
   dependent_on:
+  description:
+    content_en: "What share of lighting in buildings comes from high performance fluorescent
+      tubes?\r\n<br/><br/>\r\nThere are many types of high performance fluorescent
+      tubes on the market. They sometimes are smaller and thinner than conventional
+      fluorescent tubes. More importantly they can be up to 50% more energy efficient,
+      have a longer lifetime and produce a better, more constant light that is easier
+      to work with compared to conventional fluorescent tubes that are still used
+      in most offices today.\r\n<br/><br/>\r\nFluorescent tubes produce light by sending
+      an electric charge through a gas that is contained in the tube. A typical fluorescent
+      tube converts electricity into visible light 10 times more efficiently than
+      the traditional incandescent lamp still used in many homes. The tubes are usually
+      also more expensive, but the initial higher investment costs are offset by its
+      much longer lifetime and lower electricity use.\r\n<br/><br/>\r\nNot all fluorescent
+      tubes can be thrown away without danger of polluting the environment, as they
+      contain toxic substances. LED-tubes do not. A Fluorescent tube's lifetime is
+      shortened when its switched on and off very often."
+    content_nl: "Welk deel van verlichting in gebouwen komt van hoge opbrengst TL-buizen?\r\n<br/><br/>\r\nEr
+      zijn veel verschillende soorten hoge opbrengst TL-buizen op de markt. Sommigen
+      hiervan zijn kleiner en dunner dan een conventionele TL-buis. Belangrijker is
+      dat ze tot de helft minder elektriciteit gebruiken dan traditionele TL-buizen.
+      De TL-buizen gaan ook veel langer mee en het licht is beter, waardoor het prettiger
+      is om eronder te werken.\r\n<br/><br/>\r\nTL-buizen produceren licht doordat
+      een elektrische lading door een gas wordt gestuurd dat in de buis zit. Het gas
+      gaat hierdoor licht geven. Een gemiddelde TL-buis zet elektriciteit 10 keer
+      zo efficiënt om in zichtbaar licht dan de traditionele gloeilamp die nog veel
+      in woonhuizen wordt gebruikt. TL-buizen zijn vaak ook duurder dan gloeilampen,
+      maar de aanschafkosten kunnen snel terugverdiend worden door de veel langere
+      levensduur en het verminderde elektriciteitsgebruik.\r\n<br/><br/>\r\nJe kunt
+      een TL-buis niet altijd weggooien zonder het milieu te vervuilen, omdat er vaak
+      kwik en andere schadelijke stoffen in zitten. LED-buizen hebben dit probleem
+      niet. Verder kunnen TL-buizen er niet goed tegen als ze heel vaak aan en uitgezet
+      worden."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 402
   key: buildings_lighting_led_electricity_share
   share_group: lighting_buildings
@@ -3573,6 +6194,31 @@
   slide_id: 119
   position: 3
   dependent_on:
+  description:
+    content_en: "What share of lighting comes from LED tubes?\r\n<br/><br/>\r\nLED
+      tubes are a number of Light Emitting Diodes (LEDs) combined into a form that
+      can be easily installed in standard lighting armatures currently used in offices,
+      schools and government buildings.\r\n<br/><br/>\r\nLED tubes are 50% more efficient
+      than conventional fluorescent tubes. Unlike fluorescent tubes, LED tubes can
+      be switched on and off often without decreasing their lifetime. Investment costs
+      for LED lighting are 5 to 50 times higher than for fluorescent tubes. However,
+      their longer life and lower elektricity use will in the end make the LED tube
+      cheaper. Their chief disadvantage at this moment is that they are not (yet)
+      optimally suited for evenly lighting up a room and producing enough light for
+      an office enviroment.\r\n"
+    content_nl: "Welk deel van de verlichting in gebouwen komt van LED buizen?\r\n<br/><br/>\r\nLED
+      buizen bestaan uit een aantal licht-emitterende diodes (LEDs, Engels: Light
+      Emitting Diode) die zo gemaakt zijn dat ze gebruikt kunnen worden in standaardarmaturen
+      voor TL-buizen.\r\n<br/><br/>\r\nLED buizen besparen circa 50% elektriciteit
+      ten opzichte van de traditionele TL-buizen. Anders dan bij TL-buizen kunnen
+      LED buizen zonder problemen aan en uitgezet zonder levensduurverlies. Investeringskosten
+      voor LED verlichting is 5 tot 50 keer hoger dan voor TL-buizen. Aan de andere
+      kant maakt hun langere levensduur en lagere elektriciteitsgebruik de LED buis
+      uiteindelijke goedkoper. Hun grootste nadeel op dit moment is dat ze (nog) niet
+      geschikt zijn om een ruimte egaal te verlichten of om genoeg licht te produceren
+      voor een kantooromgeving."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 403
   key: buildings_lighting_savings_from_motion_detection_light
   share_group: ''
@@ -3596,6 +6242,22 @@
   slide_id: 119
   position: 4
   dependent_on:
+  description:
+    content_en: "How many buildings will employ motion detection?\r\n<br/><br/>\r\nMotion
+      detection is a mechanism that 'sees' whether someone is in the room. As soon
+      as someone enters the room the light switches on automatically and once nobody
+      is left in the room the light will turn off automatically.\r\n<br/><br/>\r\nThis
+      type of energy saving measure limits the amount of time a light is on to the
+      minimum required. It prevents lights from being switched on uselessly at night
+      or during lunch breaks for example."
+    content_nl: "Hoe veel gebouwen gebruiken bewegingsdetectie?\r\n<br/><br/>\r\nBewegingsdetectie
+      is een technologie dit 'ziet' of er iemand in een ruimte is. Zodra iemand de
+      ruimte binnenkomt gaat het licht aan en zodra iedereen weer weg is gaat het
+      licht automatisch weer uit.\r\n<br/><br/>\r\nOp deze manier wordt dus de tijd
+      dat een licht aanstaat verminderd tot het minimum. Het zorgt er bijvoorbeeld
+      voor dat lichten niet 's nachts of tijdens de lunch voor niets aan staan."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 404
   key: buildings_lighting_savings_from_daylight_control_light
   share_group: ''
@@ -3619,6 +6281,28 @@
   slide_id: 119
   position: 5
   dependent_on:
+  description:
+    content_en: "How many buildings use daylight-dependent control?\r\n<br/><br/>\r\nDaylight-dependent
+      control is a mechanism that varies the amount of light from lamps in a room
+      by the light that comes from outside. If the sun is shining and it is already
+      light in the room it will switch off or dim the lights automatically. But if
+      it is dark or cloudy the system will make sure that the lamps in the room give
+      of enough light to work.\r\n<br/><br/>\r\nThis technology ensures that lights
+      are not on needlessly if there is already enough light coming from outside.
+      In combination with a motion detection system the lights will only be on when
+      someone is in the office and there is not enough light coming in from outside."
+    content_nl: "In hoeveel gebouwen wordt daglicht afhankelijke regeling toegepast?\r\n<br/><br/>\r\nDaglicht
+      afhankelijke regeling is een technologie die aan de hand van de hoeveelheid
+      (dag)licht in een ruimte de lichtsterkte van de verlichting aanpast. Als de
+      zon schijnt en het is licht genoeg in een ruimte staat het licht niet aan, of
+      gedimd. Maar als het donker is of bewolkt past het systeem de verlichting zo
+      aan dat er toch genoeg licht is om te werken.\r\n<br/><br/>\r\nDeze technologie
+      zorgt er dus voor dat lichten niet nutteloos aanstaan omdat er al genoeg licht
+      van buiten komt. In combinatie met bewegingsdetectie kan er voor gezorgd worden
+      dat de lichten alleen aan staan als er mensen binnen in de ruimte zijn en er
+      niet al genoeg licht van buiten is."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 405
   key: buildings_solar_pv_solar_radiation_market_penetration
   share_group: ''
@@ -3642,6 +6326,34 @@
   slide_id: 121
   position: 1
   dependent_on: ''
+  description:
+    content_en: "Solar cells transform sunlight into electricity. These solar panels
+      are mostly installed on rooftops. This technology is developing rapidly and
+      solar panels are becoming ever more efficient and cheaper. Solar panels are
+      expected to become much cheaper in the coming 40 years.\r\n<br/><br/>\r\nSolar
+      panels produce electricity on site, so transport of electricity is not always
+      required. This avoids losses on the grid and that saves energy. Feeding locally
+      produced power back into the local power grid requires a higher capacity or
+      smarter local grid, to prevent it from overloading. \r\n<br/><br/>\r\nIn the
+      ETM solar PV panels have 867 full load hours by default. Because of technological
+      developments it is likely that future solar PV panels may produce more electricity
+      per installed capacity than today. You can adjust the full load hours of solar
+      panels <a href=\"/scenario/supply/electricity_renewable/solar-power\" >here</a>\r\n</br>"
+    content_nl: "Zonnecellen zetten licht om in elektriciteit. Deze zonnepanelen liggen
+      meestal op het dak. Deze technologie is nog volop in ontwikkeling en zonnepanelen
+      worden steeds efficiënter en goedkoper. Verwacht wordt dat zonnecellen de komende
+      40 jaar veel goedkoper zullen worden. Zie hiervoor ook de 'Expert voorspellingen'
+      in het Kosten hoofdstuk.\r\n<br/><br/>\r\nZonnepanelen produceren stroom op
+      de plek waar het gebruikt wordt en dus is het niet altijd nodig om de elektriciteit
+      te transporteren over het elektriciteitsnet. Zo worden netwerkverliezen vermeden
+      en energie bespaard. Stroom die niet wordt gebruikt kan aan het lokale netwerk
+      worden teruggeleverd. \r\n<br/><br/>\r\nIn het ETM heeft een zonnepaneel standaard
+      867 vollasturen. Het is aannemelijk dat toekomstige zonnepanelen meer elektriciteit
+      zullen produceren per geïnstalleerd vermogen dan nu. Je kunt het aantal vollasturen
+      voor zonnepanelen <a href=\"/scenario/supply/electricity_renewable/solar-power\"
+      >hier</a> aanpassen.\r\n</br>"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 406
   key: buildings_space_heater_wood_pellets_share
   share_group: heating_buildings
@@ -3665,6 +6377,22 @@
   slide_id: 115
   position: 8
   dependent_on: ''
+  description:
+    content_en: "What percentage of heat demand in offices and other buildings is
+      met by biomass-firing? Biomass heaters are especially suited for larger office
+      parks with large heat demands, as this allows transport of biomass to be concentrated.
+      That way (fossil) transport fuel use can be minimalized.\r\n<br/><br/>\r\nThe
+      mix you fill in here is probably mostly determined by fuel prices and environmental
+      legislation. "
+    content_nl: "Welk percentage van de warmtevraag in kantoren en andere gebouwen
+      wordt ingevuld door biomassa? Biomassaketels zijn goed geschikt voor relatief
+      grotere bedrijfscomplexen met grote warmtevraag, omdat op die manier het transport
+      geconcentreerd kan worden en dat spaart weer transportbrandstoffen. <br/><br/>\r\nDe
+      brandstofmix die je hier invult zal waarschijnlijk het meest afhangen van je
+      verwachtingen voor brandstofprijzen. Zie ook het onder deel 'Kosten'. Andere
+      relevante invloeden zijn milieuwetten. "
+    short_content_en: ''
+    short_content_nl: ''
 - id: 408
   key: buildings_useful_demand_cooling
   share_group: ''
@@ -3688,6 +6416,23 @@
   slide_id: 113
   position: 4
   dependent_on:
+  description:
+    content_en: "Note: these changes in energy use <strong>exclude</strong> the use
+      of the efficient technologies that you can choose below (Heating & Cooling).
+      \r\n<br/>\r\n<br/>\r\nHere you indicate how you expect cooling demand per building
+      to change. This is likely to change as buildings become ever more filled with
+      electric appliances producing heat. In fact, especially offices need cooling
+      for more hours per year than before everyone started using computers, copiers,
+      faxes and printers. "
+    content_nl: "Let op: deze verandering van energiegebruik is <strong>exclusief</strong>
+      de efficiëntere technologieën die je in dit gedeelte kunt kiezen (Verwarming
+      & Koeling).\r\n<br/>\r\n<br/>\r\nHier kun je aangeven hoe jij denkt dat de vraag
+      naar koeling per gebouw zich gaat ontwikkelen. Dit verandert onder meer doordat
+      gebouwen steeds voller komen te staan met elektrische apparaten die warmte produceren.
+      Het is zelfs zo dat gebouwen steeds meer uren per jaar gekoeld moeten worden
+      dan voordat iedereen ging werken met computers, faxen, kopieerapparaten en printers."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 409
   key: buildings_space_heater_crude_oil_share
   share_group: heating_buildings
@@ -3711,6 +6456,21 @@
   slide_id: 115
   position: 7
   dependent_on: has_coal_oil_for_heating_built_environment
+  description:
+    content_en: This shows what part of heating is produced by oil-fired heaters.
+      These are still quite common in many countries. Their advantage is that under
+      normal circumstances fuel oil burns slowly and completely, producing no air
+      pollutants other than CO<sub>2</sub>. A considerable disadvantage is the fact
+      that oil tanks tend to start leaking after a few decades and this can cause
+      significant pollution of soil and drinking water.
+    content_nl: Hier zie je welk deel van de verwarming door oliegestookte ketels
+      wordt ingevuld. Deze hebben als voordeel dat onder normale omstandigheden de
+      stookolie langzaam en volledig verbrandt, waardoor geen luchtvervuiling wordt
+      geproduceerd (behalve CO<sub>2</sub>). Een groot nadeel is dat de olietanks
+      na een paar decennia in de grond vaak gaan lekken en daarbij behoorlijke schade
+      kunnen doen aan het milieu of de kwaliteit van het drinkwater.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 411
   key: households_heater_coal_share
   share_group: heating_households
@@ -3734,6 +6494,16 @@
   slide_id: 4
   position: 12
   dependent_on: has_coal_oil_for_heating_built_environment
+  description:
+    content_en: "What percentage of heating demand in households is met by coal-firing?
+      \r\n<br/><br/>The mix you fill in here is probably mostly determined by fuel
+      prices and environmental legislation."
+    content_nl: "Welk percentage van de huishoudelijke warmtevraag wordt ingevuld
+      door kolen? \r\n<br/><br/>\r\nDe brandstofmix die je hier invult zal waarschijnlijk
+      het meest afhangen van je verwachtingen voor brandstofprijzen. Zie ook het onder
+      deel 'Kosten'. Andere relevante invloeden zijn milieuwetten."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 412
   key: households_appliances_other_electricity_efficiency
   share_group: ''
@@ -3757,6 +6527,16 @@
   slide_id: 3
   position: 8
   dependent_on:
+  description:
+    content_en: "How much more efficient do you think other appliances will be in
+      the future?\r\n<br/><br/>\r\nThis category includes: <br/>\r\nPersonal care
+      <br/>\r\nLeisure <br/>\r\nKitchenware (exclusive of cooking) <br/>\r\nVentilation"
+    content_nl: "Hoeveel efficiënter zullen andere huishoudelijke apparaten in de
+      toekomst zijn? \r\n<br/><br/>\r\nDeze categorie omvat:<br/>\r\nPersoonlijke
+      verzorging <br/>\r\nVrije tijd (klus gereedschap, naaimachine, elektrisch speelgoed,
+      etc.) <br/>\r\nKeukenapparatuur (exclusief koken) <br/>\r\nVentilatie"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 413
   key: capacity_of_energy_power_nuclear_gen2_uranium_oxide
   share_group: ''
@@ -3780,6 +6560,19 @@
   slide_id: 48
   position: 2
   dependent_on: has_old_technologies
+  description:
+    content_en: "This builds nuclear power plants of an older type of nuclear power
+      plant. In reality, these plants will not be built anymore and are included mainly
+      to show the difference between modern nuclear plants and older types.<br/>\r\nIf
+      you want to build nuclear power plants, please build the modern type of plant.
+      The capacity is converted to plants of 1,650 MWe.\r\n<br/><br/> \r\n"
+    content_nl: "Hiermee bouw je kerncentrales van een ouder type. Deze zullen in
+      de praktijk niet meer gebouwd worden en staan hier vooral om het verschil te
+      tonen met de moderne 3e generatie centrales. <br/>\r\nAls je kerncentrales wilt
+      bouwen, bouw dan een moderne 3e generatie kerncentrale. De capaciteit wordt
+      omgezet in centrales van 1.650 MWe.\r\n<br/><br/>\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 416
   key: capacity_of_energy_power_combined_cycle_ccs_network_gas
   share_group: ''
@@ -3803,6 +6596,26 @@
   slide_id: 46
   position: 2
   dependent_on: ''
+  description:
+    content_en: "The same gas-fired plant as above. This one uses capture and storage
+      of most of the produced CO<sub>2</sub>. This technology is called 'Carbon Capture
+      and Storage' (CCS). Because CCS costs energy, this power plant has a lower effective
+      production capacity than a standard CCGT power plant. To make the same amount
+      of electricity, more fuel is burnt.\r\n<br/><br/>\r\nFlexible gas-fired plants
+      are often used for meeting daily electricity demand peaks and therefore produce
+      less electricity per year than coal-fired plants of the same production capacity.
+      A CCS plant is less flexible than its non-CCS counterpart."
+    content_nl: "Dezelfde soort gascentrale als hierboven (STEG). Deze past daarnaast
+      ook afvang en opslag van de meeste geproduceerde CO<sub>2</sub> toe. Deze technologie
+      wordt 'Carbon Capture and Storage' (CCS) genoemd. Deze centrale heeft niet hetzelfde
+      productievermogen als een gewone STEG centrale, omdat CCS energie kost. Er wordt
+      dus meer gas verbrand om dezelfde hoeveelheid stroom te maken.\r\n\r\n<br/><br/>\r\n\r\nGascentrales
+      zijn flexibel en worden daarom vaak ingezet om dagelijkse pieken in de elektriciteitsvraag
+      op te vangen (vooral gasturbines) en daarom produceren ze minder stroom per
+      jaar dan kolencentrales met een vergelijkbaar vermogen. CCS centrales zijn minder
+      flexibel dan hun niet-CCS 'soortgenoten'."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 422
   key: capacity_of_energy_chp_ultra_supercritical_lignite
   share_group: ''
@@ -3826,6 +6639,15 @@
   slide_id: 45
   position: 9
   dependent_on: has_lignite
+  description:
+    content_en: "This indicates the capacity of large central lignite-fired power
+      plants are used to supply heat to district heating grids. The power generated
+      is shown in the graph on the right as coal-fired electricity production.\r\n<br/><br/> "
+    content_nl: 'Hier stel je in je hoeveel grote bruinkoolcentrales warmte leveren
+      aan stadsverwarming en andere ''laagwaardige warmte'' netwerken. De stroom die
+      wordt opgewekt zie je op de grafiek terug als kolenstroom. '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 423
   key: transport_plane_using_kerosene_share
   share_group: transport_aviation
@@ -3849,6 +6671,14 @@
   slide_id: 123
   position: 1
   dependent_on: ''
+  description:
+    content_en: 'Fossil fuels for aviation can be several, but the bulk of it is kerosene,
+      which is used for all large aircraft. '
+    content_nl: 'Er zijn verschillende fossiele brandstoffen om op te vliegen, maar
+      verreweg het grootste volume bestaat uit kerosine. Alle grote vliegtuigen vliegen
+      op kerosine. '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 424
   key: transport_plane_using_bio_ethanol_share
   share_group: transport_aviation
@@ -3872,6 +6702,21 @@
   slide_id: 123
   position: 3
   dependent_on: ''
+  description:
+    content_en: "Bio-based aviation fuels are still in an experimental stage. Transatlantic
+      flights have been completed successfully, during which one of four (or more)
+      engines used a bio-diesel. Since airplanes need so much high-energy fuel, it
+      remains to be seen whether such bio-fuels can ever make a large dent in the
+      fossil fuel use. \r\n<br/><br/>\r\nSee the <a href=\"https://github.com/quintel/etdataset-public/tree/master/carriers_source_analyses\">documentation
+      on GitHub</a> for more information on the numbers used."
+    content_nl: "Biobrandstoffen voor vliegtuigen bevinden zich nog in een experimenteel
+      stadium. Er zijn transatlantische vluchten uitgevoerd, waarbij één van de vier
+      motoren van het vliegtuig op biodiesel draaide. Aangezien vliegtuigen zeer veel
+      hoog-energetische brandstof nodig hebben, is het de vraag of biobrandstoffen
+      ooit significant zullen bijdragen.\r\n<br/><br/>\r\nZie onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/carriers_source_analyses\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 427
   key: transport_passenger_train_using_coal_share
   share_group: transport_passenger_train_tech
@@ -3895,6 +6740,21 @@
   slide_id: 125
   position: 3
   dependent_on: ''
+  description:
+    content_en: "Coal-powered trains are a bit of a relic, but still common in some
+      less developed regions of the world. Almost everywhere, coal-powered trains
+      can be replaced by diesel-powered ones, as these are more fuel-efficient and
+      much cleaner. \r\n\r\n<br/>\r\n<br/>\r\nLess developed countries with abundant
+      coal supplies may choose to use coal-powered trains to reduce their dependence
+      on foreign energy sources."
+    content_nl: "Kolentreinen zijn nogal ouderwets, maar in minder ontwikkelde delen
+      van de wereld komen ze nog veel voor. Bijna overal is het aantrekkelijk om deze
+      te vervangen door dieseltreinen, omdat die minder energie gebruiken en schoner
+      zijn.\r\n<br/>\r\n<br/>\r\nMinder ontwikkelde landen met grote kolenvoorraden
+      zouden kunnen kiezen om treinen op kolen te laten rijden om zo hun afhankelijkheid
+      van buitenlandse energiebronnen te verlagen."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 428
   key: transport_passenger_train_using_diesel_mix_share
   share_group: transport_passenger_train_tech
@@ -3918,6 +6778,18 @@
   slide_id: 125
   position: 2
   dependent_on: ''
+  description:
+    content_en: 'Diesel-powered trains are not uncommon as they do not rely on expensive
+      electricity infrastructure. They are ideal for very remote and sparsely populated
+      regions. Because Europe is a patchwork of differing standards for powerlines,
+      electric trains often cannot cross borders in Europe. '
+    content_nl: Dieseltreinen komen nog redelijk veel voor, omdat ze niet afhankelijk
+      zijn van een dure elektrische infrastructuur. Ze zijn zeer geschikt voor afgelegen
+      en dunbevolkte gebieden. Omdat Europa nog een lappendeken van standaarden is
+      voor elektrische bovenleidingen, kunnen elektrische treinen vaak niet probleemloos
+      nationale grenzen passeren.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 429
   key: transport_passenger_train_using_electricity_share
   share_group: transport_passenger_train_tech
@@ -3941,6 +6813,17 @@
   slide_id: 125
   position: 1
   dependent_on: ''
+  description:
+    content_en: Electric trains are the standard in all developed regions of the world.
+      They are a very energy efficient and rather clean form of transport. They are
+      not particularly flexible of course, and rely on expensive electric infrastructure,
+      so they will never fully replace diesel trains.
+    content_nl: Elektrische treinen zijn de standaard in alle ontwikkelde gebieden
+      in de wereld. Ze zijn zeer energie-efficiënt en schoon, maar niet erg flexibel.
+      Bovendien zijn ze afhankelijk van dure elektrische infrastructuur en daarom
+      zullen ze nooit volledig de dieseltrein vervangen.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 436
   key: households_cooker_wood_pellets_share
   share_group: cooking
@@ -3964,6 +6847,24 @@
   slide_id: 109
   position: 5
   dependent_on: ''
+  description:
+    content_en: "Cooking on biomass includes different fuels and technologies, among
+      which wood, wood pallets, bio-gas and bio-oil. Old fashioned wood stoves have
+      a very low efficiency for cooking. The efficiency of the biomass stove in the
+      Energy Transition Model is 30% and is lower than the natural gas and electric
+      alternatives since a lot of heat is lost to the environment. \r\n<br/><br/>\r\nOnly
+      the costs due to the difference in energy demand are considered. The costs of
+      the stove are not taken into account in the Energy Transition Model."
+    content_nl: "Onder koken op biomassa vallen verschillende brandstoffen en technologiën
+      zoals hout, hout pallets, bio-gas en bio-olie. Ouderwetse hout fornuizen hebben
+      een lage efficiëntie voor koken. De efficiëntie van het biomassa fornuis in
+      het Energietransitiemodel is 30%. Dat is lager dan de efficiëntie van aardgas
+      en electrische alternatieven omdat veel warmte verloren gaat naar de omgeving.
+      \r\n<br/><br/>\r\nUitsluitend de kosten door het verschil in energievraag worden
+      meegenomen. De kosten van het kooktoestel zelf worden niet meegenomen in het
+      Energietransitiemodel.\r\n \r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 441
   key: households_heater_network_gas_share
   share_group: heating_households
@@ -3987,6 +6888,15 @@
   slide_id: 4
   position: 10
   dependent_on: ''
+  description:
+    content_en: These are the same heaters as the "Condensing combi boiler", except
+      that they do not produce hot water, but only heat for a central heating systems.
+      This makes them on average a little more efficient than their 'combi' counterparts.
+    content_nl: 'Dit zijn dezelfde ketels als de "HR combiketels", behalve dat ze
+      geen warm water maken, maar alleen warmte voor de centrale verwarming. Hierdoor
+      zijn deze apparaten een beetje efficiënter dan de combiketels. '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 488
   key: green_gas_total_share
   share_group: fuels_gas
@@ -4010,6 +6920,19 @@
   slide_id: 49
   position: 2
   dependent_on: ''
+  description:
+    content_en: This slider sets the percentage of green gas in the gas network. Green
+      gas is conventionally produced by bacteria that digest biological material with
+      an upgrading step to natural gas quality. In the future green gas can also be
+      produced through gasification, which can be chosen in <a href="/scenario/supply/biomass/greengas-production">green
+      gas production</a>.
+    content_nl: Dit schuifje stelt in hoeveel van het totale gasgebruik groen is.
+      Groengas wordt gewoonlijk gemaakt door bacterieën die biologisch materiaal verteren
+      met daarna een opwerkingsstap tot aardgaskwaliteit. In de toekomst wordt groengas
+      mogelijk ook gemaakt door biomassa te vergassen, deze technologie is in te stellen
+      bij <a href="/scenario/supply/biomass/greengas-production">groengasproductie</a>.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 489
   key: natural_gas_total_share
   share_group: fuels_gas
@@ -4033,6 +6956,18 @@
   slide_id: 49
   position: 1
   dependent_on:
+  description:
+    content_en: "This slider sets the percentage of all gas used is natural gas. Natural
+      gas is a relatively clean fossil fuel that is mostly used to generate heat and
+      electricity. It is hardly used as a transport fuel yet.\r\n\r\n<br/>Apart from
+      CO<sub>2</sub> emissions gas combustion also tends to produce NO<sub>x</sub>."
+    content_nl: "Dit schuifje stelt in welk percentage van alle gasgebruik aardgas
+      is. Aardgas is een relatief schone fossiele brandstof die vooral wordt gebruikt
+      om warmte en elektriciteit te maken. Het wordt nog maar weinig voor transport
+      ingezet.\r\n<br/>Naast CO<sub>2</sub> leidt de verbranding van gas ook vaak
+      tot uitstoot van NO<sub>x</sub>."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 549
   key: buildings_cooling_collective_cooling_network_electricity_share
   share_group: cooling_buildings
@@ -4056,6 +6991,24 @@
   slide_id: 116
   position: 4
   dependent_on: has_cold_network
+  description:
+    content_en: A cooling network can use different sources of cold, like thermal
+      storage and deep lakes. In the ETM cold from deep lakes is used in the cooling
+      network to cool buildings. Lakes of 25 meters depth or deeper can be used for
+      this type of cooling. Water from the lake is pumped through a heat exchanger,
+      taking the cold from the water and using it to cool one or more buildings. Because
+      the cold stored in a lake goes down drastically during summer the year round
+      capacity of deep lakes is small.
+    content_nl: 'Een koudenetwerk kan gebruik maken van verschillende bronnen zoals
+      Warmte-koude opslag en diepe meren. In het ETM wordt met het koudenetwerk het
+      gebruik van koude uit diepe meren voor ruimtekoeling in gebouwen bedoeld. Meren
+      van 25 meter diepte of meer kunnen hiervoor gebruikt worden. Water wordt rondgepompd
+      en met behulp van een warmtewisselaar wordt de koude uit het water onttrokken
+      en in het koelingssysteem van een aantal gebouwen ingevoerd. Omdat ''s zomers
+      de hoeveelheid koude opgeslagen in een meer significant afneemt hebben meren
+      slechts een beperkte capaciteit over het jaar genomen. '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 551
   key: capacity_of_energy_chp_ultra_supercritical_coal
   share_group: ''
@@ -4079,6 +7032,20 @@
   slide_id: 45
   position: 10
   dependent_on: ''
+  description:
+    content_en: "Large ultra-supercritical pulverized coal-fired CHP plant. \r\nSuch
+      plants are identical to a common coal plant, except that it also supplies heat
+      to large heating grids. This comes at the expense of some power production.
+      \r\n \r\n\r\n\r\n"
+    content_nl: "Grote ultra-superkritische poederkolen WKK centrale. Deze centrale
+      is hetzelfde als de elektriciteitscentrale, behalve dat bij deze ook warmte
+      wordt afgetapt voor het centrale warmtenet. \r\n<br/><br/> \r\nDe Amercentrale
+      in Geertruidenberg bijvoorbeeld voedt het warmtenet voor Tilburg en Breda. Warmtelevering
+      in een dergelijke centrale gaat iets ten koste van de elektriciteitsproductie.
+      Afgezet tegen de totale kosten van een kolencentrale zijn de extra investeringen
+      in warmteuitkoppeling beperkt."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 559
   key: co_firing_biocoal_share
   share_group: coal_plant_fuel
@@ -4102,6 +7069,16 @@
   slide_id: 140
   position: 2
   dependent_on: ''
+  description:
+    content_en: 'Bio-coal is a fuel with properties sufficiently similar to coal that
+      it be used as a substitute. It is made by torrefaction of woody biomass. Torrefaction
+      of biomass occurs at temperatures of several hundred &#8451; in the absence
+      of oxygen.  '
+    content_nl: 'Biokolen is een brandstof die zoveel op kolen lijkt dat het kolen
+      kan vervangen. Het wordt gemaakt door torrefactie van houtachtige biomassa.
+      Bij torrefactie wordt biomassa verhit tot honderden &#8451; zonder zuurstof. '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 560
   key: co_firing_coal_share
   share_group: coal_plant_fuel
@@ -4125,6 +7102,15 @@
   slide_id: 140
   position: 1
   dependent_on: ''
+  description:
+    content_en: Coal is the most CO<sub>2</sub> intensive of all fossil fuels. For
+      that reason, governments promote and subsidize replacing a part of coal for
+      electricity production by biomass alternatives.
+    content_nl: Kolenverbranding stoot van alle fossiele brandstoffen het meeste CO<sub>2</sub>
+      uit. Daarom subsidiëren veel regeringen het vervangen van kolen in elektriciteitscentrales
+      door biomassa.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 561
   key: energy_mixer_for_gas_power_fuel_natural_gas_share
   share_group: energy_sector_gas
@@ -4148,6 +7134,15 @@
   slide_id: 140
   position: 3
   dependent_on: ''
+  description:
+    content_en: "Gas-fired power plants obtain their gas from the gas mains, of course.
+      Some of this gas may be green gas, if you have set this to be the case. \r\n<br/>\r\nAlternatively,
+      gas-fired plants can co-fire oil and bio-oil."
+    content_nl: "Gascentrales halen hun gas natuurlijk uit het gasnet. Een deel hiervan
+      is mogelijk groengas als je dat hierboven hebt ingesteld.\r\n<br/>\r\nAls alternatief
+      kunnen deze centrales ook olie en bio-olie bijstoken."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 562
   key: energy_import_steam_hot_water_preset_demands
   share_group: ''
@@ -4171,6 +7166,11 @@
   slide_id:
   position: 9
   dependent_on: has_heat_import
+  description:
+    content_en: ''
+    content_nl: ''
+    short_content_en:
+    short_content_nl:
 - id: 563
   key: coal_from_south_africa_share
   share_group: coal_lce
@@ -4194,6 +7194,17 @@
   slide_id: 143
   position: 1
   dependent_on:
+  description:
+    content_en: 'In South Africa both opencast and underground mining are being applied.
+      The emissions for treating the coal are relatively low. Recent studies have
+      revealed, however, that the mining sites are heavily polluting the surrounding
+      environment. '
+    content_nl: In Zuid-Afrika zijn er beide bovengronds en ondergrondse mijnen. Voor
+      behandeling van de kolen zijn de broeikasgasemissies relatief laag. Uit recente
+      studies en een Nederlandse documentaire, komt echter naar voren dat Zuid-Afrikaanse
+      mijnen zware vervuiling veroorzaken in hun omgeving.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 564
   key: coal_from_north_america_share
   share_group: coal_lce
@@ -4217,6 +7228,20 @@
   slide_id: 143
   position: 2
   dependent_on:
+  description:
+    content_en: Over 50% of mines in North America use opencast mining. Especially
+      in the Appalachian a lot of coal is being produced, where mountain tops are
+      being dug off. Open cast mining has lower mine gas (methane, a greenhouse gas)
+      emissions than underground mining. A common problem is the pollution of the
+      surroundings of the mine, caused by ‘Acid Mine Drainage’.
+    content_nl: Meer dan de helft van de kolen uit Noord-Amerika worden bovengronds
+      gewonnen. Met name in het berggebied de Appalachen worden veel kolen geproduceerd,
+      waar hele bergtoppen worden afgegraven. Bovengrondse mijnen hebben veel lagere
+      mijngasemissies (methaan, een broeikasgas) ten opzichte van ondergrondse mijnen.
+      Een probleem in Noord-Amerika is wel de vervuiling van de omgeving van de mijn
+      door ‘Acid Mine Drainage’.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 565
   key: coal_from_australia_share
   share_group: coal_lce
@@ -4240,6 +7265,19 @@
   slide_id: 143
   position: 3
   dependent_on:
+  description:
+    content_en: In Australia most coal is produced from opencast mines. The underground
+      mines, have a relatively high level of mine gas (methane, a greenhouse gas),
+      of which about 50% is released into the air. Environmental policy in Australia
+      is comparable to the EU, which implies that the environmental damage caused
+      is relatively limited.
+    content_nl: In Australië worden de meeste kolen bovengronds geproduceerd. Uit
+      de ondergrondse kolenlagen, komt relatief veel mijngas (methaan, een broeikasgas)
+      vrij, waarvan ongeveer de helft in de lucht terechtkomt. Milieuregels zijn in
+      Australië van een vergelijkbaar niveau als in de EU, waardoor de verdere milieuschade
+      van de mijnen beperkt is.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 566
   key: coal_from_eastern_europe_share
   share_group: coal_lce
@@ -4263,6 +7301,20 @@
   slide_id: 143
   position: 4
   dependent_on:
+  description:
+    content_en: Poland is one of the few European countries that still produce coal.
+      The greenhouse gas emissions for mining are relatively high, because a lot of
+      mine gas is present (methane, a greenhouse gas) of which about 50% is released
+      into the air. Although Poland is relatively nearby, transport emissions are
+      high, because transportation by train is less energy efficient per tonne of
+      coal than transportation by large ships.
+    content_nl: Polen produceert en exporteert als één van de weinige landen in Europa
+      nog kolen. De ondergrondse kolenlagen bevatten relatief veel mijngas (methaan,
+      een broeikasgas) waarvan ongeveer de helft in de lucht terechtkomt. Ook al is
+      Polen relatief dichtbij, de transportemissies zijn relatief hoog, doordat transport
+      per trein minder energie efficiënt is per ton kolen dan per oceaanschip.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 567
   key: coal_from_russia_share
   share_group: coal_lce
@@ -4286,6 +7338,19 @@
   slide_id: 143
   position: 5
   dependent_on:
+  description:
+    content_en: In Russia the emissions for mining are relative high. Most mining
+      is done underground, where a lot of mine gas is present (methane, a greenhouse
+      gas) of which about 50% is released into the air. Also the treatment step has
+      relatively high emissions. In Russia environmental policies are not enforced
+      much and the mines pollute their environment.
+    content_nl: 'Rusland heeft relatief hoge broeikasgasemissies voor de kolenmijnbouw.
+      De ondergrondse kolenlagen bevatten veel mijngas (methaan, een broeikasgas),
+      waarvan ongeveer de helft wordt afgevangen. Ook de bewerkingsfase geeft relatief
+      veel emissies. In Rusland wordt er niet streng toegezien op milieuregels, waardoor
+      de mijnen hun omgeving kunnen vervuilen.   '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 568
   key: coal_from_south_america_share
   share_group: coal_lce
@@ -4309,6 +7374,20 @@
   slide_id: 143
   position: 6
   dependent_on:
+  description:
+    content_en: Coal from South America comes mostly from Colombia. The main method
+      is underground mining and the coal layer contains relatively low amounts of
+      mine gas (methane, a greenhouse gas), of which about 50% is released into the
+      air. The coal is transported efficiently with large ships. Environmental policy
+      in Colombia is not enforced, which means Colombian mines pollute their surroundings.
+    content_nl: 'Kolen uit Zuid-Amerika worden met name in Colombia geproduceerd.
+      De mijnen bevinden zich meestal ondergronds, en de kolenlagen bevatten relatief
+      weinig mijngas (methaan, een broeikasgas) waarvan ongeveer de helft in de lucht
+      terecht komt. De kolen worden efficiënt getransporteerd in grote schepen. In
+      Colombia wordt niet toegezien op milieuregels waardoor de mijnen vervuilend
+      zijn voor de omgeving. '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 569
   key: coal_from_east_asia_share
   share_group: coal_lce
@@ -4332,6 +7411,19 @@
   slide_id: 143
   position: 7
   dependent_on:
+  description:
+    content_en: Coal mines in Asia are mainly underground. Until recently China was
+      an exporting country for coal, but nowadays uses all produced coal itself. Coal
+      is being imported mainly from Indonesia where environmental policies are enforced
+      only weakly. East Asia has relatively low mine gas emissions (methane, a greenhouse
+      gas).
+    content_nl: In Azië zijn de meeste kolenmijnen ondergronds. China was tot voor
+      kort een kolenexporterend land, maar tegenwoordig gebruikt het al zijn geproduceerde
+      kolen zelf. Kolen uit Azië komen voornamelijk uit Indonesië, waar milieuregels
+      zeer beperkt worden nageleefd met vervuiling tot gevolg. Azië heeft relatief
+      lage mijngas emissies (methaan, een broeikasgas).
+    short_content_en: ''
+    short_content_nl: ''
 - id: 571
   key: gas_from_nederlands_share
   share_group: gas_lce
@@ -4355,6 +7447,19 @@
   slide_id: 144
   position: 2
   dependent_on: ''
+  description:
+    content_en: 'The fuel chain of Dutch natural gas involves relatively little energy
+      use for transport and low leakage from the grid. Production of natural gas is
+      also relatively clean and energy efficient, as a result of energy saving measures
+      by the mining sector. Conventional gas reserves are expected to be depleted
+      by 2040. '
+    content_nl: In de keten wordt voor Nederlands aardgas uiteraard weinig energie
+      gebruikt voor transport en zijn er weinig verliezen uit het net. De winning
+      van Nederlands aardgas is relatief efficiënt en schoon, als gevolg van energiebesparingsinitiatieven
+      van de sector. Toch verwacht Energie Beheer Nederland (EBN) dat het conventionele
+      Nederlandse aardgas voor 2040 opraakt.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 572
   key: gas_from_russia_share
   share_group: gas_lce
@@ -4378,6 +7483,17 @@
   slide_id: 144
   position: 4
   dependent_on: ''
+  description:
+    content_en: Transport of Russian natural gas in pipelines is relatively energy
+      intensive, because transport distances are so large. Recompression of gas in
+      pipelines costs energy, but also leads to leakage caused by the relatively poor
+      state of compression stations.
+    content_nl: 'Russisch aardgas wordt over enorme afstanden in pijpleidingen getransporteerd
+      en dat kost de nodige energie. Recompressie van het gas in de pijpleidingen
+      kost ook energie en leidt daarnaast tot lekkage. De compressiestations verkeren
+      namelijk in vrij slechte staat. '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 575
   key: gas_from_norway_share
   share_group: gas_lce
@@ -4401,6 +7517,16 @@
   slide_id: 144
   position: 3
   dependent_on: ''
+  description:
+    content_en: Norwegian natural gas has to cover larger distances than Dutch natural
+      gas, so more energy use and subsequent CO<sub>2</sub> emissions occur during
+      transport. Because of strict environmental legislation, production and treatment
+      of the gas are relatively efficient.
+    content_nl: De ketenemissies voor Noors aardgas zijn wat hoger op transport, doordat
+      de afstanden groter zijn. Vanwege strikte milieuwetgeving is de winning en de
+      bewerking van het aardgas relatief efficiënt.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 576
   key: gas_from_algeria_share
   share_group: gas_lce
@@ -4424,6 +7550,18 @@
   slide_id: 144
   position: 1
   dependent_on: ''
+  description:
+    content_en: Algerian natural gas is transported by pipeline through the Mediterranean.
+      Since there are no recompression stations on the sea floor, the pressure has
+      to be extra high for the gas to make it across. This means high energy use and
+      subsequent CO2 emissions for transport.
+    content_nl: Het aardgas uit Algerije wordt met een pijpleiding naar Europa gebracht
+      over de bodem van de Middellandse zee. Aangezien op de zeebodem geen recompressie
+      stations staan, moet de druk extra hoog zijn om ervoor te zorgen dat het gas
+      de overkant haalt. Dat betekent een hoog energiegebruik en bijbehorende CO2
+      uitstoot voor transport van het gas.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 578
   key: uranium_from_kazachstan_share
   share_group: nuclear_lce
@@ -4447,6 +7585,20 @@
   slide_id: 146
   position: 1
   dependent_on:
+  description:
+    content_en: Kazakhstan currently supplies the uranium used in the Borssele nuclear
+      power plant. The main mining method is in-situ leaching, which reduces the amounts
+      of low-level radioactive rock waste, but is associated with ground water acidification.
+      Kazakh mining companies are relatively untransparent, making it difficult to
+      assess environmental and safety issues.
+    content_nl: Kazachstan levert de uranium voor de kerncentrale in Borssele. Uranium
+      wordt vooral gewonnen door het ondergronds op te lossen ('in-situ leaching').
+      Hierbij wordt weinig afval geproduceerd, maar het grondwater verzuurt er wel
+      door.  Hoe mijnbouwbedrijven uit Kazachstan werken is niet   erg transparant,
+      dat maakt het lastig om te bepalen hoe ze presteren op het gebied van milieu
+      en veiligheid.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 579
   key: uranium_from_australia_share
   share_group: nuclear_lce
@@ -4470,6 +7622,17 @@
   slide_id: 146
   position: 2
   dependent_on:
+  description:
+    content_en: Australia is currently the third largest uranium-producing country.
+      Australian mining companies employ a variety of mining methods and are considered
+      relatively clean. Transportation distances are large, and Australian mining
+      companies use relatively high amounts of energy per tonne of uranium ore.
+    content_nl: Australië is momenteel de derde uraniumproducent van de wereld. Bij
+      de winning worden verschillende technieken gebruikt. De mijnen geven over het
+      algemeen vrij weinig vervuiling. Wel zijn de transportafstanden nogal groot
+      en er is relatief veel energie nodig om een hoeveelheid brandstof te maken.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 580
   key: uranium_from_canada_share
   share_group: nuclear_lce
@@ -4493,6 +7656,18 @@
   slide_id: 146
   position: 3
   dependent_on:
+  description:
+    content_en: Canada is home to the most highly concentrated uranium deposits. Consequently,
+      the energy required for mining a tonne of uranium is lower than in other countries.
+      Canadian mines mainly employ open-pit and underground mining methods, which
+      are associated with large amounts of toxic and low-level radioactive rock wastes.
+    content_nl: De uraniumlagen in Canada zijn het meest geconcentreerd van de hele
+      wereld. Daardoor is er minder energie nodig om het te winnen dan in de rest
+      van de wereld. Canadese mijnen gebruiken vooral dagbouw en ondergrondse mij
+      n bouw methodes. Deze leveren relatief veel laag-radioactief en giftig steenafval
+      op.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 581
   key: energy_mixer_for_gas_power_fuel_crude_oil_share
   share_group: energy_sector_gas
@@ -4516,6 +7691,19 @@
   slide_id: 140
   position: 5
   dependent_on: ''
+  description:
+    content_en: This slider sets what percentage of the total input consists of oil-derivatives
+      that are 'co-fired' in industrial CHPs. The oil is injected into the furnace
+      as a fine mist together with the gas. In theory, it is possible to substitute
+      100% of the gas in this way without losing efficiency. In practice less than
+      the theoretical maximum is co-fired in such plants.
+    content_nl: Met dit schuifje geef je aan hoeveel procent van de brandstof in industriële
+      WKK's bestaat uit bijgemengde olie-derivaten. De olie wordt verneveld en ingespoten
+      met het gas. In theorie kan zo 100% van het gas vervangen worden door olie,
+      zonder dat daarbij de efficiëntie van verbranding achteruit gaat. In de praktijk
+      wordt nooit zoveel olie bijgemengd.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 582
   key: households_heater_district_heating_steam_hot_water_share
   share_group: heating_households
@@ -4539,6 +7727,17 @@
   slide_id: 4
   position: 2
   dependent_on: ''
+  description:
+    content_en: District heating is heat supplied by a heat network. The heat can
+      be produced by local heat plants / large-scale burners or the heat can be imported
+      from outside your region. You can set the heat sources in the Supply-section
+      under the header <a href="/scenario/supply/heat" >"Heat networks"</a>.
+    content_nl: Warmte uit een warmtenet kan geproduceerd worden door lokale warmtecentrales
+      / grootschalige warmteketels óf de warmte kan worden geïmporteerd van buiten
+      jouw gebied. Kies de warmtebronnen in het Aanbod-gedeelte onder het kopje <a
+      href="/scenario/supply/heat" >"Warmtenetten"</a>.
+    short_content_en:
+    short_content_nl:
 - id: 583
   key: capacity_of_energy_power_turbine_network_gas
   share_group: ''
@@ -4562,6 +7761,21 @@
   slide_id: 46
   position: 3
   dependent_on: ''
+  description:
+    content_en: "Here you can set capacity of gas turbine power plants. These are
+      less efficient than the combined-cycle gas turbines (CCGT), but have the advantage
+      that they can handle being turned on and off within minutes. \r\nThese turbines
+      are therefore most often used to provide power during demand peaks. \r\n<br/><br/>\r\nAlthough
+      the number of operating hours per year and total electricity production of these
+      plants are quite limited, they are extremely useful to have in your power mix."
+    content_nl: "Hier kun je opgesteld vermogen van gasturbine centrales instellen.
+      Deze zijn niet zo efficiënt als de twee-staps Stoom en Gas (STEG) centrales,
+      maar hebben als voordeel dat ze er goed tegen kunnen om vaak aan- en uitgezet
+      te worden. Daarom leveren deze centrales alleen stroom bij zogenaamde piekvraag.
+      <br/><br/>\r\nHoewel het aantal draaiuren en de jaarproductie van deze centrales
+      dus beperkt is, zijn ze zeer nuttig om te hebben."
+    short_content_en:
+    short_content_nl:
 - id: 584
   key: capacity_of_energy_power_engine_diesel
   share_group: ''
@@ -4585,6 +7799,29 @@
   slide_id: 47
   position: 2
   dependent_on: ''
+  description:
+    content_en: "This is a small diesel generator of 2 MWe. <br/>\r\nA diesel generator
+      is the combination of a diesel engine with an electric generator to generate
+      electrical energy. Although they are expensive to run, their relative simplicity,
+      reliability and safety make them attractive for use in places without connection
+      to the power grid, as emergency power supply if the grid fails, as well as for
+      more complex applications to stabilize the power grid. \r\n<br/>\r\nThe technical
+      parameters used are based on the assumption that the diesel generator does not
+      run at base load, but rather to stabilize the grid or as backup power supply,
+      meaning it only runs occasionally.\r\n<br/><br/>\r\nThe input of the slider
+      (in MW) is converted to a (partial) number of the plant described above."
+    content_nl: "Dit is een dieselgenerator van 2 MWe <br/>\r\nEen dieselgenerator
+      is de combinatie van een dieselmotor en een generator om stroom te produceren.
+      Hoewel deze machines vrij duur zijn in het gebruik, zijn vanwege hun relatieve
+      eenvoud, betrouwbaarheid en veiligheid aantrekkelijk om gebruikt te worden op
+      plaatsen waar geen stroomnet is, als noodaggregaten of voor ingewikkelder toepassingen
+      om het stroomnet te stabiliseren.\r\n<br/>\r\nDe technische gegevens voor het
+      model, zijn gebaseerd op de aanname dat deze generator niet voor basislast gebruikt
+      wordt, maar om het stroomnet te stabiliseren of als noodaggregaat en dus weinig
+      draait. \r\n<br/><br/>\r\nDe schuifjesinstelling wordt omgezet naar (deel)aantallen
+      van de centrale zoals hierboven omschreven."
+    short_content_en:
+    short_content_nl:
 - id: 585
   key: buildings_space_heater_district_heating_steam_hot_water_share
   share_group: heating_buildings
@@ -4608,6 +7845,17 @@
   slide_id: 115
   position: 11
   dependent_on: ''
+  description:
+    content_en: District heating is heat supplied by a heat network. The heat can
+      be produced by local heat plants / large-scale burners or the heat can be imported
+      from outside your region. You can set the heat sources in the Supply-section
+      under the header <a href="/scenario/supply/heat" >"Heat networks"</a>.
+    content_nl: Warmte uit een warmtenet kan geproduceerd worden door lokale warmtecentrales
+      / grootschalige warmteketels óf de warmte kan worden geïmporteerd van buiten
+      jouw gebied. Kies de warmtebronnen in het Aanbod-gedeelte onder het kopje <a
+      href="/scenario/supply/heat" >"Warmtenetten"</a>.
+    short_content_en:
+    short_content_nl:
 - id: 586
   key: employment_local_fraction
   share_group: ''
@@ -4631,6 +7879,18 @@
   slide_id: 154
   position: 2
   dependent_on: ''
+  description:
+    content_en: "What fraction of total labor for the production of parts do you think
+      is done locally?\r\n<br/><br/>\r\n\r\nHow much local employment results from
+      the use of a technology, depends on how much of the labor is done abroad. Especially
+      the production of parts (such as piping, bolts and screws) is chiefly done abroad."
+    content_nl: "Welk deel van het werk voor de productie van onderdelen gebeurt in
+      eigen land?\r\n<br/><br/>\r\nOm te weten hoeveel binnenlandse werkgelegenheid
+      het inzetten van een technologie oplevert, moeten we weten welke fractie van
+      het werk in het buitenland wordt gedaan. Vooral onderdelen (zoals bouten en
+      moeren) worden voornamelijk in het buitenland geproduceerd."
+    short_content_en:
+    short_content_nl:
 - id: 587
   key: employment_economic_multiplier
   share_group: ''
@@ -4654,6 +7914,16 @@
   slide_id: 154
   position: 3
   dependent_on:
+  description:
+    content_en: "Employment has a positive feedback effect. If employment increases,
+      consumption increases accordingly, allowing employment to grow even more.\r\nHow
+      strong do you think this effect is for energy-related jobs?"
+    content_nl: "Werkgelegenheid heeft een zelfversterkend effect. Een toename van
+      werkgelegenheid heeft een positief effect op de koopkracht. Toenemende koopkracht
+      stimuleert op haar beurt de werkgelegenheid weer.\r\nHoe sterk denkt u dat dit
+      effect zal zijn voor 'energiebanen'?"
+    short_content_en:
+    short_content_nl:
 - id: 588
   key: transport_plane_using_gasoline_share
   share_group: transport_aviation
@@ -4677,6 +7947,15 @@
   slide_id: 123
   position: 2
   dependent_on:
+  description:
+    content_en: 'Not a large percentage of airplanes use gasoline as fuel. Its use
+      is mostly limited to smaller private planes, since larger planes need higher
+      energy content fuels to get far enough. '
+    content_nl: Momenteel gebruiken vooral kleinere privé vliegtuigjes benzine. Grotere
+      vliegtuigen hebben over het algemeen een energierijkere brandstof nodig om ver
+      genoeg te kunnen vliegen.
+    short_content_en:
+    short_content_nl:
 - id: 590
   key: transport_rail_mixer_diesel_biodiesel_share
   share_group: transport_rail_diesel
@@ -4700,6 +7979,31 @@
   slide_id: 155
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Biodiesel can be made from a range of vegetable or animals fats.
+      Seed oils are particularly popular. Diesel produced from algae has captured
+      people's imagination, since growing crops for biodiesel often still competes
+      for space with growing food. So far, it accounts for only a small percentage
+      of the total production of bio-diesel, as it is not commercially viable yet.\r\n<br/><br/>\r\nEngines
+      can run on bio-diesel without modifications, but the vegetable-based diesels
+      tend to be rather corrosive to the engine.\r\n<br/><br/>\r\nSee the <a href=\"https://github.com/quintel/etdataset-public/tree/master/carriers_source_analyses\">documentation
+      on GitHub</a> for more information on the numbers used."
+    content_nl: "Biodiesel kun je maken van verschillende plantaardige en dierlijke
+      vetten. Vooral zaadoliën zijn erg populair. Tegenwoordig zijn mensen nogal gecharmeerd
+      door diesel uit algen, omdat daarvoor geen landbouwgrond hoeft te worden opgegeven.
+      Op dit moment is algen-diesel maar een klein deel van de totale bio-diesel productie,
+      omdat het nog niet commercieel levensvatbaar is. \r\n<br/><br/>\r\nMotoren kunnen
+      bio-diesel verbranden zonder anders afgesteld te worden, maar de plantaardige
+      varianten zijn wel vrij corrosief voor de motor. \r\n<br/><br/>\r\nZie onze
+      <a href=\"https://github.com/quintel/etdataset-public/tree/master/carriers_source_analyses\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen.\r\n<br/><br/>\r\n<object
+      width=\"640\" height=\"385\"><param name=\"movie\" value=\"http://www.youtube.com/v/Rt8G0bujc-A?fs=1&amp;hl=en_US&amp;rel=0\"></param><param
+      name=\"allowFullScreen\" value=\"true\"></param><param name=\"allowscriptaccess\"
+      value=\"always\"></param><embed src=\"http://www.youtube.com/v/Rt8G0bujc-A?fs=1&amp;hl=en_US&amp;rel=0\"
+      type=\"application/x-shockwave-flash\" allowscriptaccess=\"always\" allowfullscreen=\"true\"
+      width=\"425\" height=\"300\"></embed></object>"
+    short_content_en:
+    short_content_nl:
 - id: 591
   key: transport_rail_mixer_diesel_diesel_share
   share_group: transport_rail_diesel
@@ -4723,6 +8027,17 @@
   slide_id: 155
   position: 1
   dependent_on:
+  description:
+    content_en: Diesel is the standard fossil fuel for trains in 'remote' areas that
+      lack an electric rail system. Diesel engines are quite efficient and sturdy.
+      Due to emissions of fine particulate matter, filters are becoming mandatory
+      in most parts of the world.
+    content_nl: 'Diesel is de fossiele brandstof van keuze voor treinen in meer ''afgelegen''
+      gebieden waar geen elektrisch spoor is. Dieseltreinen zijn efficiënt en betrouwbaar.
+      Omdat dieselmotoren fijnstof produceren worden in steeds meer delen van de wereld
+      filters voorgeschreven. '
+    short_content_en:
+    short_content_nl:
 - id: 592
   key: employment_fraction_production
   share_group: ''
@@ -4746,6 +8061,17 @@
   slide_id: 154
   position: 1
   dependent_on: ''
+  description:
+    content_en: "What contribution do you think the production phase makes to employment?\r\n</br></br>\r\nAlthough
+      the production of parts for heaters, plants and other energy related appliances
+      represents a significant part of the total employment, the share of this phase
+      is uncertain."
+    content_nl: "Welke bijdrage levert de productiefase volgens u aan de totale werkgelegenheid?\r\n</br></br>\r\nDe
+      productie van onderdelen voor verwarmingsapparaten en elektriciteit-centrales
+      \ levert mogelijk een grote hoeveelheid werkgelegenheid op. Hoe groot dit aandeel
+      is ten opzichte van de het totaal is echter onzeker."
+    short_content_en:
+    short_content_nl:
 - id: 594
   key: investment_costs_micro_chp
   share_group: ''
@@ -4769,6 +8095,20 @@
   slide_id: 157
   position: 1
   dependent_on: _always_hidden
+  description:
+    content_en: "As more micro-CHPs are installed their costs are likely to decrease.
+      If you believe this technology will be successful in the future, you can indicate
+      how much cheaper you think they may become.\r\n<br/>\r\nMicro-CHPs can be chosen
+      as heating technology in the <a href=\"/scenario/demand/households/space-heating\"a>households
+      section<a/>. \r\n"
+    content_nl: "Naarmate er meer micro-WKKs (HRe ketels) geïnstalleerd worden, zullen
+      de kosten ook afnemen. Als je gelooft dat deze technologie in de toekomst succesvol
+      zal zijn, kun je hier invullen hoeveel goedkoper de HRe ketel wordt. \r\n<br/>\r\nIn
+      het onderdeel <a href=\"/scenario/demand/households/space-heating\"a>huishoudens<a/>
+      kun je aangeven welk aandeel micro-WKK's zullen hebben in het leveren van ruimteverwarming
+      en warm water. "
+    short_content_en:
+    short_content_nl:
 - id: 595
   key: investment_costs_fuel_cell
   share_group: ''
@@ -4792,6 +8132,20 @@
   slide_id: 157
   position: 2
   dependent_on: _always_hidden
+  description:
+    content_en: "As more fuel cells are installed their costs are likely to decrease.
+      If you believe this technology will be successful in the future, you can indicate
+      how much cheaper you think they may become. <br/>\r\nFuel cells can be chosen
+      as water heating technology in the <a href=\"/scenario/demand/households/space-heating\"a>households
+      section<a/>. \r\n"
+    content_nl: "Naarmate er meer brandstofcellen geïnstalleerd worden, zullen de
+      kosten ook afnemen. Als je gelooft dat deze technologie in de toekomst succesvol
+      zal zijn, kun je hier invullen hoeveel goedkoper de brandstofcel wordt. \r\n<br/>\r\nIn
+      het onderdeel <a href=\"/scenario/demand/households/space-heating\"a>huishoudens<a/>
+      kun je aangeven welk aandeel brandstofcellen zullen hebben in het leveren van
+      warm water. "
+    short_content_en:
+    short_content_nl:
 - id: 599
   key: industry_aluminium_production
   share_group: ''
@@ -4815,6 +8169,17 @@
   slide_id: 160
   position: 1
   dependent_on: ''
+  description:
+    content_en: "Here you can indicate by how much production volumes of aluminium
+      will change. \r\n</br></br>\r\nProduction of aluminium in Europe has on average
+      increased by 1% per year since 2001. Globally growth is over ~6% with China
+      the strongest contributor ( ~18% annually). "
+    content_nl: "Geef hier aan hoeveel de productie van aluminium de komende jaren
+      gaat groeien of afnemen.\r\n</br></br>\r\nBinnen Europa is de aluminiumproductie
+      vanaf 2001 met ongeveer 1% per jaar gestegen. Wereldwijd is dit meer dan 6%
+      per jaar, met China als belangrijkste land (18% per jaar).\r\n"
+    short_content_en:
+    short_content_nl:
 - id: 600
   key: industry_aluminium_electrolysis_bat_electricity_share
   share_group: aluminium_production
@@ -4838,6 +8203,18 @@
   slide_id: 160
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Production of primary aluminium by electrolysis is quite energy intensive,
+      but there is room for improvement. Best available technology (BAT) is ~10% more
+      efficient than plants operating today.\r\n</br></br>\r\nHere you can indicate
+      what share BAT electrolysis has in aluminium production."
+    content_nl: "De productie van primair aluminium door middel van elektrolyse is
+      erg energie-intensief, maar er zijn nog wel verbeterstappen te maken. Aluminiumproductie
+      volgens de best available technology is ongeveer 10% efficiënter dan nu gemiddeld
+      gebeurt.\r\n</br></br>\r\nGeef hier aan welk aandeel de elektrolyse BAT heeft
+      bij de productie van aluminium.\r\n"
+    short_content_en:
+    short_content_nl:
 - id: 601
   key: industry_aluminium_smeltoven_electricity_share
   share_group: aluminium_production
@@ -4861,6 +8238,18 @@
   slide_id: 160
   position: 4
   dependent_on: ''
+  description:
+    content_en: "Aluminium (like all metals) can be recycled endlessly. To do so,
+      it needs to be melted down, a process that represents a 95% energy reduction
+      compared to production of primary aluminium. \r\n</br></br>\r\nHere you can
+      indicate what share of total aluminium production comes from recycled aluminium.
+      \ "
+    content_nl: "Aluminium kan eindeloos gerecycled worden. Voor het recyclen hoeft
+      het slechts omgesmolten te worden in een oven. Het recyclen gebruikt 95% minder
+      energie dan de productie van primair aluminium.\r\n</br></br>\r\nGeef hier aan
+      welk aandeel van de aluminiumproductie uit gerecycled aluminium komt.\r\n"
+    short_content_en:
+    short_content_nl:
 - id: 602
   key: industry_aluminium_carbothermalreduction_electricity_share
   share_group: aluminium_production
@@ -4884,6 +8273,24 @@
   slide_id: 160
   position: 3
   dependent_on: ''
+  description:
+    content_en: "Separating aluminium and oxygen by carbothermal reduction is a fundamentally
+      different method of primary aluminium production from electrolysis. The former
+      is a temperature assisted chemical reaction, the latter an electrochemical reaction.
+      \r\nProducing primary aluminium this way is 20% more energy efficient than electrolysis.
+      \r\nThis technology is currently still being developed for large-scale industrial
+      application. \r\n</br></br>\r\nHere you can indicate what share of aluminium
+      production will come from carbothermal reduction."
+    content_nl: "Het scheiden van aluminium en zuurstof door koolstofthermische reductie
+      is een fundamenteel andere methode dan via elektrolyse. Het gaat hierbij om
+      een chemische reactie (onder hoge temperatuur) en niet om een elektrochemische
+      reactie zoals bij elektrolyse. De productie van primair aluminium via koolstofthermische
+      reductie is ongeveer 20% energie-efficiënter dan via elektrolyse.\r\nDe techniek
+      is op dit moment nog in ontwikkeling voor grootschalige industriële toepassing.\r\n</br></br>\r\nGeef
+      hier aan welk aandeel de koolstofthermische reductie heeft bij de productie
+      van aluminium.\r\n"
+    short_content_en:
+    short_content_nl:
 - id: 603
   key: industry_aluminium_electrolysis_current_electricity_share
   share_group: aluminium_production
@@ -4907,6 +8314,20 @@
   slide_id: 160
   position: 1
   dependent_on: ''
+  description:
+    content_en: "The standard process for producing primary aluminium from ore is
+      by electrolysis (Hall-Héroult process). This process separates aluminium and
+      oxygen from aluminiumoxide and requires large amounts of electricity. All primary
+      aluminium production around the world is presently done by electrolysis.\r\n</br></br>\r\nHere
+      you can indicate what share electrolysis will have in aluminium production."
+    content_nl: "Het standaardproces voor de productie van primair aluminium (uit
+      aluinaarde) is productie door middel van elektrolyse (het Hall-Héroult-proces).
+      Bij de elektrolyse worden het aluminium en de zuurstof in de aluinaarde van
+      elkaar gescheiden. Hier is veel elektriciteit voor nodig. Op dit moment wordt
+      alle primaire aluminium in de wereld geproduceerd door elektrolyse.\r\n</br></br>\r\nGeef
+      hier aan welk aandeel de elektrolyse heeft bij de productie van aluminium.\r\n"
+    short_content_en:
+    short_content_nl:
 - id: 604
   key: industry_other_metals_process_electricity_efficiency
   share_group: ''
@@ -4930,6 +8351,19 @@
   slide_id: 161
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Producing and processing other metals requires large amounts of electricity.
+      Examples of electricity applications are pressing, cutting and pumping. Quite
+      a few energy saving measures are available. Together, these measures can result
+      in incremental improvements in energy efficiency for electricity application.\r\n</br></br>\r\nHere
+      you can indicate what annual efficiency improvements will be. "
+    content_nl: "Bij de productie en bewerking van overige metalen is elektriciteit
+      nodig voor bijvoorbeeld verspanen, omvormen, snijden of pompen. Er zijn veel
+      efficiëntiemaatregelen die hierop van toepassing zijn. Gezamenlijk zorgen zij
+      voor een incrementele efficiëntieverbetering op elektriciteit.\r\n</br></br>\r\nGeef
+      hier aan wat de jaarlijkse efficiëntieverbetering op elektriciteit is.\r\n"
+    short_content_en:
+    short_content_nl:
 - id: 605
   key: industry_other_metals_process_heat_useable_heat_efficiency
   share_group: ''
@@ -4953,6 +8387,20 @@
   slide_id: 161
   position: 3
   dependent_on: ''
+  description:
+    content_en: "Melting down, smelting and processing other metals requires heat.
+      Quite a few energy saving measures are available, such as insulation of production
+      spaces, ovens or pipes, more efficient burners, etc. All these measures together
+      provide incremental improvements to energy efficiency for heat applications.
+      \r\n</br></br>\r\nHere you can indicate what the annual efficiency improvements
+      will be."
+    content_nl: "Voor het smelten en bewerken van overige metalen is warmte nodig.
+      Er zijn vele maatregelen die hierbij een besparing kunnen leveren, zoals isolatie
+      van ruimten, leidingen of ovens, efficiëntere branders. Al deze maatregelen
+      leveren een incrementele efficiëntieverbetering op warmte.\r\n</br></br>\r\nGeef
+      hier aan wat de jaarlijkse efficiëntieverbetering op warmte is.\r\n"
+    short_content_en:
+    short_content_nl:
 - id: 606
   key: industry_other_metals_production
   share_group: ''
@@ -4976,6 +8424,15 @@
   slide_id: 161
   position: 1
   dependent_on: ''
+  description:
+    content_en: "The 'other metals' sector comprises the production of lead, zinc,
+      copper and precious metals like gold and silver. \r\n</br></br>\r\nHere you
+      can indicate how the total production volumes of these metals will change. "
+    content_nl: "Overig metaal bestaat onder andere uit de productie van lood, koper,
+      zink en edelmetalen als goud en zilver.\r\n</br></br>\r\nGeef hier aan hoeveel
+      de productie van deze metalen de komende jaren gaat groeien of afnemen."
+    short_content_en:
+    short_content_nl:
 - id: 607
   key: buildings_space_heater_coal_share
   share_group: heating_buildings
@@ -4999,6 +8456,12 @@
   slide_id: 115
   position: 6
   dependent_on: has_coal_oil_for_heating_built_environment
+  description:
+    content_en: This shows what part of heating is produced by coal-fired heaters.
+    content_nl: Hier zie je welk deel van de verwarming door kolengestookte ketels
+      wordt ingevuld.
+    short_content_en:
+    short_content_nl:
 - id: 608
   key: industry_steel_production
   share_group: ''
@@ -5022,6 +8485,17 @@
   slide_id: 162
   position: 1
   dependent_on: ''
+  description:
+    content_en: "Here you can indicate how the production of crude steel will change
+      in the future. \r\n</br></br>\r\nIn Europe, steel production has grown by 0.5%
+      annually since 2001. Globally, growth is more than 5% with China the biggest
+      contributor (~16% annually).  "
+    content_nl: "Geef hier aan hoeveel de productie van ruwstaal de komende jaren
+      gaat groeien of afnemen.\r\n</br></br>\r\nBinnen Europa is de staalproductie
+      vanaf 2001 met ongeveer 0,5% per jaar gestegen. Wereldwijd is dit meer dan 5%
+      per jaar, met China als belangrijkste land (16% per jaar).\r\n"
+    short_content_en:
+    short_content_nl:
 - id: 609
   key: industry_steel_blastfurnace_bat_consumption_useable_heat_share
   share_group: steel_production
@@ -5045,6 +8519,22 @@
   slide_id: 162
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Blast furnaces are part of extensive industrial complexes that have
+      a technical lifetime of decades. Few adjustments are possible during their lifetime,
+      making optimal efficiencies difficult to attain. Best available technology (BAT)
+      blast furnaces are built according to latest insights. Such blast furnaces would
+      be roughly 10% more efficient than conventional blast furnaces.\r\n</br></br>\r\nHere
+      you can indicate what share of iron and steel production uses BAT blast furnaces.\r\n<br>"
+    content_nl: "Hoogovencomplexen zijn omvangrijk en hebben een levensduur van tientallen
+      jaren. Tijdens deze levensduur kan een beperkt aantal aanpassingen worden gemaakt
+      aan de installatie, waardoor een optimale efficiëntie lastig te bereiken is.
+      De hoogoven BAT (best available technology) is een hoogoven die volgens de meest
+      recente stand van zaken wordt gebouwd. Aangenomen wordt dat een hoogoven BAT
+      10% efficiënter is dan een conventionele hoogoven.\r\n</br></br>\r\nGeef hier
+      aan welk aandeel de hoogoven BAT heeft bij de productie van ijzer en staal.\r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 610
   key: industry_steel_blastfurnace_current_consumption_useable_heat_share
   share_group: steel_production
@@ -5068,6 +8558,17 @@
   slide_id: 162
   position: 1
   dependent_on: ''
+  description:
+    content_en: "Iron and steel are conventionally produced in a blastfurnace. Globally,
+      two-thirds of all iron and steel is produced this way (the rest is recycled
+      steel).  \r\n</br></br>\r\nHere you can indicate what share blast furnaces have
+      in total iron and steel production ."
+    content_nl: "IJzer- en staalproductie met een hoogoven is de conventionele wijze
+      van produceren. Wereldwijd wordt tweederde van de ijzer- en staalproductie met
+      een hoogoven geproduceerd.\r\n</br></br>\r\nGeef hier aan welk aandeel de hoogoven
+      heeft bij de productie van ijzer en staal.\r\n"
+    short_content_en:
+    short_content_nl:
 - id: 611
   key: industry_steel_hisarna_consumption_useable_heat_share
   share_group: steel_production
@@ -5091,6 +8592,25 @@
   slide_id: 162
   position: 3
   dependent_on: ''
+  description:
+    content_en: "Iron production is energy and carbon intensive, so a strong incentive
+      exists to look for alternative technologies to make the process more efficient.
+      \r\nCyclone ovens (also known as Hisarna ovens) will combine several different
+      processes in one, reducing energy consumption and CO<sub>2</sub> emissions.
+      In 2011 the first test plant was built in the Netherlands. It is expected that
+      several more years of development are needed before the technology is fully
+      mature. \r\n<br/><br/>\r\nHere you can indicate what share cyclone ovens will
+      have in future iron and steel production. "
+    content_nl: "Wereldwijd wordt er gezocht naar nieuwe technieken om de productie
+      van ijzer en staal efficiënter te maken en minder CO<sub>2</sub> uit te stoten.
+      De cycloonoven is één van die technieken. De cycloonoven is een combinatie van
+      technieken die de productie van ruwijzer voor staal in minder stappen doet dan
+      een hoogoven en minder energiegebruik en CO<sub>2</sub>-uitstoot heeft. In 2011
+      is in Nederland de eerste testfabriek hiervoor geplaatst. Naar verwachting duurt
+      het nog enkele jaren voordat de techniek helemaal is uitgewerkt.\r\n<br><br>\r\nGeef
+      hier aan welk aandeel de cycloonoven heeft bij de productie van ijzer en staal."
+    short_content_en:
+    short_content_nl:
 - id: 612
   key: industry_steel_electricfurnace_electricity_share
   share_group: steel_production
@@ -5114,6 +8634,21 @@
   slide_id: 162
   position: 4
   dependent_on: ''
+  description:
+    content_en: "Steel (like all metals) can be endlessly recycled. Electric arc furnaces
+      are used to recycle 100% used steel. Steel can also be melted in blast furnaces,
+      but input is limited to 20% there (80% new iron is required). Globally, almost
+      one third of steel is produced in electric arc furnaces. \r\n<p>\r\nHere you
+      can indicate what share electric arc furnaces will have in steel production. "
+    content_nl: "Staal kan eindeloos gerecycled worden. De elektrische oven wordt
+      ingezet om gebruikt staal te recyclen. Hoewel gebruikt staal ook in een hoogoven
+      omgesmolten kan worden, kan dit maar tot ongeveer 20% van het totaal (80% moet
+      nieuw ijzer zijn). In een elektrische oven wordt 100% gebruikt staal verwerkt.
+      Wereldwijd komt ongeveer een derde van de staalproductie uit een elektrische
+      oven.\r\n<p>\r\nGeef hier aan welk aandeel de elektrische oven heeft bij de
+      productie van ijzer en staal.\r\n"
+    short_content_en:
+    short_content_nl:
 - id: 613
   key: energy_steel_hisarna_transformation_coal_woodpellets_share
   share_group: ''
@@ -5137,6 +8672,27 @@
   slide_id: 162
   position: 5
   dependent_on: ''
+  description:
+    content_en: "Producing pig iron for steel in a blast furnace requires large amounts
+      of coal. The coal serves a source of carbon and 'reducing agent' for separating
+      iron and oxygen from iron ore. Coal is used partly in the form of cokes and
+      partly as injected coal. The injected coal could also be replaced by biomass
+      in the form of charcoal. The potential for replacing coal in blast furnaces
+      is 50%.\r\n<br><br>\r\nThe potential for replacing coal in cyclone furnaces
+      by biomass in the form of torrified wood pellets is 100%.\r\n<br/><br/>\r\nHere
+      you can indicate what share of coal input in cyclone furnaces is replaced by
+      torrified wood pellets. "
+    content_nl: "Bij de productie van ruwijzer voor staal wordt in een hoogoven veel
+      steenkool gebruikt als reductiemiddel om het ijzer zuiver te krijgen. Een deel
+      van de steenkool wordt ingezet als cokes en een deel als injectiekolen. Deze
+      injectiekolen kunnen (in principe) ook vervangen worden door biomassa in de
+      vorm van houtskool. Dit kan bij een hoogoven tot maximaal 50% van de koleninzet
+      zijn.\r\n<br/><br/>\r\nBij de cycloonoven kunnen de kolen tot 100% vervangen
+      worden door biomassa in de vorm van getorrificeerde houtpellets. \r\n<br><br>\r\nGeef
+      hier aan welk deel van de kolen in de Hisarna wordt vervangen door getorrificeerde
+      houtpellets."
+    short_content_en:
+    short_content_nl:
 - id: 614
   key: settings_enable_merit_order
   share_group: ''
@@ -5160,6 +8716,11 @@
   slide_id: 153
   position: 999
   dependent_on: ''
+  description:
+    content_en: ''
+    content_nl: ''
+    short_content_en:
+    short_content_nl:
 - id: 615
   key: flexibility_outdoor_temperature
   share_group: ''
@@ -5183,6 +8744,24 @@
   slide_id: 163
   position: 1
   dependent_on: ''
+  description:
+    content_en: "By how much do you think the outdoor temperature will change in the
+      future?\r\n<br/><br/>\r\nYour choice will affect the useful demand for heating
+      and cooling in households and buildings. To translate a temperature change into
+      a change in useful demand, it is assumed that people will start heating their
+      homes when the outside temperature drops beneath 18 &degC and will cool their
+      homes when it rises above 23 &degC.\r\n<br/><br/>\r\nFor more information about
+      the climate change calculation consult our <a href=\"https://github.com/quintel/documentation/blob/master/general/climate.md\"
+      target =\"_blank\">documentation</a>."
+    content_nl: "Hoeveel denk je dat de buitentemperatuur zal veranderen in de toekomst?\r\n<br/><br/>\r\nJe
+      keuze heeft invloed op de warmte- en koudevraag van huishoudens en gebouwen.
+      Om de vertaalslag van temperatuur naar nuttig gebruik te maken is aangenomen
+      dat mensen hun huis verwarmen als de buitentemperatuur onder de 18 &degC daalt
+      en gaan koelen als ze boven de 23 &degC stijgt.\r\n<br/><br/>\r\nKijk voor meer
+      informatie over de klimaatberekening in onze <a href=\"https://github.com/quintel/documentation/blob/master/general/climate.md\"
+      target =\"_blank\">documentatie</a>."
+    short_content_en:
+    short_content_nl:
 - id: 627
   key: investment_costs_electric_heat_pumps
   share_group: ''
@@ -5206,6 +8785,29 @@
   slide_id: 157
   position: 3
   dependent_on: ''
+  description:
+    content_en: "As more electric heat pumps are installed their costs are likely
+      to decrease. If you believe this technology will be successful in the future,
+      you can indicate how much cheaper you think they may become.\r\n<br/><br/>\r\nVarious
+      kinds of electric heat pumps can be chosen as heating technology in <a href=\"/scenario/demand/households/space-heating\">households
+      space heating<a/>, <a href=\"/scenario/demand/households/district-heating\">households
+      district heating<a/>, <a href=\"/scenario/demand/buildings/space-heating\">buildings
+      space heating<a/>, <a href=\"/scenario/demand/buildings/district-heating\">buildings
+      district heating<a/> and <a href=\"/scenario/demand/industry/chemicals\">chemical
+      industry<a/>. \r\n<br/><br/>\r\nThe technical and financial parameters of one
+      kind of heat pump can be seen by clicking the link below."
+    content_nl: "Naarmate er meer elektrische warmtepompen geïnstalleerd worden, zullen
+      de kosten ook afnemen. Als je gelooft dat deze technologie in de toekomst succesvol
+      zal zijn, kun je hier invullen hoeveel goedkoper ze worden. \r\n<br/><br/>\r\nIn
+      het onderdeel <a href=\"/scenario/demand/households/space-heating\">ruimteverwarming
+      huishoudens<a/>, <a href=\"/scenario/demand/households/district-heating\">warmtenet
+      huishoudens<a/>, <a href=\"/scenario/demand/buildings/space-heating\">ruimteverwarming
+      gebouwen<a/>, <a href=\"/scenario/demand/buildings/district-heating\">warmtenet
+      gebouwen<a/> en <a href=\"/scenario/demand/industry/chemicals\">chemische industrie<a/>.
+      \r\n<br/><br/>\r\nDe technische en financiële parameters van een zo'n warmtepomp
+      kun je zien als je op de link hieronder klikt. "
+    short_content_en:
+    short_content_nl:
 - id: 628
   key: investment_costs_gas_heat_pumps
   share_group: ''
@@ -5229,6 +8831,22 @@
   slide_id: 157
   position: 4
   dependent_on: ''
+  description:
+    content_en: "As more gas-fired heat pumps are installed their costs are likely
+      to decrease. If you believe this technology will be successful in the future,
+      you can indicate how much cheaper you think they may become.\r\n<br/>\r\nGas-fired
+      heat pumps can be chosen as heating technology in the <a href=\"/scenario/demand/households/space-heating\"a>households
+      section<a/>. <br/>\r\nThe technical and financial parameters of one kind of
+      gas-fired heat pump can be seen by clicking the link below."
+    content_nl: "Naarmate er meer gaswarmtepompen geïnstalleerd worden, zullen de
+      kosten ook afnemen. Als je gelooft dat deze technologie in de toekomst succesvol
+      zal zijn, kun je hier invullen hoeveel goedkoper ze worden. \r\n<br/>\r\nIn
+      het onderdeel <a href=\"/scenario/demand/households/space-heating\"a>huishoudens<a/>
+      kun je aangeven welk aandeel gaswarmtepompen zullen hebben in het leveren van
+      ruimteverwarming en warm water. \r\n<br/>\r\nDe technische en financiële parameters
+      van zo'n gaswarmtepomp kun je zien als je op de link hieronder klikt. "
+    short_content_en:
+    short_content_nl:
 - id: 630
   key: capacity_of_industry_chp_turbine_gas_power_fuelmix
   share_group: ''
@@ -5252,6 +8870,23 @@
   slide_id: 44
   position: 2
   dependent_on: ''
+  description:
+    content_en: "This gas turbine CHP is typically found at a medium-sized industrial
+      firm to deliver power and steam. Several units are sometimes found on one site
+      in order to deliver steam to neighboring firms.\r\n<br/><br/>\r\nFirms in the
+      petro-chemical industry often work round the clock. so full load hours for electricity
+      are up to 8000 hours a year. Steam delivery may vary, for example as a result
+      of seasonal differences, meaning full load hours for heat are lower at 6000
+      hours per year. "
+    content_nl: "Deze gasturbine WKK staat typisch op een middelgroot industrieel
+      bedrijf en produceert elektriciteit en stoom. Soms staan er verschillende units
+      naast elkaar en wordt er ook stoom geleverd aan naburige bedrijven.\r\n<br/><br/>\r\nIn
+      de chemische industrie wordt veelal gewerkt in vijfploegendienst en het aantal
+      draaiuren van de WKK is dan ook 8000 uur per jaar. De stoomlevering over het
+      jaar kan fluctueren, bijvoorbeeld als gevolg van seizoensinvloeden, en daarom
+      zijn er 6000 vollasturen warmte (stoomlevering)."
+    short_content_en:
+    short_content_nl:
 - id: 631
   key: capacity_of_industry_chp_engine_gas_power_fuelmix
   share_group: ''
@@ -5275,6 +8910,19 @@
   slide_id: 44
   position: 4
   dependent_on: ''
+  description:
+    content_en: "This gas-powered engine may well produce heat and power for local
+      use in the food industry.\r\nFor a three-shift work rotation common in the food
+      industry, the number of full load hours would be ~6000 hours per year.\r\n<br/><br/>\r\nGenerating
+      heat and power for local use can be considerably more efficient than buying
+      power from the grid and generating heat with a burner. "
+    content_nl: "Deze gasmotor WKK staat bijvoorbeeld in de voedingsindustrie en maakt
+      stroom en warmte voor lokaal gebruik. \r\nStel er wordt gedraaid in een drieploegendienst.
+      Het aantal draaiuren komt uit op 6000 per jaar.\r\n<br/><br/>\r\nHet lokaal
+      produceren van eigen warmte en stroom kan een stuk efficiënter zijn dan de stroom
+      van het net te kopen en warmte met een ketel te maken. "
+    short_content_en:
+    short_content_nl:
 - id: 634
   key: capacity_of_energy_chp_supercritical_waste_mix
   share_group: ''
@@ -5298,6 +8946,27 @@
   slide_id: 55
   position: 2
   dependent_on: ''
+  description:
+    content_en: "This builds a high energy yield waste-incineration plant that delivers
+      heat to a central heating grid (60 MWe and 33 MWth). Waste that can be safely
+      burnt is used to generate electricity and heat. By incinerating waste under
+      the right conditions, it can be processed in a relatively clean way. Rotting
+      or decomposing waste produces strong greenhouse gasses, so incineration is often
+      preferable from an environmental point of view.<br/><br/>\r\nThe maximum potential
+      for these power plants is limited by available domestic waste. We assume no
+      waste will be imported.\r\n<br/><br/>\r\nThe input of the slider (in MW) is
+      converted to a (partial) number of the plant described above."
+    content_nl: "Hiermee bouw je een hoogrendment afvalverbrandingscentrale die warmte
+      levert aan een warmtenet (60 MWe, 33 MWth). Brandbaar afval (huishoudelijk-
+      en sloop-afval) wordt gebruikt om elektriciteit en warmte op te wekken. Door
+      het onder de juiste omstandigheden te verbranden, kan afval op een relatief
+      schone manier verwerkt worden. Rottend afval produceert methaan, een sterker
+      broeikasgas dan CO<sub>2</sub>, daarom is verbranden vaak beter. <br/><br/>\r\nHet
+      model importeert geen afval, dus de beschikbare hoeveelheid afval bepaalt het
+      potentieel voor deze technologie.\r\n<br/><br/>\r\nDe schuifjesinstelling wordt
+      omgezet naar (deel)aantallen van de centrale zoals hierboven omschreven."
+    short_content_en:
+    short_content_nl:
 - id: 635
   key: capacity_of_other_chp_engine_biogas
   share_group: ''
@@ -5324,6 +8993,26 @@
   slide_id: 102
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Combined heat and power (CHP) engines like these (~1 MWe and ~1 MWth)
+      are gas-fired engines that generate both heat and electricity. The combination
+      of heat and electricity makes this option quite energy efficient. CHPs are primarily
+      used at sites with a predictable demand for heat, such as greenhouses for example.\r\n<br/><br/>\r\nThis
+      unit is powered by locally produced biogas. The biogas is created by sewage
+      treatment or from rotting waste in covered dump sites. Gas is produced in a
+      steady flow, meaning this CHP is running all the time.\r\n<br/><br/>\r\nThe
+      input of the slider (in MW) is converted to a (partial) number of the plant
+      described above."
+    content_nl: "Kleine warmtekrachtkoppelingen (WKK’s) als deze (~1 MWe en ~1 MWth)
+      maken warmte en elektriciteit. Deze combinatie maakt WKK's vrij energie-efficiënt.
+      WKK's worden vooral gebouwd op locaties met een voorspelbare warmtevraag, zoals
+      bijvoorbeeld broeikassen.\r\n<br/<br/>\r\nDeze WKK gebruikt biogas dat gemaakt
+      wordt in rioolwaterzuivering of door verrotting van afval op een vuilstort.
+      Omdat een constante stroom van gas geproduceerd wordt, staat deze WKK vrijwel
+      constant aan.\r\n<br/><br/>\r\nDe schuifjesinstelling wordt omgezet naar (deel)aantallen
+      van de centrale zoals hierboven omschreven."
+    short_content_en:
+    short_content_nl:
 - id: 636
   key: households_useful_demand_cooking_per_person
   share_group: ''
@@ -5347,6 +9036,19 @@
   slide_id: 43
   position: 4
   dependent_on: ''
+  description:
+    content_en: "Note: these changes in energy demand do <strong>not</strong> depend
+      on the technologies chosen below (Cooking slide). \r\n<br/>\r\n<br/>\r\nHere
+      you can indicate how you expect the demand for cooking per person to change.
+      As people become wealthier, they go out for dinner or take away food more often,
+      resulting in a lower demand for cooking at home."
+    content_nl: "Let op: deze verandering van energiegebruik is <strong>onafhankelijk</strong>
+      van de technologieën die je hieronder kunt kiezen (Koken slide).\r\n<br>\r\n<br>\r\nHier
+      kun je aangeven hoe jij denkt dat de energievraag voor koken per persoon zich
+      gaat ontwikkelen. Als mensen rijker worden gaan ze vaker uit eten of eten afhalen.
+      Dit heeft tot gevolg dat de energievraag voor koken lager wordt."
+    short_content_en:
+    short_content_nl:
 - id: 637
   key: households_useful_demand_electric_appliances
   share_group: ''
@@ -5370,6 +9072,19 @@
   slide_id: 43
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Note: these changes in energy demand do <strong>not</strong> depend
+      on the technologies chosen below (Appliances slide). \r\n<br/>\r\n<br/>\r\nHere
+      you indicate how you expect demand for appliances per person to change. This
+      is mainly determined by growth in prosperity. As people become richer, they
+      tend to possess more electric appliances."
+    content_nl: "Let op: deze verandering van energiegebruik is <strong>onafhankelijk</strong>
+      van de technologieën die je hieronder kunt kiezen (Apparaten slide).\r\n<br>\r\n<br>\r\nHier
+      kun je aangeven hoe jij denkt dat de energievraag voor apparaten per persoon
+      zich gaat ontwikkelen. Dit hangt vooral af van de welvaartsgroei. Hoe rijker
+      mensen zijn, des te meer apparaten ze bezitten."
+    short_content_en:
+    short_content_nl:
 - id: 638
   key: households_useful_demand_lighting
   share_group: ''
@@ -5393,6 +9108,20 @@
   slide_id: 43
   position: 3
   dependent_on: ''
+  description:
+    content_en: "Note: these changes in energy demand do <strong>not</strong> depend
+      on the technologies chosen below (Lighting slide). \r\n<br/>\r\n<br/>\r\nHere
+      you indicate how you expect demand for lighting per person to change. This is
+      mainly determined by growth in prosperity. As people become richer, they start
+      living in larger houses that require more lighting."
+    content_nl: "Let op: deze verandering van energiegebruik is <strong>onafhankelijk</strong>
+      van de technologieën die je hieronder kunt kiezen (Verlichting slide).\r\n<br>\r\n<br>\r\nHier
+      kun je aangeven hoe jij denkt dat de energievraag voor verlichting per persoon
+      zich gaat ontwikkelen. Dit hangt vooral af van de welvaartsgroei. Als mensen
+      rijker worden, gaan ze in grotere huizen wonen waarvoor meer verlichting nodig
+      is."
+    short_content_en:
+    short_content_nl:
 - id: 642
   key: capacity_of_energy_chp_ultra_supercritical_cofiring_coal
   share_group: ''
@@ -5416,6 +9145,25 @@
   slide_id: 45
   position: 11
   dependent_on: ''
+  description:
+    content_en: "Large ultra-supercritical pulverized coal-fired CHP plant. \r\nSuch
+      plants are identical to a common coal plant, except that it also supplies heat
+      to large heating grids. This comes at the expense of some power production.
+      Additionally, this plant co-fires 50% wood-pellets in addition to coal. By changing
+      the capacity of plants with and without co-firing an overall percentage of co-firing
+      can be established between 0% and 50%."
+    content_nl: "Grote ultra-superkritische poederkolen WKK centrale. Deze centrale
+      is hetzelfde als de elektriciteitscentrale, behalve dat bij deze ook warmte
+      wordt afgetapt voor het centrale warmtenet. Daarnaast verstookt deze WKK centrale
+      naast kolen ook wood-pellets met een bijstook percentage van 50%. Door het combineren
+      van het opgesteld vermogen van centrales met en zonder bijstook kan een bijstookpercentage
+      tussen 0% en 50% gerealiseerd worden.\r\n<br/><br/> \r\nDe Amercentrale in Geertruidenberg
+      bijvoorbeeld voedt het warmtenet voor Tilburg en Breda. Warmtelevering in een
+      dergelijke centrale gaat iets ten koste van de elektriciteitsproductie. Afgezet
+      tegen de totale kosten van een kolencentrale zijn de extra investeringen in
+      warmteuitkoppeling beperkt."
+    short_content_en:
+    short_content_nl:
 - id: 643
   key: capacity_of_energy_power_ultra_supercritical_cofiring_coal
   share_group: ''
@@ -5439,6 +9187,41 @@
   slide_id: 45
   position: 2
   dependent_on: ''
+  description:
+    content_en: "730 megawatt electric (MWe) ultra-supercritical pulverized coal-fired
+      plant with 50% co-firing of biomass. Of all types of power plants, coal and
+      lignite-fired ones contribute most to pollution of the environment. By co-firing
+      biomass the emission of pollution is reduced. This is the most common type of
+      modern coal-fired power plant in rich countries with relatively strict regulations
+      for air pollution. Also see information in section \"Costs\". \r\n\r\n<br/><br/>\r\nA
+      coal-fired power plant is a baseload power plant, meaning it is producing at
+      maximum capacity more than 75% of the time.\r\n\r\n<br/><br/> \r\nBecause the
+      model uses standard size plants, and in reality both smaller and larger plants
+      may exist, the number of plants installed may not be a whole number.\r\n<br/><br/>
+      \r\nBy changing the amount of plants with and without co-firing an overall percentage
+      of co-firing can be set between 0% and 50%. For example: 1 plant without co-firing
+      and 1 plant with co-firing leads to 25% co-firing in total.\r\n<br/><br/>\r\nThe
+      input of the slider (in MW) is converted to a (partial) number of the plant
+      described above."
+    content_nl: "Ultra-superkritische poederkolencentrale van 730 megawatt elektrisch
+      (MWe) met bijstook van biomassa van 50%. Dit is de meest voorkomende kolencentrale
+      in landen met relatief strenge milieuwetgeving. Van alle typen elektriciteitsopwek
+      geven kolen- en bruinkoolcentrales wel de grootste luchtvervuiling. Door de
+      bijstook van biomassa wordt deze uitstoot een stuk teruggebracht. De CO<sub>2</sub>
+      uitstoot van een kolencentrale is ongeveer 2x zo groot als die van een gascentrale
+      per opgewekte megawattuur (MWh). Zie verder ook de informatie bij onderdeel
+      'Kosten'. \r\n\r\n<br/><br/>\r\nEen kolencentrale is een basislast-centrale,
+      en daarom draait hij meer dan 75% van de tijd op vol vermogen.\r\n\r\n<br/><br/>\r\nOmdat
+      het model een standaard centralegrootte hanteert, en er in werkelijkheid kleinere
+      en grotere centrales bestaan, is het mogelijk dat het opgestelde aantal centrales
+      geen geheel getal is.\r\n<br/><br/>\r\nDoor het aantal centrales met en zonder
+      bijstook te wijzigen kan een overkoepelend bijstookpercentage tussen 0% en 50%
+      gerealiseerd worden. Voorbeeld: 1 centrale zonder bijstook en 1 centrale met
+      bijstook levert een gezamenlijk bijstookpercentage van 25% op.\r\n<br/><br/>\r\nDe
+      schuifjesinstelling wordt omgezet naar (deel)aantallen van de centrale zoals
+      hierboven omschreven."
+    short_content_en:
+    short_content_nl:
 - id: 644
   key: investment_costs_solar_concentrated_solar_power
   share_group: ''
@@ -5462,6 +9245,14 @@
   slide_id: 17
   position: 2
   dependent_on: has_solar_csp
+  description:
+    content_en: This slider sets the height of the assumed costs for concentrated
+      solar power (CSP). Costs are compared to current costs.
+    content_nl: 'Deze schuif stelt je de toe-of afname in die je verwacht voor de
+      investeringskosten voor ''concentrated solar power'' (CSP). De kosten worden
+      vergeleken met de kosten van vandaag de dag. '
+    short_content_en:
+    short_content_nl:
 - id: 645
   key: other_useful_demand_non_energetic
   share_group: ''
@@ -5485,6 +9276,18 @@
   slide_id: 32
   position: 3
   dependent_on: ''
+  description:
+    content_en: "Note: these changes in energy demand do <strong>not</strong> depend
+      on the technologies chosen below.\r\n<br/><br/>\r\nWhat do you expect the development
+      of non-energetic demand in the other sector will be like? This depends primarily
+      on the growth of the this sector (determined by economic growth, but also conditions
+      for investment etc.)."
+    content_nl: "Let op: deze verandering van energiegebruik is <strong>onafhankelijk</strong>
+      van de technologieën die je hieronder kunt kiezen.\r\n<br/><br/>\r\nHoe denk
+      jij dat de niet-energetische vraag voor de overig sector zich gaat ontwikkelen?
+      Dat hangt vooral af van economische groeiverwachtingen en bevolkingsgroei."
+    short_content_en:
+    short_content_nl:
 - id: 659
   key: capacity_of_energy_power_engine_network_gas
   share_group: ''
@@ -5508,6 +9311,55 @@
   slide_id: 46
   position: 4
   dependent_on: ''
+  description:
+    content_en: "This is a power plant made up of 22 reciprocating combustion engine
+      units (18 MWe each), which makes for a 400 MWe power plant. The engines are
+      flexible in terms of what fuel they can use, but in the ETM they are gas-fired.\r\n<br/><br/>\r\nAlthough
+      marginal costs are a bit high for these plants, their total costs are quite
+      low compared to other gas-fired plants, making them an attractive back up option
+      in high wind and solar scenarios.\r\n<br/><br/>\r\nThese power plants are sometimes
+      touted as an excellent solution to the problem of highly variable power production
+      in scenarios that have a lot of installed wind and solar power. Reciprocating
+      engines offer several advantages over traditional power plants. Most important
+      are their flexibility and the speed at which they can vary their power output.
+      \r\n<br/><br/>\r\nEach unit can operate at any load between <1% and 100% without
+      loss of output efficiency. Each unit can also increase its output from 0 to
+      100% in ~2 minutes, and start delivering power to the grid within 30 seconds
+      of being started, regardless of its off time. Since each <em>plant</em> contains
+      22 units, the plant can provide anywhere between ~1 MWe and 400 MWe of power
+      to the grid within minutes at most, shut down completely within 1 minute and
+      be back at full power 2 minutes later <em>without any loss of efficiency</em>.
+      This makes it possible to balance large fluctuations in wind power production
+      and maintain grid stability. Power plants with a steam cycle or even gas turbines
+      often lose tens of percents in efficiency when their load drops to below 60
+      - 70%, making them much less efficient in balancing wind power. \r\n<br/><br/>\r\nThe
+      input of the slider (in MW) is converted to a (partial) number of the plant
+      described above."
+    content_nl: "Deze centrale bestaat uit 22 motor-generator eenheden van ieder 18
+      MWe en heeft dus een vermogen van 400 MWe. De motoren zijn flexibel wat de brandstofvraag
+      betreft, maar in het ETM draaien ze op gas.\r\n<br/><br/>\r\nHoewel deze centrales
+      vrij hoge draaikosten hebben, zijn de totaalkosten erg laag in vergelijking
+      met andere grote gascentrales. Vooral dat maakt ze uiteindelijk aantrekkelijk
+      als back up voor veel wind en zon. Dat leggen we hieronder uit.\r\n<br/><br/>\r\nDeze
+      centrales worden soms opgevoerd als een uitstekende oplossing voor het probleem
+      van sterk variërende stroomproductie in scenario's met veel opgesteld wind-
+      en zonvermogen. Gasmotorcentrales bieden voordelen boven traditionele gascentrales.
+      De belangrijkste zijn de flexibiliteit en snelheid waarmee ze hun stroomproductie
+      kunnen variëren. \r\n<br/><br/>\r\nElke eenheid kan tussen <1 en 100% van zijn
+      vermogen leveren, zonder dat de efficiëntie afneemt. Iedere unit kan ook van
+      0 naar 100% vermogen in ~2 minuten en binnen 30 seconden na de start stroom
+      op het net leveren, ongeacht hoe lang hij uit heeft gestaan. Aangezien iedere
+      <em>centrale</em> uit 22 eenhede bestaat kan hij tussen de ~1 en 400 MWe aan
+      het net leveren binnen minuten, volledig uitgeschakeld worden binnen 1 minuut
+      en vervolgens weer binnen 2 minuten op vol vermogen leveren <em>zonder efficiëntieverlies</em>.
+      Hierdoor wordt het mogelijk om om grote fluctuaties in windstroomproductie op
+      te vangen en het net stabiel te houden. Centrales met een stoomcyclus of zelfs
+      gasturbines verliezen vaak tientallen procentpunten efficiëntie als hun belastig
+      onder de 60 - 70% komt. Daardoor zijn ze veel minder efficiënt in te zetten
+      voor de balancering van windstroom. \r\n<br/><br/>\r\nDe schuifjesinstelling
+      wordt omgezet naar (deel)aantallen van de centrale zoals hierboven omschreven."
+    short_content_en:
+    short_content_nl:
 - id: 660
   key: capacity_of_industry_chp_ultra_supercritical_coal
   share_group: ''
@@ -5531,6 +9383,23 @@
   slide_id: 44
   position: 4
   dependent_on: ''
+  description:
+    content_en: "Combined heat and power (CHP) plants generate both heat and electricity.
+      The combination of heat and electricity makes this option quite energy efficient.
+      Also, locally producing and using heat and electricity reduces transportation
+      losses and saves energy. CHPs are primarily used at sites with a predictable
+      demand for heat, such as chemical factories for example.\r\n<br/><br/>\r\nMost
+      CHP plants are gas-fired, but depending on the availability of fuels coal-fired
+      CHP plants can be installed as well."
+    content_nl: "Warmtekrachtkoppelingen (WKK’s) produceren warmte en elektriciteit.
+      Deze combinatie maakt WKK's vrij energie-efficiënt. Lokaal produceren en gebruiken
+      van warmte en elektriciteit vermijdt transportverliezen en dat bespaart weer
+      energie. WKK's worden vooral gebouwd op locaties met een voorspelbare warmtevraag,
+      zoals bijvoorbeeld chemische fabrieken.\r\n<br/><br/>\r\nDe meeste WKK's draaien
+      op gas, maar afhankelijk van de beschikbaarheid van brandstoffen kunnen ook
+      kolen WKK's worden gebouwd."
+    short_content_en:
+    short_content_nl:
 - id: 661
   key: households_flexibility_p2p_electricity_market_penetration
   share_group: ''
@@ -5554,6 +9423,19 @@
   slide_id: 166
   position: 1
   dependent_on: ''
+  description:
+    content_en: 'Household batteries are often mentioned as a convenient way to store
+      excess electricity such that you can use it at a later time. Using this slider
+      you can set the percentage of households that is equipped with a household battery.
+      Households batteries in the ETM have a battery volume of 19.8 kWh and can be
+      charged using grid power or solar panels. '
+    content_nl: 'Thuisbatterijen worden vaak genoemd als oplossing voor het opvangen
+      van elektriciteitsoverschotten. Met de volgende slider kun je aangeven welk
+      percentage van de huishoudens is uitgerust met batterijopslag. De batterijen
+      in het ETM hebben een batterijvolume van 19.8 kWh en kunnen worden opgeladen
+      met netstroom of stroom uit zonnepanelen. '
+    short_content_en:
+    short_content_nl:
 - id: 662
   key: transport_car_using_electricity_availability
   share_group: ''
@@ -5577,6 +9459,28 @@
   slide_id: 166
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Electric vehicles could provide a cost-effective way of storing electricity
+      as they contain a relatively large battery. With this slider, you can set which
+      percentage of the electric vehicles' battery is reserved for flexibility purposes.
+      You can set the percentage of electric vehicles in the <a href=\"/scenario/demand/transport_passenger_transport/car-technology\">car
+      technology section of transport</a>.\r\n</br></br>\r\nElectric vehicles in the
+      ETM have a battery volume of 100 kWh. Not all of this volume can be used for
+      flexibility purposes as some of the electricity is needed to fuel the next ride.
+      With this slider you can set the percentage of the battery volume that can be
+      used for flexibility purposes."
+    content_nl: "Elektrische auto's zijn een kosteneffectieve manier om elektriciteit
+      op te slaan omdat ze een relatief grote batterij bevatten. Met de volgende slider
+      kun je daarom aangeven welk percentage van de batterij in alle elektrische auto's
+      kan worden gebruikt voor flexibiliteitsdoeleinden. Je kunt het percentage elektrische
+      auto's instellen in <a href=\"/scenario/demand/transport_passenger_transport/car-technology\">autotechnologie
+      slide</a>.\r\n<br/><br/>\r\nElektrische auto's in het ETM hebben een batterijvolume
+      van 100 kWh. Niet dit hele volume kan worden ingezet voor flexibiliteitsdoeleinden.
+      Een deel van het volume is immers ook nodig om mee te rijden. Met deze slider
+      kun je aangeven welk percentage van de batterij kan worden gebruikt voor om
+      elektriciteitsoverschotten op te vangen."
+    short_content_en:
+    short_content_nl:
 - id: 663
   key: capacity_of_energy_hydrogen_flexibility_p2g_electricity
   share_group: ''
@@ -5600,6 +9504,17 @@
   slide_id: 168
   position: 1
   dependent_on: ''
+  description:
+    content_en: Power-to-gas plants convert <strong>excess</strong> electricity to
+      hydrogen. This slider allows this hydrogen to be used in the central hydrogen
+      network. Any excess hydrogen is exported. The power-to-gas plants have an input
+      capacity of 10 MWe.
+    content_nl: Power-to-gas installaties produceren waterstof met elektriciteitsoverschotten.
+      Dit schuifje zorgt ervoor dat deze waterstof wordt ingezet in het centrale waterstofnetwerk.
+      Overtollig waterstof wordt geëxporteerd. De power-to-gas installaties hebben
+      een inputcapaciteit van 10 MWe.
+    short_content_en:
+    short_content_nl:
 - id: 664
   key: interconnectors_availability_for_export
   share_group: ''
@@ -5623,6 +9538,20 @@
   slide_id: 187
   position: 3
   dependent_on: ''
+  description:
+    content_en: It is very likely that not all of the physical interconnector capacity
+      can be used during times of excess electricity production. When there is to
+      much electricity production by wind turbines and solar panels, this is probably
+      also true for the neighbouring countries. Using this slider you can set the
+      percentage of the interconnector capacity that is available for export.
+    content_nl: Het is erg waarschijnlijk dat niet alle fysieke interconnectiecapaciteit
+      kan worden gebruikt wanneer er elektriciteitsoverschotten zijn als gevolg van
+      de overproductie door windmolens en zonnepanelen omdat de omringende landen
+      hier op dat moment ook last van zullen hebben. Met deze slider kun je daarom
+      instellen welk deel van de interconnectiecapaciteit je verwacht te kunnen gebruiken
+      voor export.
+    short_content_en:
+    short_content_nl:
 - id: 665
   key: interconnectors_availability_for_import
   share_group: ''
@@ -5646,6 +9575,20 @@
   slide_id: 187
   position: 2
   dependent_on: ''
+  description:
+    content_en: It is very likely that not all of the physical interconnector capacity
+      can be used during times of excess electricity production. When there is to
+      much electricity production by wind turbines and solar panels, this is probably
+      also true for the neighbouring countries. Using this slider you can set the
+      percentage of the interconnector capacity that is available for import.
+    content_nl: Het is erg waarschijnlijk dat niet alle fysieke interconnectiecapaciteit
+      kan worden gebruikt wanneer er elektriciteitsoverschotten zijn als gevolg van
+      de overproductie door windmolens en zonnepanelen omdat de omringende landen
+      hier op dat moment ook last van zullen hebben. Met deze slider kun je daarom
+      instellen welk deel van de interconnectiecapaciteit je verwacht te kunnen gebruiken
+      voor import.
+    short_content_en:
+    short_content_nl:
 - id: 666
   key: interconnectors_interconnector_capacity
   share_group: ''
@@ -5669,6 +9612,14 @@
   slide_id: 187
   position: 1
   dependent_on: ''
+  description:
+    content_en: The interconnectors with neighbouring countries have limited capacity.
+      Using this slider you can change the interconnector capacity from its present
+      value.
+    content_nl: De interconnectiecapaciteit met de omringende landen is beperkt. Met
+      deze slider kun je de toekomstige interconnectiecapaciteit instellen.
+    short_content_en:
+    short_content_nl:
 - id: 668
   key: investment_costs_households_flexibility_p2p_electricity
   share_group: ''
@@ -5692,6 +9643,19 @@
   slide_id: 232
   position: 1
   dependent_on: ''
+  description:
+    content_en: "Household batteries are often mentioned as a convenient way to store
+      excess electricity such that you can use it at a later time. With <a href=\"/scenario/flexibility/flexibility_storage/storage-in-household-batteries\"
+      >this slider</a> you can choose what percentage of all households should have
+      such a battery and with the above slider you can presumably set your assumption
+      for the future change in investment costs of households batteries.\r\n</br>"
+    content_nl: "Batterijen in huishouden worden vaak genoemd als oplossing voor het
+      opvangen van elektriciteitsoverschotten. Met <a href=\"/scenario/flexibility/flexibility_storage/storage-in-household-batteries\"
+      >deze slider</a> kun je aangeven welk percentage van de huishoudens is uitgerust
+      met batterijopslag en vervolgens kan je met bovenstaande slider aangeven hoeveel
+      de investeringskosten zullen veranderen voor deze batterijen.\r\n</br>"
+    short_content_en:
+    short_content_nl:
 - id: 669
   key: investment_costs_flexibility_p2h_electricity
   share_group: ''
@@ -5715,6 +9679,19 @@
   slide_id: 233
   position: 1
   dependent_on: ''
+  description:
+    content_en: Power-to-heat plants convert excess electricity to heat. In the ETM
+      power-to-heat can be used in <a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-households">households</a>
+      and in <a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-industry">industry</a>.
+      This slider determines the future change in investment costs of electric boilers.<br
+      />
+    content_nl: Power-to-heat-installaties produceren warmte met elektriciteitsoverschotten.
+      In het ETM kan power-to-heat worden ingezet bij <a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-households">huishoudens</a>
+      en in de <a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-industry">industrie</a>.
+      Dit schuifje bepaalt hoeveel de investeringskosten voor elektrische boilers
+      in de toekomst gaan veranderen. <br />
+    short_content_en:
+    short_content_nl:
 - id: 670
   key: investment_costs_hydrogen_electrolysis
   share_group: ''
@@ -5738,6 +9715,23 @@
   slide_id: 233
   position: 1
   dependent_on: ''
+  description:
+    content_en: Power-to-gas plants use electricity to produce gas (like hydrogen
+      or methane). This is called electrolysis. This slider determines the change
+      in investment costs of power-to-gas plants. This affects the costs of hydrogen
+      production using <a href="/scenario/supply/hydrogen/hydrogen-production">wind
+      and solar power</a>, the costs of hydrogen production using <a href="/scenario/flexibility/flexibility_conversion/conversion-to-hydrogen">excess
+      electricity</a> and the costs of <a href="/scenario/flexibility/flexibility_conversion/conversion-to-kerosene-for-aviation">synthetic
+      kerosene production</a> for aviation.<br />
+    content_nl: Power-to-gas-installaties gebruiken elektriciteit voor het produceren
+      gas (zoals waterstof of methaan). Dit gebeurt door middel van elektrolyse. Dit
+      schuifje bepaalt de verandering in investeringskosten voor elektrolyse-apparaten.
+      Dit heeft effect op de kosten voor waterstofproductie uit <a href="/scenario/supply/hydrogen/hydrogen-production">wind-
+      en zonnestroom</a>, de kosten voor waterstofproductie uit <a href="/scenario/flexibility/flexibility_conversion/conversion-to-hydrogen">elektriciteitsoverschotten</a>
+      en de kosten voor <a href="/scenario/flexibility/flexibility_conversion/conversion-to-kerosene-for-aviation">synthetische
+      kerosineproductie</a> voor de luchtvaart.<br />
+    short_content_en:
+    short_content_nl:
 - id: 672
   key: transport_ship_using_diesel_mix_share
   share_group: transport_marine
@@ -5761,6 +9755,28 @@
   slide_id: 191
   position: 1
   dependent_on: ''
+  description:
+    content_en: "The vast majority of ships for inland waterway transport are powered
+      by diesel engines. These engines can run in several cycles and at high and low
+      pressures. Depending on the exact engine configuration, diesel engines can also
+      run in a dual fuel mode in which they use both diesel and LNG. In this dual
+      fuel mode, the actual fuel usage can vary from 100% diesel to 1% diesel / 99%
+      LNG. In the <a href=\"/scenario/supply/transport_fuels/domestic-navigation\"
+      >transport fuels section</a> , you can determine the exact fuel mix of ships
+      with diesel / dual fuel engines.\r\n<br/><br/>\r\nSee the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used."
+    content_nl: "Schepen voor de binnenvaart worden doorgaans aangedreven door dieselmotoren.
+      Deze motoren kunnen volgens diverse processen en onder hoge en lage druk werken.
+      Afhankelijk van de precieze motor configuratie, kunnen dieselmotoren ook in
+      een zogeheten dual fuel modus opereren waarbij zij zowel diesel als vloeibaar
+      aardgas (LNG) kunnen gebruiken. In deze dual fuel modus, kan het daadwerkelijke
+      brandstofgebruik variëren van 100% diesel tot 1% diesel / 99% LNG. In de <a
+      href=\"/scenario/supply/transport_fuels/domestic-navigation\" >transport brandstoffen
+      sectie</a> kun je de brandstofmix voor schepen met diesel / dual fuel-motoren
+      instellen.\r\n<br/><br/>\r\nZie onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en:
+    short_content_nl:
 - id: 673
   key: transport_ship_using_lng_mix_share
   share_group: transport_marine
@@ -5784,6 +9800,23 @@
   slide_id: 191
   position: 2
   dependent_on: ''
+  description:
+    content_en: "(Liquefied) natural gas engines are a rather novel ship engine technology.
+      They are spark-ignited engines which operate at low pressures and are optimized
+      for liquefied natural gas (LNG). As a result, these engines can only run on
+      LNG but have superior performance to dual fuel engines. On the other hand, dual
+      fuel engines allow for more flexibility, being less dependent on the availability
+      of shipping fuels.\r\n<br/><br/>\r\nSee the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used."
+    content_nl: "(Vloeibaar) aardgas-motoren zijn een relatief nieuwe motortechnologie.
+      Dit zijn Ottomotoren die op lage druk werken en geoptimaliseerd zijn voor vloeibaar
+      aardgas (LNG). Hierdoor werken zij enkel op LNG, maar zijn de prestaties wel
+      beter dan die van dual fuel-motoren. Aan de andere kant zorgen dual fuel-motoren
+      wel voor meer flexibiliteit, omdat schepen dan minder afhankelijk zijn van de
+      beschikbaarheid van brandstoffen.\r\n<br/><br/>\r\nZie onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en:
+    short_content_nl:
 - id: 674
   key: transport_truck_using_lng_mix_share
   share_group: transport_truck_tech
@@ -5807,6 +9840,21 @@
   slide_id: 26
   position: 5
   dependent_on: ''
+  description:
+    content_en: "What percentage of all trucks will use liquefied natural gas (LNG)
+      fueled internal combustion engine (ICE) technology? LNG trucks have a longer
+      driving range than compressed network gas (CNG) trucks, because the energy content
+      of LNG is higher. However, LNG trucks also need expensive, highly insulated
+      tanks.\r\n<br/><br/>\r\nSee the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used."
+    content_nl: "Welk percentage van alle vrachtwagen zal op vloeibaar aardgas (LNG)
+      rijden in de toekomst? LNG vrachtwagens kunnen verder rijden op een tanklading
+      dan vrachtwagens op gas onder druk, omdat de energie inhoud van LNG hoger is.
+      LNG vrachtwagens hebben daarentegen wel dure, goed isolerende tanks nodig.\r\n<br/><br/>\r\nZie
+      onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en:
+    short_content_nl:
 - id: 675
   key: transport_road_mixer_lng_lng_share
   share_group: transport_lng_road
@@ -5830,6 +9878,28 @@
   slide_id: 156
   position: 5
   dependent_on: ''
+  description:
+    content_en: "Liquefied Natural Gas (LNG) is a clean burning fossil fuel. Liquefaction
+      makes natural gas significantly richer in energy, and therefore interesting
+      for long distance transport. Currently the only large scale European liquefaction
+      plants are found in Norway and LNG is imported from the Middle East as well.\r\n<br/><br/>\r\nLNG
+      is used by trucks (and not by cars) because of its high energy content and its
+      slow evaporation process (since it is cooled passively). As the annual mileage
+      of trucks is significantly higher and their usage much more constant and almost
+      continuous, the high energy content allows for a large driving range while LNG
+      evaporation does not pose a problem."
+    content_nl: "Vloeibaar aardgas is een relatief schone fossiele brandstof. Liquefactie
+      maakt aardgas veel rijker in energie en daarom interessant voor lange afstand
+      transport. Momenteel staan de enige grootschalige liquefactie fabrieken in Noorwegen
+      en wordt vloeibaar aardgas daarnaast uit het Midden Oosten geïmporteerd.\r\n<br/><br/>\r\nVloeibaar
+      aardgas wordt als brandstof door vrachtwagens (en niet door auto's) gebruikt
+      door de hoge energiedichtheid van LNG en het langzame verdampingsproces daarvan
+      (aangezien het passief gekoeld wordt). Doordat de jaarlijks afgelegde afstand
+      veel hoger is en het gebruik van vrachtwagens heel regelmatig en vrijwel continu
+      is, zorgt de energiedichtheid voor een goede actieradius terwijl de verdamping
+      geen probleem vormt."
+    short_content_en:
+    short_content_nl:
 - id: 676
   key: transport_road_mixer_lng_bio_lng_share
   share_group: transport_lng_road
@@ -5853,6 +9923,22 @@
   slide_id: 156
   position: 6
   dependent_on: ''
+  description:
+    content_en: Bio LNG is in fact liquefied bio methane. Through anaerobic digestion
+      or fermentation biodegradable materials can be converted into biogas. This gas
+      consists of mostly bio methane, carbondioxide and several other gases. It is
+      upgraded to bio methane by removing all the unwanted gases - engines are very
+      sensitive to the exact composition and energy content of the fuels burnt. To
+      then increase the energetic density, bio methane is liquefied and bio LNG is
+      obtained.
+    content_nl: Door anaërobe vergisting van organische materialen wordt biogas geproduceerd.
+      Dit bestaat grotendeels uit biomethaan, maar ook uit koolstofdioxide en andere
+      gassen. Biogas wordt vervolgens opgewaardeerd tot bio methaan door alle ongewenste
+      gassen te verwijderen - motoren zijn zeer gevoelig voor de precieze samenstelling
+      en energie inhoud van de brandstoffen die erin gaan. Om tot slot de energetische
+      dichtheid te vergroten, wordt bio methaan vloeibaar gemaakt.
+    short_content_en:
+    short_content_nl:
 - id: 677
   key: energy_treatment_natural_gas_share
   share_group: grid_natural_gas_origin
@@ -5876,6 +9962,12 @@
   slide_id: 49
   position: 3
   dependent_on: ''
+  description:
+    content_en: Which percentage of the natural gas in the national gas network is
+      natural gas?
+    content_nl: Welk percentage van het aardgas in het nationale gas netwerk is aardgas?
+    short_content_en:
+    short_content_nl:
 - id: 678
   key: energy_regasification_lng_share
   share_group: grid_natural_gas_origin
@@ -5899,6 +9991,18 @@
   slide_id: 49
   position: 4
   dependent_on: ''
+  description:
+    content_en: Which percentage of the natural gas in the national gas network is
+      regasified LNG? LNG is mainly imported from Norway and the Middle East, then
+      regasified to natural gas at import terminals and fed into the national gas
+      network. In liquid form (hence, as LNG) it is only used in the transport sector.
+    content_nl: Welk percentage van het gas in het nationale gasnetwerk is hervergast  LNG?
+      Vloeibaar aardgas wordt geïmporteerd vanuit met name Noorwegen en het Midden-Oosten,
+      dan hervergast tot aardgas bij import terminals en tot slot het gas netwerk
+      ingevoerd.  In vloeibare vorm (dus als LNG) wordt het enkel in de transport
+      sector gebruikt.
+    short_content_en:
+    short_content_nl:
 - id: 681
   key: transport_shipping_mixer_lng_lng_share
   share_group: transport_lng_ship
@@ -5922,6 +10026,25 @@
   slide_id: 124
   position: 6
   dependent_on: ''
+  description:
+    content_en: Liquified Natural Gas (LNG) is a rather novel shipping fuel. Traditionally,
+      large ships use large fractions of oil and smaller vessels typically run on
+      diesel-like fuels. Ships transporting large cargo over long distances require
+      very powerful engines and energy-rich fuels. Natural gas is an unsuitable shipping
+      fuel as its energetic density is very low, but through liquefaction it increases
+      by a factor 600 - more than enough to compete with diesel. Since LNG is also
+      a clean-burning fossil fuel, it is an alternative shipping fuel worth considering.
+    content_nl: Vloeibaar aardgas is een opkomende brandstof in de scheepvaart. Normaliter
+      gebruiken grote schepen zware oliefracties en varen kleinere schepen op brandstoffen
+      die meer op diesel lijken. Schepen transporteren zware ladingen over grote afstanden
+      en hebben daarom zeer krachtige motoren en energierijke brandstoffen nodig.
+      Aardgas is een ongeschikte brandstof voor de scheepvaart doordat de energetische
+      dichtheid erg laag is, maar door het vloeibaar te maken wordt deze dichtheid
+      met een factor 600 vergroot - meer dan genoeg om te concurreren met diesel.
+      Aangezien vloeibaar aardgas ook een schone fossiele brandstof is, is het een
+      interessant alternatief voor conventionele brandstoffen.
+    short_content_en:
+    short_content_nl:
 - id: 682
   key: transport_shipping_mixer_lng_bio_lng_share
   share_group: transport_lng_ship
@@ -5945,6 +10068,21 @@
   slide_id: 124
   position: 7
   dependent_on: ''
+  description:
+    content_en: 'Bio-based fuels for navigation are not common. Very large ocean-faring
+      vessels tend to use extremely heavy tar-like oil fractions that will probably
+      never be replaced by bio-fuels, as this is hardly economical. Furthermore, since
+      ships are relatively efficient, you might wonder whether it is a good idea  to
+      have them run on bio-fuels. Road transport being far less efficient, bio-fuels
+      will have a much larger impact there. '
+    content_nl: Biobrandstoffen worden nog nauwelijks in schepen ingezet. Zeer grote
+      oceaanschepen verbranden zeer zware teer-achtige oliefracties die waarschijnlijk
+      nooit vervangen zullen worden door bio-brandstoffen, omdat dat economisch niet
+      haalbaar is. Daar komt bij dat schepen zeer efficiënt zijn in vergelijking met
+      bijvoorbeeld wegtransport. Daarom is de winst in wegtransport door de inzet
+      van biobrandstoffen veel hoger.
+    short_content_en:
+    short_content_nl:
 - id: 683
   key: transport_shipping_mixer_diesel_diesel_share
   share_group: transport_diesel_ship
@@ -5968,6 +10106,19 @@
   slide_id: 124
   position: 1
   dependent_on: ''
+  description:
+    content_en: Large ships use tar-like fractions of oil, which tend to be a waste
+      product of all but the most advanced refineries. This makes this fuel very cheap
+      (and rich in energy). The smaller a ship becomes, the closer its fuel will tend
+      to common diesel. Since ships in domestic navigation are relatively small, diesel
+      is a rather common fuel there.
+    content_nl: Grote schepen verbranden een teer-achtige substantie die als afvalproduct
+      overblijft bij alle behalve de meest moderne raffinaderijen. Hierdoor is deze
+      brandstof zeer goedkoop en energierijk. Hoe kleiner het schip wordt, hoe meer
+      de brandstof gaat lijken op gewone diesel. Aangezien schepen in de binnenvaart
+      doorgaans vrij klein zijn, is diesel een veelgebruikte brandstof.
+    short_content_en:
+    short_content_nl:
 - id: 684
   key: transport_shipping_mixer_diesel_biodiesel_share
   share_group: transport_diesel_ship
@@ -5991,6 +10142,21 @@
   slide_id: 124
   position: 2
   dependent_on: ''
+  description:
+    content_en: 'Bio-based fuels for navigation are not common. Very large ocean-faring
+      vessels tend to use extremely heavy tar-like oil fractions that will probably
+      never be replaced by bio-fuels, as this is hardly economical. Furthermore, since
+      ships are relatively efficient, you might wonder whether it is a good idea  to
+      have them run on bio-fuels. Road transport being far less efficient, bio-fuels
+      will have a much larger impact there. '
+    content_nl: Biobrandstoffen worden nog nauwelijks in schepen ingezet. Zeer grote
+      oceaanschepen verbranden zeer zware teer-achtige oliefracties die waarschijnlijk
+      nooit vervangen zullen worden door bio-brandstoffen, omdat dat economisch niet
+      haalbaar is. Daar komt bij dat schepen zeer efficiënt zijn in vergelijking met
+      bijvoorbeeld wegtransport. Daarom is de winst in wegtransport door de inzet
+      van biobrandstoffen veel hoger.
+    short_content_en:
+    short_content_nl:
 - id: 685
   key: transport_shipping_mixer_diesel_lng_share
   share_group: transport_diesel_ship
@@ -6014,6 +10180,25 @@
   slide_id: 124
   position: 3
   dependent_on: ''
+  description:
+    content_en: Liquified Natural Gas (LNG) is a rather novel shipping fuel. Traditionally,
+      large ships use large fractions of oil and smaller vessels typically run on
+      diesel-like fuels. Ships transporting large loads over long distances, require
+      very powerful engines and energy-rich fuels. Natural gas is an unsuitable shipping
+      fuel as its energetic density is very low, but through liquefaction it increases
+      by a factor 600 - more than enough to compete with diesel. Since LNG is also
+      a clean-burning fossil fuel, it is an alternative shipping fuel worth considering.
+    content_nl: Vloeibaar aardgas is een opkomende brandstof in de scheepvaart. Normaliter
+      gebruiken grote schepen zware oliefracties en varen kleinere schepen op brandstoffen
+      die meer op diesel lijken. Schepen transporteren zware ladingen over grote afstanden
+      en hebben daarom zeer krachtige motoren en energierijke brandstoffen nodig.
+      Aardgas is een ongeschikt brandstof voor de scheepvaart doordat de energetische
+      dichtheid erg laag is, maar door het vloeibaar te maken wordt deze dichtheid
+      met een factor 600 vergroot - meer dan genoeg om te concurreren met diesel.
+      Aangezien vloeibaar aardgas ook een schone fossiele brandstof is, is het een
+      interessant alternatief voor conventionele brandstoffen.
+    short_content_en:
+    short_content_nl:
 - id: 686
   key: transport_shipping_mixer_diesel_bio_lng_share
   share_group: transport_diesel_ship
@@ -6037,6 +10222,21 @@
   slide_id: 124
   position: 4
   dependent_on: ''
+  description:
+    content_en: 'Bio-based fuels for navigation are not common. Very large ocean-faring
+      vessels tend to use extremely heavy tar-like oil fractions that will probably
+      never be replaced by bio-fuels, as this is hardly economical. Furthermore, since
+      ships are relatively efficient, you might wonder whether it is a good idea  to
+      have them run on bio-fuels. Road transport being far less efficient, bio-fuels
+      will have a much larger impact there. '
+    content_nl: Biobrandstoffen worden nog nauwelijks in schepen ingezet. Zeer grote
+      oceaanschepen verbranden zeer zware teer-achtige oliefracties die waarschijnlijk
+      nooit vervangen zullen worden door bio-brandstoffen, omdat dat economisch niet
+      haalbaar is. Daar komt bij dat schepen zeer efficiënt zijn in vergelijking met
+      bijvoorbeeld wegtransport. Daarom is de winst in wegtransport door de inzet
+      van biobrandstoffen veel hoger.
+    short_content_en:
+    short_content_nl:
 - id: 687
   key: transport_shipping_mixer_diesel_heavy_fuel_oil_share
   share_group: transport_diesel_ship
@@ -6060,6 +10260,18 @@
   slide_id: 124
   position: 5
   dependent_on: ''
+  description:
+    content_en: The larger a ship becomes, the heavier the fuel it uses. Large ocean-faring
+      ships use a tar-like substance that is a waste product of all but the most advanced
+      refineries. Since these fractions have few other uses without being broken down
+      further, they are relatively cheap.
+    content_nl: Hoe groter een schip wordt, hoe zwaarder de oliefractie die het gebruikt.
+      De grote oceaanschepen gebruiken teer-achtige substanties die als afvalproduct
+      uit alle behalve de meest  geavanceerde raffinaderijen komen. Omdat deze fracties
+      verder weinig toepassingen hebben zonder verder afgebroken te worden, zijn ze
+      relatief goedkoop.
+    short_content_en:
+    short_content_nl:
 - id: 688
   key: lng_from_algeria_share
   share_group: lng_fce
@@ -6083,6 +10295,15 @@
   slide_id: 144
   position: 5
   dependent_on: ''
+  description:
+    content_en: Algeria also exports natural gas as liquefied natural gas. It has
+      several liquefaction plants, but Algeria mostly delivers LNG to countries in
+      Southern Europe such as France and Spain because of their proximity.
+    content_nl: Algerije exporteert ook aardgas als vloeibaar aardgas. Er zijn diverse
+      liquefactie fabrieken, maar Algerije levert met name vloeibaar aardgas aan Zuid-Europese
+      landen zoals Frankrijk en Spanje vanwege hun nabijheid.
+    short_content_en:
+    short_content_nl:
 - id: 689
   key: lng_from_norway_share
   share_group: lng_fce
@@ -6106,6 +10327,15 @@
   slide_id: 144
   position: 6
   dependent_on: ''
+  description:
+    content_en: Norway is the only country in Europe which has large scale natural
+      gas liquefaction facilities. It is relatively close to the Netherlands, so energy
+      use and CO<sub>2</sub> emissions for transport are relatively low.
+    content_nl: Noorwegen is het enige land in Europa dat grootschalige aardgas liquefactie
+      faciliteiten heeft. Het ligt relatief dichtbij Nederland, dus de CO<sub>2</sub>
+      uitstoot voor transport is vrij laag.
+    short_content_en:
+    short_content_nl:
 - id: 690
   key: lng_from_qatar_share
   share_group: lng_fce
@@ -6129,6 +10359,14 @@
   slide_id: 144
   position: 7
   dependent_on: ''
+  description:
+    content_en: Qatar is the main exporter of LNG worldwide. It also delivers LNG
+      to all of the three LNG trading markets, which are Europe, Asia and the Americas.
+    content_nl: Qatar is de grootste exporteur van vloeibaar aardgas wereldwijd. Het
+      levert vloeibaar aardgas aan alle drie LNG markten, namelijk Europa, Azië en
+      Amerika (Noord en Zuid).
+    short_content_en:
+    short_content_nl:
 - id: 691
   key: lng_from_trinidad_share
   share_group: lng_fce
@@ -6152,6 +10390,17 @@
   slide_id: 144
   position: 8
   dependent_on: ''
+  description:
+    content_en: Trinidad (& Tobago) is a rather small player in the LNG market, and
+      mostly exports LNG to the Americas. However, it also ships small quantities
+      to Europe, but due to the long distance the CO<sub>2</sub> emissions for transport
+      are quite high.
+    content_nl: Trinidad (& Tobago) is een vrij kleine speler op de LNG markt en exporteert
+      met name naar Noord en Zuid Amerika. Kleine hoeveelheden LNG worden ook naar
+      Europa verscheept, maar door de grote afstand zijn de CO<sub>2</sub> emissies
+      voor transport vrij hoog.
+    short_content_en:
+    short_content_nl:
 - id: 692
   key: households_heater_hybrid_heatpump_air_water_electricity_share
   share_group: heating_households
@@ -6175,6 +10424,58 @@
   slide_id: 4
   position: 5
   dependent_on: ''
+  description:
+    content_en: "This heater is a combination of an electric heat pump that draws
+      its heat from the outside air and an efficient conventional gas-fired boiler.
+      Essentially, the hybrid heat pump offers a way to strongly reduce natural gas
+      demand for heating, while buying time for grid management companies to reinforce
+      grids. \r\n<br/><br/>\r\nThis works as follows:<br/>\r\nThe gas-fired part takes
+      over all of the heating of the building on cold winter days, when heat demand
+      peaks. Because of this clever trick, the heat pump has less impact on the electricity
+      grid than an all-electric heat pump does. Smart use of hybrid heat pumps may
+      therefore avoid the need to reinforce local power grids. \r\n<br/><br/>\r\nHeat
+      pumps move heat from one place to another. Refrigerators use heat pumps, for
+      example, but buildings can use them for heating and cooling too. For optimal
+      results with <em>most</em> types of heat pump, installation of under-floor and
+      wall heating instead of radiators is often required, as well as good levels
+      of insulation. The <em>hybrid</em> heat pump is an exception, because of its
+      gas-fired heater as a fall-back option. Hybrid heat pumps can intelligently
+      use whichever part (heat pump or gas-fired heater) is the most efficient or
+      cost-effective given the weather conditions and insulation level. Houses with
+      limited insulation will rely on the gas-fired part more, better insulated ones
+      will make more use of the heat pump.\r\n<br/><br/>\r\nThe COP of the electric
+      part of the hybrid heat pump is dependent of ambient temperature. When the COP
+      drops below the threshold value the hybrid heat pump switches to gas. With the
+      default value of the threshold COP space heating is as much as possible supplied
+      by the electric part of the hybrid heat pump. The threshold value can be adjusted
+      in the section <a href=\"/scenario/flexibility/flexibility_net_load/demand-response-heat-pumps\"
+      >Demand response - Heat pumps</a>. \r\n\r\n"
+    content_nl: "Deze verwarmingsoptie is een combinatie van een elektrische warmtepomp
+      met een gasgestookte HR-ketel. Een hybride warmtepomp maakt het mogelijk om
+      snel veel gas voor verwarming te besparen en geeft netbeheerders bovendien meer
+      tijd om stroomnetten te verzwaren.\r\n<br/><br/>\r\nHet werkt zo:<br/>\r\nDe
+      gasketel verwarmt het huis op koude dagen, als de warmtevraag het hoogst is.
+      Deze slimme truc zorgt ervoor dat een hybride warmtepomp het stroomnet minder
+      belast dan een elektrische warmtepomp alleen. Door slim gebruik te maken van
+      zulke hybride warmtepompen kan de noodzaak om stroomnetten te verzwaren vermeden
+      worden. \r\n<br/><br/>\r\nWarmtepompen verplaatsen warmte van de ene plek naar
+      de andere. Koelkasten gebruiken bijvoorbeeld warmtepompen, maar huizen kunnen
+      dat ook doen voor verwarming of koelen. Dit werkt het eigenlijk alleen als gebouwen
+      goed geïsoleerd zijn en als ze vloer- en muurverwarming hebben in plaats van
+      radiatoren. Hybride warmtepompen zijn een uitzondering op deze regel doordat
+      de gasketel ingezet kan worden. Ze kunnen slim kiezen welk deel (de warmtepomp
+      of de gasketel) het meest efficiënt of kosteneffectief is om aan te zetten,
+      afhankelijk van het weer en hoe goed een huis geïsoleerd is. Minder geïsoleerde
+      huizen zullen de gasketel vaker nodig hebben, beter geïsoleerde huizen gebruiken
+      vooral de warmtepomp.  \r\n<br/><br/>\r\nDe COP van het elektrische deel van
+      de hybride warmtepomp is afhankelijk van de buitentemperatuur. Als de COP onder
+      de drempelwaarde zakt schakelt de hybride warmtepomp volledig over op gas. De
+      standaard-drempelwaarde zorgt dat ruimteverwarming zo veel mogelijk via het
+      elektrische gedeelte van de hybride warmtepomp gebeurt. De omslag-COP is in
+      de sectie <a href=\"/scenario/flexibility/flexibility_net_load/demand-response-heat-pumps\"
+      >Vraagsturing - Warmtepompen</a> aan te passen. \r\n"
+    short_content_en:
+    short_content_nl:
 - id: 696
   key: transport_car_using_hydrogen_share
   share_group: transport_car_tech
@@ -6198,6 +10499,56 @@
   slide_id: 25
   position: 2
   dependent_on: ''
+  description:
+    content_en: "What percentage of all cars will be hydrogen fuelled vehicles in
+      the future? Hydrogen cars have been hyped as well as criticised a lot, and as
+      with many choices, their value depends on other choices you make. Hydrogen is
+      an energy carrier - not an energy source -, so it has to be produced first.
+      In the <a href=\"/scenario/supply/hydrogen/hydrogen-production\" >hydrogen production
+      section</a> you can determine how this is done - through steam reforming of
+      methane (a powerful greenhouse gas) or through green electrolysis.\r\n<br/><br/>\r\nHydrogen
+      cars (in the ETM) are fuel cell electric vehicles (FCEVs). Hydrogen in consumer
+      vehicles is stored at a very high pressure of 700 bar in order to ensure a long
+      driving range (of typically 500 km). Hydrogen is fed to a stack of fuel cells,
+      where it undergoes a chemical (redox) reaction with oxygen,  generates a current
+      and releases water. It thus produces electricity that drives the (electric)
+      engine. FCEVs are therefore electric vehicles, but they differ from electric
+      vehicles in the sense that the electricity is not stored on board in a battery,
+      but instead generated in the car itself. \r\n<br/><br/>\r\nCombined with smart
+      grid systems and energy storage technologies, electric vehicles could not only
+      potentially reduce our dependence on fossil fuels but even function as a storage
+      medium or production technology. <a href=\"https://www.thegreenvillage.org/projects/hydrolectric\"a>The
+      Green Village</a>, an initiative of Delft University of Technology, is doing
+      research on how electric cars can be used as more than just an end - for example,
+      as power plants and storage devices.\r\n<br/><br/>\r\nSee the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used."
+    content_nl: "Welk percentage van alle auto's zal op waterstof rijden in de toekomst?
+      Waterstofauto's worden aan de ene kant veel geprezen, maar aan de andere kant
+      ook stevig bekritiseerd. Zoals voor veel keuzes, hangt de waarde van een waterstofauto
+      af van andere keuzes die je maakt. Waterstof is een energiedrager - geen energiebron
+      -,  dus het zal eerst geproduceerd moeten worden. In de <a href=\"/scenario/supply/hydrogen/hydrogen-production\"
+      >waterstofproductiesectie</a> kun je bepalen hoe dat gedaan wordt - door het
+      reformen van methaan (een krachtig broeikasgas) of door groene elektrolyse.\r\n<br/><br/>\r\nWaterstofauto's
+      (in het ETM) zijn Fuel Cell Electric Vehicles (FCEVs), ofwel elektrische auto's
+      met een brandstofcel. Waterstof wordt onder een hele hoge druk van 700 bar opgeslagen
+      in personenauto's om een grote actieradius (van ongeveer 500 km) te garanderen.
+      Waterstof wordt gevoed aan geschakelde groep brandstofcellen, waar het een chemische
+      (redox) reactie ondergaat met zuurstof, elektriciteit genereert en water uitstoot.
+      Op deze manier produceert de brandstofcel de elektriciteit die de (elektro)motor
+      aandrijft. Waterstofauto's zijn daarom ook elektrische auto's, maar zij verschillen
+      van elektrische auto's in de zin dat de elektriciteit niet aan boord in een
+      accu opgeslagen is, maar tijdens het gebruik in de auto gegenereerd wordt.\r\n<br/><br/>\r\nIn
+      combinatie met slimme stroomnetten en energie opslag technologie, kunnen elektrische
+      auto's en waterstofauto's niet alleen mogelijk onze afhankelijkheid van fossiele
+      brandstoffen flink verlagen, maar zelfs functioneren als energie opslag medium
+      of productie technologie. <a href=\"https://www.thegreenvillage.org/projects/hydrolectric\"a>The
+      Green Village</a>, een initiatief van de Technische Universiteit Delft, doet
+      onderzoek naar hoe elektrische auto's gebruikt kunnen worden als meer dan enkel
+      een vervoersmiddel - bijvoorbeeld als minicentrale en voor energie opslag.\r\n<br/><br/>\r\nZie
+      onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en:
+    short_content_nl:
 - id: 697
   key: transport_vehicle_using_hydrogen_efficiency
   share_group: ''
@@ -6221,6 +10572,25 @@
   slide_id: 34
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Here you can indicate how much more efficient future hydrogen vehicles
+      will become every year. Hydrogen vehicles include all vehicles that can run
+      on hydrogen: cars, busses and trucks.\r\n<br/><br/>\r\nSince hydrogen vehicles
+      are a rather novel technology, there is still quite some room for improvement.
+      The electric engine is very efficient already, but the hydrogen fuel cell stack
+      (the part that generates electricity) can perform better.\r\n<br/><br/>\r\nSee
+      the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used."
+    content_nl: "Hier kun je aangeven hoeveel efficiënter jij denkt dat voertuigen
+      die op waterstof rijden ieder jaar worden. Waterstofvoertuigen zijn alle voertuigen
+      die op waterstof kunnen rijden: auto's, bussen and vrachtwagens. \r\n<br/><br/>\r\nAangezien
+      waterstofvoertuigen een vrij nieuwe technologie zijn, is er nog relatief veel
+      ruimte voor verbeteringen. De elektrische motor is al zeer efficiënt, maar de
+      waterstofcellen (het onderdeel van de elektrische auto dat elektriciteit genereert)
+      kunnen beter presteren.\r\n<br/><br/>\r\nZie onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en:
+    short_content_nl:
 - id: 698
   key: capacity_of_energy_hydrogen_steam_methane_reformer_ccs
   share_group: ''
@@ -6244,6 +10614,45 @@
   slide_id: 193
   position: 4
   dependent_on: ''
+  description:
+    content_en: "Steam methane reforming is a very mature hydrogen production process.
+      It works like this: methane reacts in the presence of a catalyst with high temperature
+      steam and gives a mixture of hydrogen and other gases. The unwanted gases (including
+      CO<sub>2</sub>) are then separated through further reactions and the resulting
+      hydrogen is purified to meet industrial standards. \r\n<br/><br/>\r\nSteam methane
+      reforming is already widely employed, but mostly for industry use. This plant's
+      input is network gas, so by changing the network gas composition <a href=\"/scenario/supply/other_fuels/gas-from-gas-network\"
+      >here</a>, you can change how green the hydrogen you produce is. Steam methane
+      reforming is often thought of an important transitional hydrogen production
+      process: far from the cleanest and greenest, but able to facilitate upcoming
+      hydrogen demand.\r\n<br/><br/>\r\nTo reduce its CO<sub>2</sub>-emissions, this
+      plant has received a CCS (CO<sub>2</sub> Capture and Storage) extension. In
+      short, this means that carbon dioxide is separated, captured and then stored
+      in nearby depleted gas or oil fields, or geological formations like salt caverns.
+      This of course requires higher investments and maintenance costs, but in return
+      significantly cuts GHG emissions.<br/>"
+    content_nl: "Aardgas-reforming (of beter: methaan-reforming) is een ver ontwikkeld
+      waterstofproductieproces. Het werkt als volgt: methaan reageert in de aanwezigheid
+      van een katalysator met stoom met een hoge temperatuur en geeft een mengsel
+      van waterstof en andere gassen. De ongewenste gassen (inclusief CO<sub>2</sub>)
+      worden dan afgescheiden door verdere reacties en het aldus verkregen waterstof
+      wordt gezuiverd opdat het voldoet aan de industriële standaard.\r\n<br/><br/>\r\nDeze
+      techniek wordt reeds uitgebreid toegepast, maar met name om waterstof te produceren
+      voor industrieel gebruik. Deze centrale gebruikt gas van het gasnet, dus door
+      de <a href=\"/scenario/supply/other_fuels/gas-from-gas-network\" >gassamenstelling</a>
+      in het gasnet aan te passen, kun je veranderen hoe groen de waterstof die je
+      produceert is. Methaan-reforming wordt vaak gezien als een belangrijke overgangsproductiemethode:
+      lang niet de schoonste en de groenste, maar in staat om de toenemende vraag
+      naar waterstof te faciliteren.\r\n<br/><br/>\r\nOm zijn CO<sub>2</sub>-uitstoot
+      te verlagen, is deze centrale uitgerust met een CCS-uitbreiding (CO<sub>2</sub>
+      Capture and Storage, CO<sub>2</sub> opvang en opslag). In het kort betekent
+      dit dat koolstofdioxide wordt gescheiden, opgevangen en tot slot opgeslagen
+      in nabijgelegen uitgeputte olie- of gasvelden of andere geologische formaties
+      zoals zoutgrotten. Dit zorgt uiteraard voor hogere investeringskosten en onderhoudskosten,
+      maar levert aan de andere kant wel een significante beperking in broeikasgasuitstoot
+      op.<br/>"
+    short_content_en:
+    short_content_nl:
 - id: 699
   key: capacity_of_energy_hydrogen_steam_methane_reformer
   share_group: ''
@@ -6267,6 +10676,33 @@
   slide_id: 193
   position: 3
   dependent_on: ''
+  description:
+    content_en: "Steam methane reforming is a very mature hydrogen production process.
+      It works like this: methane reacts in the presence of a catalyst with high temperature
+      steam and gives a mixture of hydrogen and other gases. The unwanted gases (including
+      CO<sub>2</sub>) are then separated through further reactions and the resulting
+      hydrogen is purified to meet industrial standards. \r\n<br/><br/>\r\nSteam methane
+      reforming is already widely employed, but mostly for industry use. This plant's
+      input is network gas, so by changing the network gas composition <a href=\"/scenario/supply/other_fuels/gas-from-gas-network\"
+      >here</a>, you can change how green the hydrogen you produce is. Steam methane
+      reforming is often thought of an important transitional hydrogen production
+      process: far from the cleanest and greenest, but able to facilitate upcoming
+      hydrogen demand.<br />"
+    content_nl: "Aardgas-reforming (of beter, methaan-reforming) is een ver ontwikkeld
+      waterstofproductie proces. Het werkt als volgt: methaan reageert in de aanwezigheid
+      van een katalysator met stoom met een hoge temperatuur en geeft een mengsel
+      van waterstof en andere gassen. De ongewenste gassen (inclusief CO<sub>2</sub>)
+      worden dan afgescheiden door verdere reacties en het aldus verkregen waterstof
+      wordt gezuiverd opdat het voldoet aan de industriële standaard.\r\n<br/><br/>\r\nDeze
+      techniek wordt reeds uitgebreid toegepast, maar met name om waterstof te produceren
+      voor industrieel gebruik. Deze centrale gebruikt gas van het gasnet, dus door
+      de <a href=\"/scenario/supply/other_fuels/gas-from-gas-network\" >gassamenstelling</a>
+      in het gasnet aan te passen, kun je veranderen hoe groen de waterstof die je
+      produceert is. Methaan-reforming wordt vaak gezien als een belangrijke overgangsproductiemethode:
+      lang niet de schoonste en de groenste, maar in staat om de toenemende vraag
+      naar waterstof te faciliteren.<br/>"
+    short_content_en:
+    short_content_nl:
 - id: 700
   key: energy_local_electrolysis_hydrogen_share
   share_group: hydrogen_production
@@ -6290,6 +10726,42 @@
   slide_id: 193
   position: 5
   dependent_on: _always_hidden
+  description:
+    content_en: "Electrolysis is a hydrogen production process known for many, many
+      years. Put simply, by adding to electrodes and applying a current to a container
+      filled with water, water molecules are forced to split into hydrogen and oxygen.
+      This is an energy intensive process, since current does not travel through water
+      easily. Water is made more conductive by using an electrolyte, i.e. a substance
+      that when dissolved has a charge and conducts electricity.\r\n<br/><br/>\r\nThe
+      various main types of electrolysis differ in electrolyte, temperature and pressure
+      of operation. This is a small local electrolysis plant of 0.5MW installed at
+      a retail station that produces hydrogen through alkaline electrolysis (based
+      on the Hamburg Vattenfall station). Larger, central electrolysis units exist,
+      but as of now have only slightly higher efficiencies.\r\n<br/><br/>\r\nThe most
+      promising technique with a significantly higher efficiency, nowadays still in
+      R&D phase and coping with a short lifetime and limited capacity, is high temperature
+      solid oxide electrolysis. Generally expected to be commercially available between
+      2020 and 2025, it would be a large scale highly efficient process that, especially
+      when coupled with renewably produced electricity, can be a major leap in greening
+      our fuels."
+    content_nl: "Elektrolyse is een waterstofproductie proces dat al vele jaren bekend
+      is. Door een stroom te laten lopen door een volume water, worden water moleculen
+      gesplitst in waterstof en zuurstof. Dit is een energie-intensief proces, aangezien
+      stroom niet makkelijk door water loopt. Water wordt beter geleidend gemaakt
+      door een elektrolyt (een stof die wanneer opgelost een lading heeft en geleidt)
+      te gebruiken.\r\n<br/><br/>\r\nDe verschillende elektrolyse methoden verschillen
+      in elektrolyt, operationele druk en operationele temperatuur. Dit is een kleine
+      lokale elektrolyse unit van 0.5MW die geïnstalleerd is bij een tankstation (gebaseerd
+      op het Hamburg Vattenfall station). Grotere, centrale elektrolyse units bestaan,
+      maar die hebben maar een iets hogere efficiëntie.\r\n<br/><br/>\r\nDe meest
+      veelbelovende techniek met een significant hogere efficiëntie, momenteel nog
+      in onderzoeksfase en kampend met een korte levensduur en beperkte capaciteit,
+      is hoge temperatuur solid oxide elektrolyse. Over het algemeen verwacht commercieel
+      beschikbaar te zijn tussen 2020 en 2025, zou het een zeer efficiënt productieproces
+      op grote schaal zijn dat, vooral wanneer gecombineerd met hernieuwbaar geproduceerde
+      elektriciteit, een grote stap in het vergroenen van onze brandstoffen kan zijn."
+    short_content_en:
+    short_content_nl:
 - id: 701
   key: capacity_of_energy_hydrogen_biomass_gasification_ccs
   share_group: ''
@@ -6313,6 +10785,14 @@
   slide_id: 193
   position: 7
   dependent_on: _always_hidden
+  description:
+    content_en: 'Biomass gasification with carbon capture and storage is a hydrogen
+      production technique that is not yet available for large scale production. '
+    content_nl: 'Biomassavergassing met koolstofdioxide opvang en opslag is een manier
+      om waterstof te produceren die nog niet volledig op grote schaal beschikbaar
+      is. '
+    short_content_en:
+    short_content_nl:
 - id: 702
   key: capacity_of_energy_hydrogen_biomass_gasification
   share_group: ''
@@ -6336,6 +10816,13 @@
   slide_id: 193
   position: 5
   dependent_on: ''
+  description:
+    content_en: Biomass gasification is a mature technology in which biomass is converted
+      into hydrogen. <br />
+    content_nl: Biomassavergassing is een volwassen technologie voor de productie
+      van waterstof uit biomassa. <br />
+    short_content_en:
+    short_content_nl:
 - id: 703
   key: investment_costs_electric_cars
   share_group: ''
@@ -6359,6 +10846,26 @@
   slide_id: 195
   position: 1
   dependent_on: ''
+  description:
+    content_en: "With this slider you can determine how much higher the average purchase
+      price (excluding taxes) of an electric car is compared to that of a combustion
+      engine car. You therefore set the price <i>difference</i> between the two. The
+      chart on the right shows the initial investment of a reference petrol car as
+      a grey bar and the initial investment of an electric car as a blue bar.\r\n<br/>\r\n<br/>\r\nPlease
+      note that, in this version, the ETM does not take into account investment costs
+      for cars except for the price difference you specify here. This is because the
+      total costs in the dashboard would otherwise be dominated by the resulting costs."
+    content_nl: "Met dit schuifje stel je in hoeveel hoger de gemiddelde aanschafprijs
+      van een elektrische auto (zonder belastingen) is dan die van een auto met een
+      verbrandingsmotor. Je geeft daarom dus het prijs <i>verschil</i> aan. De grafiek
+      rechts geeft de aanschafprijs van een referentie benzine auto weer als een grijze
+      balk en dat van een elektrische auto als een blauwe balk.\r\n<br/>\r\n<br/>\r\nWees
+      ervan bewust dat het ETM in deze versie geen investeringskosten voor auto's
+      meeneemt, behalve de extra kosten die je hier specificeert. De reden hiervoor
+      is dat de totale kosten in het dashboard anders gedomineerd zouden worden door
+      deze kosten."
+    short_content_en:
+    short_content_nl:
 - id: 704
   key: industry_useful_demand_for_chemical_refineries
   share_group: ''
@@ -6382,6 +10889,12 @@
   slide_id: 199
   position: 1
   dependent_on: ''
+  description:
+    content_en: Here you can indicate the total size of refineries in the future.
+    content_nl: Geef hier aan hoe de raffinagesector in de toekomst zal groeien of
+      krimpen.
+    short_content_en:
+    short_content_nl:
 - id: 705
   key: industry_useful_demand_for_chemical_refineries_electricity_efficiency
   share_group: ''
@@ -6405,6 +10918,15 @@
   slide_id: 199
   position: 2
   dependent_on: ''
+  description:
+    content_en: How will electric efficiency in refineries improve every year? These
+      improvements are the result of technological innovation or newer and more efficient
+      energetic processes.
+    content_nl: Hoe zal de efficiëntie van de raffinaderijen ieder jaar verbeteren,
+      wat de elektriciteitsvraag betreft? Deze verbeteringen zijn het resultaat van
+      technologische vernieuwing of efficiëntere processen.
+    short_content_en:
+    short_content_nl:
 - id: 706
   key: industry_useful_demand_for_chemical_refineries_useable_heat_efficiency
   share_group: ''
@@ -6428,6 +10950,16 @@
   slide_id: 199
   position: 3
   dependent_on: ''
+  description:
+    content_en: How will the demand for heat generated by burning fuels change in
+      refineries? These improvements are the result of newer and more efficient energetic
+      processes or the result of replacement of fuel-fired heat by ambient or electric
+      heat.
+    content_nl: Hoe zal de efficiëntie van de raffinaderijen ieder jaar verbeteren,
+      wat de warmtevraag betreft? Deze verbeteringen zijn het resultaat van technologische
+      vernieuwing of efficiëntere processen.
+    short_content_en:
+    short_content_nl:
 - id: 707
   key: industry_chemicals_refineries_burner_network_gas_share
   share_group: chemical_refineries_heat
@@ -6451,6 +10983,17 @@
   slide_id: 199
   position: 4
   dependent_on: ''
+  description:
+    content_en: "All heat that is not generated with any of the methods below will
+      be generated using a gas-fired heating system. These systems are quite energy
+      efficient, but emit CO<sub>2</sub>. The latter is a problem if you wish to reduce
+      emissions significantly.\r\n<br>"
+    content_nl: "Alle warmte die niet wordt opgewekt met de methodes hieronder, wordt
+      door het model automatisch ingevuld met een gasketel. Dit zijn behoorlijk efficiënte
+      systemen, maar ze stoten wel CO<sub>2</sub> uit. Dat kan een probleem zijn als
+      je hele grote reducties van broeikasgasemissies wilt halen.\r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 708
   key: industry_chemicals_refineries_burner_crude_oil_share
   share_group: chemical_refineries_heat
@@ -6474,6 +11017,19 @@
   slide_id: 199
   position: 5
   dependent_on: ''
+  description:
+    content_en: "What percentage of heat demand in industry is met by oil-fired heaters?
+      </br></br>\r\nIndustrial heat demand tends to be for high-grade heat, which
+      is best generated by burning fuel.\r\nThe mix you fill in here is probably mostly
+      determined by fuel prices and environmental legislation. See also the <a href=/scenario/costs/fuel_costs/combustion-fuel>‘Costs’</a>
+      part. \r\n<br>"
+    content_nl: "Welk percentage van de industriële warmtevraag wordt ingevuld door
+      oliegestookte ketels? \r\n</br></br>\r\nIn de industrie is vooral hoge temperatuur
+      nodig. Die kan nu het best gemaakt worden door brandstoffen te verstoken. \r\nDe
+      brandstofmix die je hier invult zal waarschijnlijk het meest afhangen van je
+      verwachtingen voor brandstofprijzen. Zie ook het onderdeel <a href=/scenario/costs/fuel_costs/combustion-fuel>'Kosten'</a>.\r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 709
   key: industry_chemicals_refineries_burner_wood_pellets_share
   share_group: chemical_refineries_heat
@@ -6497,6 +11053,19 @@
   slide_id: 199
   position: 6
   dependent_on: ''
+  description:
+    content_en: "What percentage of heat demand in industry is met by biomass-firing?
+      \r\n</br></br>\r\nThis can be used to generate high-grade heat, which is the
+      kind most in demand in industry.\r\nThe mix you fill in here is probably mostly
+      determined by fuel prices and environmental legislation. See also the <a href=/scenario/costs/fuel_costs/combustion-fuel>‘Costs’</a>
+      part.\r\n<br>"
+    content_nl: "Welk percentage van de industriële warmtevraag wordt ingevuld door
+      biomassa? \r\n</br></br>\r\nIn de industrie is vooral hoge temperatuur nodig.
+      Die kan nu het best gemaakt worden door brandstoffen te verstoken.\r\nDe brandstofmix
+      die je hier invult zal waarschijnlijk het meest afhangen van je verwachtingen
+      voor brandstofprijzen. Zie ook het onderdeel <a href=/scenario/costs/fuel_costs/combustion-fuel>'Kosten'</a>.\r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 710
   key: industry_chemicals_refineries_burner_coal_share
   share_group: chemical_refineries_heat
@@ -6520,6 +11089,22 @@
   slide_id: 199
   position: 7
   dependent_on: ''
+  description:
+    content_en: "What percentage of heat demand in industry is met by coal-firing?
+      \r\n</br></br>\r\nCoal (or cokes) are mainly used in the steel manufacturing
+      industry to produce the heat to smelt iron ore.\r\nThe mix you fill in here
+      is probably mostly determined by fuel prices and environmental legislation.
+      See also the <a href=/scenario/costs/fuel_costs/combustion-fuel>‘Costs’</a>
+      part.\r\n<br>"
+    content_nl: "Welk percentage van de industriële warmtevraag wordt ingevuld door
+      kolen? \r\n</br></br>\r\nIn de industrie is vooral hoge temperatuur nodig. Die
+      kan nu het best gemaakt worden door brandstoffen te verstoken. Kolen (of cokes)
+      worden vooral in de staalindustrie ingezet. \r\n</br></br>\r\nDe brandstofmix
+      die je hier invult zal waarschijnlijk het meest afhangen van je verwachtingen
+      voor brandstofprijzen. Zie ook het onderdeel <a href=/scenario/costs/fuel_costs/combustion-fuel>'Kosten'</a>.
+      \r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 711
   key: industry_final_demand_for_chemical_refineries_steam_hot_water_share
   share_group: chemical_refineries_heat
@@ -6543,6 +11128,17 @@
   slide_id: 199
   position: 8
   dependent_on: ''
+  description:
+    content_en: "District heating is heat supplied by a heat network. The heat can
+      be produced by local heat plants / large-scale burners or the heat can be imported
+      from outside your region. You can set the heat sources in the Supply-section
+      under the header <a href=\"/scenario/supply/heat\" >\"Heat networks\"</a>.\r\n"
+    content_nl: Warmte uit een warmtenet kan geproduceerd worden door lokale warmtecentrales
+      / grootschalige warmteketels óf de warmte kan worden geïmporteerd van buiten
+      jouw gebied. Kies de warmtebronnen in het Aanbod-gedeelte onder het kopje <a
+      href="/scenario/supply/heat" >"Warmtenetten"</a>.
+    short_content_en:
+    short_content_nl:
 - id: 712
   key: industry_useful_demand_for_chemical_fertilizers
   share_group: ''
@@ -6566,6 +11162,13 @@
   slide_id: 201
   position: 1
   dependent_on: ''
+  description:
+    content_en: Here you can indicate the total size of the fertilizer industry in
+      the future.
+    content_nl: Geef hier aan hoe de kunstmestsector in de toekomst zal groeien of
+      krimpen.
+    short_content_en:
+    short_content_nl:
 - id: 713
   key: industry_useful_demand_for_chemical_fertilizers_electricity_efficiency
   share_group: ''
@@ -6589,6 +11192,15 @@
   slide_id: 201
   position: 2
   dependent_on: ''
+  description:
+    content_en: "How will electric efficiency in the fertilizer industry improve every
+      year? \r\n</br></br>\r\nThese improvements are the result of technological innovation
+      or newer and more efficient energetic processes."
+    content_nl: "Hoe zal de efficiëntie van de kunstmestindustrie ieder jaar verbeteren,
+      wat de elektriciteitsvraag betreft? \r\n</br></br>\r\nDeze verbeteringen zijn
+      het resultaat van technologische vernieuwing of efficiëntere processen."
+    short_content_en:
+    short_content_nl:
 - id: 714
   key: industry_useful_demand_for_chemical_fertilizers_useable_heat_efficiency
   share_group: ''
@@ -6612,6 +11224,16 @@
   slide_id: 201
   position: 3
   dependent_on: ''
+  description:
+    content_en: "How will the demand for heat generated by burning fuels change in
+      the fertilizer industry? \r\n</br></br>\r\nThese improvements are the result
+      of newer and more efficient energetic processes or the result of replacement
+      of fuel-fired heat by ambient or electric heat."
+    content_nl: "Hoe zal de efficiëntie van de kunstmestindustrie ieder jaar verbeteren,
+      wat de warmtevraag betreft? \r\n</br></br>\r\nDeze verbeteringen zijn het resultaat
+      van technologische vernieuwing of efficiëntere processen."
+    short_content_en:
+    short_content_nl:
 - id: 715
   key: industry_chemicals_fertilizers_burner_network_gas_share
   share_group: chemical_fertilizers_heat
@@ -6635,6 +11257,17 @@
   slide_id: 201
   position: 4
   dependent_on: ''
+  description:
+    content_en: "All heat that is not generated with any of the methods below will
+      be generated using a gas-fired heating system. These systems are quite energy
+      efficient, but emit CO<sub>2</sub>. The latter is a problem if you wish to reduce
+      emissions significantly.\r\n<br>"
+    content_nl: Alle warmte die niet wordt opgewekt met de methodes hieronder, wordt
+      door het model automatisch ingevuld met een gasketel. Dit zijn behoorlijk efficiënte
+      systemen, maar ze stoten wel CO<sub>2</sub> uit. Dat kan een probleem zijn als
+      je hele grote reducties van broeikasgasemissies wilt halen.<br>
+    short_content_en:
+    short_content_nl:
 - id: 716
   key: industry_chemicals_fertilizers_burner_crude_oil_share
   share_group: chemical_fertilizers_heat
@@ -6658,6 +11291,19 @@
   slide_id: 201
   position: 5
   dependent_on: ''
+  description:
+    content_en: "What percentage of heat demand in industry is met by oil-fired heaters?
+      \r\n</br></br>\r\nIndustrial heat demand tends to be for high-grade heat, which
+      is best generated by burning fuel.\r\nThe mix you fill in here is probably mostly
+      determined by fuel prices and environmental legislation. See also the <a href=/scenario/costs/fuel_costs/combustion-fuel>‘Costs’</a>
+      part. \r\n<br>"
+    content_nl: "Welk percentage van de industriële warmtevraag wordt ingevuld door
+      oliegestookte ketels? \r\n</br></br>\r\nIn de industrie is vooral hoge temperatuurswarmte
+      nodig. Die kan nu het best gemaakt worden door brandstoffen te verstoken. \r\nDe
+      brandstofmix die je hier invult zal waarschijnlijk het meest afhangen van je
+      verwachtingen voor brandstofprijzen. Zie ook het onderdeel <a href=/scenario/costs/fuel_costs/combustion-fuel>'Kosten'</a>.\r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 717
   key: industry_chemicals_fertilizers_burner_coal_share
   share_group: chemical_fertilizers_heat
@@ -6681,6 +11327,22 @@
   slide_id: 201
   position: 7
   dependent_on: ''
+  description:
+    content_en: "What percentage of heat demand in industry is met by coal-firing?
+      \r\n</br></br>\r\nCoal (or cokes) are mainly used in the steel manufacturing
+      industry to produce the heat to smelt iron ore.\r\nThe mix you fill in here
+      is probably mostly determined by fuel prices and environmental legislation.
+      See also the <a href=/scenario/costs/fuel_costs/combustion-fuel>‘Costs’</a>
+      part.\r\n<br>"
+    content_nl: "Welk percentage van de industriële warmtevraag wordt ingevuld door
+      kolen? \r\n</br></br>\r\nIn de industrie is vooral hoge temperatuur nodig. Die
+      kan nu het best gemaakt worden door brandstoffen te verstoken. Kolen (of cokes)
+      worden vooral in de staalindustrie ingezet. \r\nDe brandstofmix die je hier
+      invult zal waarschijnlijk het meest afhangen van je verwachtingen voor brandstofprijzen.
+      Zie ook het onderdeel <a href=/scenario/costs/fuel_costs/combustion-fuel>'Kosten'</a>.
+      \r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 718
   key: industry_chemicals_fertilizers_burner_wood_pellets_share
   share_group: chemical_fertilizers_heat
@@ -6704,6 +11366,19 @@
   slide_id: 201
   position: 6
   dependent_on: ''
+  description:
+    content_en: "What percentage of heat demand in industry is met by biomass-firing?
+      \r\n</br></br>\r\nThis can be used to generate high-grade heat, which is the
+      kind most in demand in industry.\r\nThe mix you fill in here is probably mostly
+      determined by fuel prices and environmental legislation. See also the <a href=/scenario/costs/fuel_costs/combustion-fuel>‘Costs’</a>
+      part.\r\n<br>"
+    content_nl: "Welk percentage van de industriële warmtevraag wordt ingevuld door
+      biomassa? \r\n</br></br>\r\nIn de industrie is vooral hoge temperatuurswarmte
+      nodig. Die kan nu het best gemaakt worden door brandstoffen te verstoken.\r\nDe
+      brandstofmix die je hier invult zal waarschijnlijk het meest afhangen van je
+      verwachtingen voor brandstofprijzen. Zie ook het onderdeel <a href=/scenario/costs/fuel_costs/combustion-fuel>'Kosten'</a>.\r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 719
   key: industry_final_demand_for_chemical_fertilizers_steam_hot_water_share
   share_group: chemical_fertilizers_heat
@@ -6727,6 +11402,17 @@
   slide_id: 201
   position: 10
   dependent_on: ''
+  description:
+    content_en: District heating is heat supplied by a heat network. The heat can
+      be produced by local heat plants / large-scale burners or the heat can be imported
+      from outside your region. You can set the heat sources in the Supply-section
+      under the header <a href="/scenario/supply/heat" >"Heat networks"</a>.
+    content_nl: Warmte uit een warmtenet kan geproduceerd worden door lokale warmtecentrales
+      / grootschalige warmteketels óf de warmte kan worden geïmporteerd van buiten
+      jouw gebied. Kies de warmtebronnen in het Aanbod-gedeelte onder het kopje <a
+      href="/scenario/supply/heat" >"Warmtenetten"</a>.
+    short_content_en:
+    short_content_nl:
 - id: 720
   key: industry_useful_demand_for_chemical_other
   share_group: ''
@@ -6750,6 +11436,17 @@
   slide_id: 202
   position: 1
   dependent_on: ''
+  description:
+    content_en: "Non-energetic demand for oil products is the use of oil to make chemical
+      products that do not serve as fuels. For example, plastics, pharmaceuticals
+      and dyes are mainly made from oil.\r\n</br></br>\r\nHere you can indicate the
+      total size of the chemical industry in the future."
+    content_nl: "In geval van niet-energetisch gebruik worden olieproducten gebruikt
+      om chemische producten te maken die niet als brandstof dienen. Onder andere
+      verscheidene plastics, farmaceutica en smeermiddelen worden uit olie gemaakt.\r\n</br></br>\r\nGeef
+      hier aan hoe de raffinagesector in de toekomst zal groeien of krimpen."
+    short_content_en:
+    short_content_nl:
 - id: 721
   key: industry_useful_demand_for_chemical_other_electricity_efficiency
   share_group: ''
@@ -6773,6 +11470,15 @@
   slide_id: 202
   position: 2
   dependent_on: ''
+  description:
+    content_en: "How will electric efficiency in the chemical industry improve every
+      year?\r\n</br></br>\r\nThese improvements are the result of technological innovation
+      or newer and more efficient energetic processes."
+    content_nl: "Hoe zal de efficiëntie van de chemische industrie ieder jaar verbeteren,
+      wat de elektriciteitsvraag betreft? \r\n</br></br>\r\nDeze verbeteringen zijn
+      het resultaat van technologische vernieuwing of efficiëntere processen."
+    short_content_en:
+    short_content_nl:
 - id: 722
   key: industry_useful_demand_for_chemical_other_useable_heat_efficiency
   share_group: ''
@@ -6796,6 +11502,16 @@
   slide_id: 202
   position: 3
   dependent_on: ''
+  description:
+    content_en: "How will the demand for heat generated by burning fuels change in
+      the chemical industry? \r\n</br></br>\r\nThese improvements are the result of
+      newer and more efficient energetic processes or the result of replacement of
+      fuel-fired heat by ambient or electric heat."
+    content_nl: "Hoe zal de efficiëntie van de chemische industrie ieder jaar verbeteren,
+      wat de warmtevraag betreft? \r\n</br></br>\r\nDeze verbeteringen zijn het resultaat
+      van technologische vernieuwing of efficiëntere processen."
+    short_content_en:
+    short_content_nl:
 - id: 723
   key: industry_chemicals_other_burner_network_gas_share
   share_group: chemical_other_heat
@@ -6819,6 +11535,17 @@
   slide_id: 202
   position: 4
   dependent_on: ''
+  description:
+    content_en: All heat that is not generated with any of the methods below will
+      be generated using a gas-fired heating system. These systems are quite energy
+      efficient, but emit CO<sub>2</sub>. The latter is a problem if you wish to reduce
+      emissions significantly.
+    content_nl: Alle warmte die niet wordt opgewekt met de methodes hieronder, wordt
+      door het model automatisch ingevuld met een gasketel. Dit zijn behoorlijk efficiënte
+      systemen, maar ze stoten wel CO<sub>2</sub> uit. Dat kan een probleem zijn als
+      je hele grote reducties van broeikasgasemissies wilt halen.
+    short_content_en:
+    short_content_nl:
 - id: 724
   key: industry_chemicals_other_burner_crude_oil_share
   share_group: chemical_other_heat
@@ -6842,6 +11569,19 @@
   slide_id: 202
   position: 5
   dependent_on: ''
+  description:
+    content_en: "What percentage of heat demand in industry is met by oil-fired heaters?
+      \r\n</br></br>\r\nIndustrial heat demand tends to be for high-grade heat, which
+      is best generated by burning fuel.\r\nThe mix you fill in here is probably mostly
+      determined by fuel prices and environmental legislation. See also the <a href=/scenario/costs/fuel_costs/combustion-fuel>‘Costs’</a>
+      part. \r\n<br>"
+    content_nl: "Welk percentage van de industriële warmtevraag wordt ingevuld door
+      oliegestookte ketels? \r\n</br></br>\r\nIn de industrie is vooral hoge temperatuur
+      nodig. Die kan nu het best gemaakt worden door brandstoffen te verstoken. \r\nDe
+      brandstofmix die je hier invult zal waarschijnlijk het meest afhangen van je
+      verwachtingen voor brandstofprijzen. Zie ook het onderdeel <a href=/scenario/costs/fuel_costs/combustion-fuel>'Kosten'</a>.\r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 725
   key: industry_chemicals_other_burner_wood_pellets_share
   share_group: chemical_other_heat
@@ -6865,6 +11605,19 @@
   slide_id: 202
   position: 7
   dependent_on: ''
+  description:
+    content_en: "What percentage of heat demand in industry is met by biomass-firing?
+      \r\n</br></br>\r\nThis can be used to generate high-grade heat, which is the
+      kind most in demand in industry.\r\nThe mix you fill in here is probably mostly
+      determined by fuel prices and environmental legislation. See also the <a href=/scenario/costs/fuel_costs/combustion-fuel>‘Costs’</a>
+      part.\r\n<br>"
+    content_nl: "Welk percentage van de industriële warmtevraag wordt ingevuld door
+      biomassa? \r\n</br></br>\r\nIn de industrie is vooral hoge temperatuur nodig.
+      Die kan nu het best gemaakt worden door brandstoffen te verstoken.\r\nDe brandstofmix
+      die je hier invult zal waarschijnlijk het meest afhangen van je verwachtingen
+      voor brandstofprijzen. Zie ook het onderdeel <a href=/scenario/costs/fuel_costs/combustion-fuel>'Kosten'</a>.\r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 726
   key: industry_chemicals_other_burner_coal_share
   share_group: chemical_other_heat
@@ -6888,6 +11641,22 @@
   slide_id: 202
   position: 6
   dependent_on: ''
+  description:
+    content_en: "What percentage of heat demand in industry is met by coal-firing?
+      \r\n</br></br>\r\nCoal (or cokes) are mainly used in the steel manufacturing
+      industry to produce the heat to smelt iron ore.\r\nThe mix you fill in here
+      is probably mostly determined by fuel prices and environmental legislation.
+      See also the <a href=/scenario/costs/fuel_costs/combustion-fuel>‘Costs’</a>
+      part.\r\n<br>"
+    content_nl: "Welk percentage van de industriële warmtevraag wordt ingevuld door
+      kolen? \r\n</br></br>\r\nIn de industrie is vooral hoge temperatuur nodig. Die
+      kan nu het best gemaakt worden door brandstoffen te verstoken. Kolen (of cokes)
+      worden vooral in de staalindustrie ingezet. \r\nDe brandstofmix die je hier
+      invult zal waarschijnlijk het meest afhangen van je verwachtingen voor brandstofprijzen.
+      Zie ook het onderdeel <a href=/scenario/costs/fuel_costs/combustion-fuel>'Kosten'</a>.
+      \r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 727
   key: industry_final_demand_for_chemical_other_steam_hot_water_share
   share_group: chemical_other_heat
@@ -6911,6 +11680,17 @@
   slide_id: 202
   position: 13
   dependent_on: ''
+  description:
+    content_en: District heating is heat supplied by a heat network. The heat can
+      be produced by local heat plants / large-scale burners or the heat can be imported
+      from outside your region. You can set the heat sources in the Supply-section
+      under the header <a href="/scenario/supply/heat" >"Heat networks"</a>.
+    content_nl: Warmte uit een warmtenet kan geproduceerd worden door lokale warmtecentrales
+      / grootschalige warmteketels óf de warmte kan worden geïmporteerd van buiten
+      jouw gebied. Kies de warmtebronnen in het Aanbod-gedeelte onder het kopje <a
+      href="/scenario/supply/heat" >"Warmtenetten"</a>.
+    short_content_en:
+    short_content_nl:
 - id: 728
   key: industry_useful_demand_for_other_food
   share_group: ''
@@ -6934,6 +11714,12 @@
   slide_id: 203
   position: 1
   dependent_on: ''
+  description:
+    content_en: Here you can indicate the total size of the food industry in the future.
+    content_nl: Geef hier aan hoe de voedingsmiddelenindustrie in de toekomst zal
+      groeien of krimpen.
+    short_content_en:
+    short_content_nl:
 - id: 729
   key: industry_useful_demand_for_other_food_efficiency
   share_group: ''
@@ -6957,6 +11743,15 @@
   slide_id: 203
   position: 2
   dependent_on: ''
+  description:
+    content_en: "How will efficiency in the food industry improve every year? \r\n</br></br>\r\nThese
+      improvements are the result of technological innovation or newer and more efficient
+      energetic processes."
+    content_nl: "Hoe zal de efficiëntie van de voedingsmiddelenindustrie ieder jaar
+      verbeteren? \r\n</br></br>\r\nDeze verbeteringen zijn het resultaat van technologische
+      vernieuwing of efficiëntere processen."
+    short_content_en:
+    short_content_nl:
 - id: 731
   key: industry_useful_demand_for_other_paper
   share_group: ''
@@ -6980,6 +11775,13 @@
   slide_id: 204
   position: 1
   dependent_on: ''
+  description:
+    content_en: Here you can indicate the total size of the paper industrie in the
+      future.
+    content_nl: Geef hier aan hoe de papierindustrie in de toekomst zal groeien of
+      krimpen.
+    short_content_en:
+    short_content_nl:
 - id: 732
   key: industry_useful_demand_for_other_paper_efficiency
   share_group: ''
@@ -7003,6 +11805,15 @@
   slide_id: 204
   position: 2
   dependent_on: ''
+  description:
+    content_en: "How will efficiency in the paper industry improve every year? \r\n</br></br>\r\nThese
+      improvements are the result of technological innovation or newer and more efficient
+      energetic processes."
+    content_nl: "Hoe zal de efficiëntie van de papier en karton industrie ieder jaar
+      verbeteren? \r\n</br></br>\r\nDeze verbeteringen zijn het resultaat van technologische
+      vernieuwing of efficiëntere processen."
+    short_content_en:
+    short_content_nl:
 - id: 745
   key: climate_relevant_co2_biomass_gas_present
   share_group: ''
@@ -7026,6 +11837,26 @@
   slide_id: 208
   position: 1
   dependent_on: ''
+  description:
+    content_en: "Here you indicate which part of CO<sub>2</sub> emission caused by
+      combustion of gaseous biomass is relevant for climate change.\r\n<p>\r\nBiogas
+      made by fermentation of wet biomass (manure,roadside grass, organic waste and
+      sewage sludge) scores (very) well on sustainability aspects.\r\n<p>\r\nGasification
+      of solid biomass is not common yet. The climate impact may be higher than that
+      of fermentation because the life of solid biomass is longer than that of wet
+      biomass (waste).\r\n<p>\r\nYou can find more information in our <a href=\"https://github.com/quintel/documentation/blob/master/general/co2_biomass.md\"
+      target =\"_blank\">documentation</a>. \r\n"
+    content_nl: "Hier kun je voor de huidige situatie aangeven welk deel van de uitstoot
+      veroorzaakt door het verbranden van gasvormige biomassa je denkt dat relevant
+      is voor klimaatverandering. \r\n<p>\r\nBiogas op basis van mest of reststromen
+      (bermgras, natuurgras, GFT en RWZI-slib) scoort (zeer) goed op de duurzaamheidsaspecten.\r\nVergassing
+      van vaste biomassastromen is nu nog niet gebruikelijk. De klimaatimpact hiervan
+      is mogelijk hoger dan die van vergisting omdat de levensloop van vaste biomassa
+      langer is dan die van natte biomassa(rest)stromen.\r\n<p>\r\nMeer informatie
+      is <a href=\"https://github.com/quintel/documentation/blob/master/general/co2_biomass.md\"
+      target =\"_blank\">hier</a> te vinden. "
+    short_content_en:
+    short_content_nl:
 - id: 746
   key: climate_relevant_co2_biomass_liquid_present
   share_group: ''
@@ -7049,6 +11880,25 @@
   slide_id: 208
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Here you indicate which part of CO<sub>2</sub> emission caused by
+      combustion of gaseous biomass is relevant for climate change.\r\n<p>\r\nThe
+      raw materials for liquid biomass (corn, sugar beet, palm) are commonly grown
+      agricultural. The life cycle of this biomass is short (<1 year). However, the
+      risk of (indirectly) Land Use Change is large. Policies and guidelines seek
+      to reduce this risk through policies and guidelines.\r\n<p>\r\nYou can find
+      more information in our <a href=\"https://github.com/quintel/documentation/blob/master/general/co2_biomass.md\"
+      target =\"_blank\">documentation</a>. "
+    content_nl: "Hier kun je voor de huidige situatie aangeven welk deel van de uitstoot
+      veroorzaakt door het verbranden van vloeibare biomassa je denkt dat relevant
+      is voor klimaatverandering. \r\n<p>\r\nDe grondstoffen voor vloeibare biomassa
+      (maïs, suikerbiet, palm) worden vaak agrarisch verbouwd. De levensloop van deze
+      biomassa is dus kort (< 1 jaar). Het risico van (Indirect) Land Use Change is
+      echter groot. Via beleid en richtlijnen wordt getracht dit risico te beperken.\r\n<p>\r\nMeer
+      informatie is <a href=\"https://github.com/quintel/documentation/blob/master/general/co2_biomass.md\"
+      target =\"_blank\">hier</a> te vinden. "
+    short_content_en:
+    short_content_nl:
 - id: 747
   key: climate_relevant_co2_biomass_solid_present
   share_group: ''
@@ -7072,6 +11922,30 @@
   slide_id: 208
   position: 3
   dependent_on: ''
+  description:
+    content_en: "Here you indicate which part of CO<sub>2</sub> emission caused by
+      combustion of gaseous biomass is relevant for climate change.\r\n<p>\r\nRegrowth
+      after logging takes 20 to 100 years (for example poplar grows fast, birch and
+      pine have a long regrowth-time).\r\n<P>\r\nUse of pruning and waste wood accelerates
+      the natural decomposition process. Typical half-lives for natural decay in forests
+      ranges from 2-5 years for bark to 10-35 years for dead trees.\r\n<P> \r\nThere
+      are also trees species with a short rotation. Willow has an rotation cycle of
+      several years. Using this type of biomass involves risk of land change (LUC
+      and ILUC).\r\n<p>\r\nYou can find more information in our <a href=\"https://github.com/quintel/documentation/blob/master/general/co2_biomass.md\"
+      target =\"_blank\">documentation</a>. "
+    content_nl: "Hier kun je voor de huidige situatie aangeven welk deel van de uitstoot
+      veroorzaakt door het verbranden van vaste biomassa je denkt dat relevant is
+      voor klimaatverandering. \r\n<p>\r\nHergroeien na houtkap duurt 20 tot 100 jaar
+      (kort voor bijvoorbeeld populieren, lang voor bijvoorbeeld berk- en dennenhout)\r\n<p>\r\nGebruik
+      van snoei- en afvalhout versnelt het natuurlijke afbraak proces. Typische halfwaardetijden
+      voor natuurlijk verval in het bos variëren van 2-5 jaar voor schors tot 10-35
+      jaar voor dode bomen.\r\n<p>Er zijn ook bomensoorten met een korte omlooptijd.
+      Wilgenhout heeft een omlooptijd van enkele jaren. Bij dit type biomassa is wel
+      verhoogd risico van landverandering (LUC en ILUC).\r\n<p>\r\nMeer informatie
+      is <a href=\"https://github.com/quintel/documentation/blob/master/general/co2_biomass.md\"
+      target =\"_blank\">hier</a> te vinden. "
+    short_content_en:
+    short_content_nl:
 - id: 748
   key: climate_relevant_co2_biomass_gas_future
   share_group: ''
@@ -7095,6 +11969,26 @@
   slide_id: 208
   position: 4
   dependent_on: ''
+  description:
+    content_en: "Here you indicate which part of CO<sub>2</sub> emission caused by
+      combustion of gaseous biomass is relevant for climate change.\r\n<p>\r\nBiogas
+      made by fermentation of wet biomass (manure,roadside grass, organic waste and
+      sewage sludge) scores (very) well on sustainability aspects.\r\n<p>\r\nGasification
+      of solid biomass is not common yet. The climate impact may be higher than that
+      of fermentation because the life cycle of solid biomass is longer than that
+      of wet biomass (waste).\r\n<p>\r\nYou can find more information in our <a href=\"https://github.com/quintel/documentation/blob/master/general/co2_biomass.md\"
+      target =\"_blank\">documentation</a>. "
+    content_nl: "Hier kun je voor de toekomst aangeven welk deel van de uitstoot veroorzaakt
+      door het verbranden van gasvormige biomassa je denkt dat relevant is voor klimaatverandering.
+      \r\n<p>\r\nBiogas op basis van mest of reststromen (bermgras, natuurgras, GFT
+      en RWZI-slib) scoort (zeer) goed op de duurzaamheidsaspecten.\r\nVergassing
+      van vaste biomassastromen is nu nog niet gebruikelijk. De klimaatimpact hiervan
+      is mogelijk hoger dan die van vergisting omdat de levensloop van vaste biomassa
+      langer is dan die van natte biomassa(rest)stromen.\r\n<p>\r\nMeer informatie
+      is <a href=\"https://github.com/quintel/documentation/blob/master/general/co2_biomass.md\"
+      target =\"_blank\">hier</a> te vinden. "
+    short_content_en:
+    short_content_nl:
 - id: 749
   key: climate_relevant_co2_biomass_liquid_future
   share_group: ''
@@ -7118,6 +12012,25 @@
   slide_id: 208
   position: 5
   dependent_on: ''
+  description:
+    content_en: "Here you indicate which part of CO<sub>2</sub> emission caused by
+      combustion of gaseous biomass is relevant for climate change.\r\n<p>\r\nThe
+      raw materials for liquid biomass (corn, sugar beet, palm) are commonly grown
+      agricultural. The life cycle of this biomass is short (<1 year). However, the
+      risk of (indirectly) Land Use Change is large. Policies and guidelines seek
+      to reduce this risk through policies and guidelines.\r\n<p>\r\nYou can find
+      more information in our <a href=\"https://github.com/quintel/documentation/blob/master/general/co2_biomass.md\"
+      target =\"_blank\">documentation</a>. "
+    content_nl: "Hier kun je voor de toekomst aangeven welk deel van de uitstoot veroorzaakt
+      door het verbranden van vloeibare biomassa je denkt dat relevant is voor klimaatverandering.
+      \r\n<p>\r\nDe grondstoffen voor vloeibare biomassa (maïs, suikerbiet, palm)
+      worden vaak agrarisch verbouwd. De levensloop van deze biomassa is dus kort
+      (< 1 jaar). Het risico van (Indirect) Land Use Change is echter groot. Via beleid
+      en richtlijnen wordt getracht dit risico te beperken.\r\n<p>\r\nMeer informatie
+      kunt is <a href=\"https://github.com/quintel/documentation/blob/master/general/co2_biomass.md\"
+      target =\"_blank\">hier</a> te vinden. "
+    short_content_en:
+    short_content_nl:
 - id: 750
   key: climate_relevant_co2_biomass_solid_future
   share_group: ''
@@ -7141,6 +12054,29 @@
   slide_id: 208
   position: 6
   dependent_on: ''
+  description:
+    content_en: "Here you indicate which part of CO<sub>2</sub> emission caused by
+      combustion of gaseous biomass is relevant for climate change.\r\n<p>\r\nRegrowth
+      after logging takes 20 to 100 years (for example poplar grows fast, birch and
+      pine have a long regrowth-time)\r\n<P>\r\nUse of pruning and waste wood accelerates
+      the natural decomposition process. Typical half-lives for natural decay in forests
+      ranges from 2-5 years for bark to 10-35 years for dead trees.\r\n<P> \r\nThere
+      are also trees species with a short rotation. Willow has an rotation cycle of
+      several years. Using this type of biomass involves risk of land use change (LUC
+      and ILUC).\r\n<p>\r\nYou can find more information in our <a href=\"https://github.com/quintel/documentation/blob/master/general/co2_biomass.md\"
+      target =\"_blank\">documentation</a>. "
+    content_nl: "Hier kun je voor de toekomst aangeven welk deel van de uitstoot veroorzaakt
+      door het verbranden van vaste biomassa relevant is voor het klimaat. \r\n<p>\r\nHergroeien
+      na houtkap duurt 20 tot 100 jaar (kort voor bijvoorbeeld populieren, lang voor
+      bijvoorbeeld berk- en dennenhout)\r\n<p>\r\nGebruik van snoei- en afvalhout
+      versnelt het natuurlijke afbraak proces. Typische halfwaardetijden voor natuurlijk
+      verval in het bos variëren van 2-5 jaar voor schors tot 10-35 jaar voor dode
+      bomen.\r\n<p>Er zijn ook bomensoorten met een korte omlooptijd. Wilgenhout heeft
+      een omlooptijd van enkele jaren. Bij dit type biomassa is wel verhoogd risico
+      van landverandering (LUC en ILUC).\r\n<p>\r\nMeer informatie is <a href=\"https://github.com/quintel/documentation/blob/master/general/co2_biomass.md\"
+      target =\"_blank\">hier</a> te vinden. "
+    short_content_en:
+    short_content_nl:
 - id: 751
   key: industry_useful_demand_for_other_ict
   share_group: ''
@@ -7164,6 +12100,12 @@
   slide_id: 211
   position: 1
   dependent_on: ''
+  description:
+    content_en: Here you can indicate the total size of the central ICT industry in
+      the future.
+    content_nl: Geef hier aan hoe de ICT-industrie in de toekomst zal groeien of krimpen.
+    short_content_en:
+    short_content_nl:
 - id: 752
   key: industry_useful_demand_for_other_ict_efficiency
   share_group: ''
@@ -7187,6 +12129,15 @@
   slide_id: 211
   position: 2
   dependent_on: ''
+  description:
+    content_en: "How will efficiency in the ICT industry improve every year? \r\n</br></br>\r\nThese
+      improvements are the result of technological innovation or newer and more efficient
+      energetic processes."
+    content_nl: "Hoe zal de efficiëntie van de ICT-industrie ieder jaar verbeteren?
+      \r\n</br></br>\r\nDeze verbeteringen zijn het resultaat van technologische vernieuwing
+      of efficiëntere processen."
+    short_content_en:
+    short_content_nl:
 - id: 753
   key: industry_other_food_burner_coal_share
   share_group: other_food_heat
@@ -7210,6 +12161,22 @@
   slide_id: 203
   position: 5
   dependent_on: ''
+  description:
+    content_en: "What percentage of heat demand in industry is met by coal-firing?
+      \r\n</br></br>\r\nCoal (or cokes) are mainly used in the steel manufacturing
+      industry to produce the heat to smelt iron ore.\r\nThe mix you fill in here
+      is probably mostly determined by fuel prices and environmental legislation.
+      See also the <a href=/scenario/costs/fuel_costs/combustion-fuel>‘Costs’</a>
+      part.\r\n<br>"
+    content_nl: "Welk percentage van de industriële warmtevraag wordt ingevuld door
+      kolen? \r\n</br></br>\r\nIn de industrie is vooral hoge temperatuur nodig. Die
+      kan nu het best gemaakt worden door brandstoffen te verstoken. Kolen (of cokes)
+      worden vooral in de staalindustrie ingezet. \r\nDe brandstofmix die je hier
+      invult zal waarschijnlijk het meest afhangen van je verwachtingen voor brandstofprijzen.
+      Zie ook het onderdeel <a href=/scenario/costs/fuel_costs/combustion-fuel>'Kosten'</a>.
+      \r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 754
   key: industry_other_food_burner_crude_oil_share
   share_group: other_food_heat
@@ -7233,6 +12200,19 @@
   slide_id: 203
   position: 4
   dependent_on: ''
+  description:
+    content_en: "What percentage of heat demand in industry is met by oil-fired heaters?
+      \r\n</br></br>\r\nIndustrial heat demand tends to be for high-grade heat, which
+      is best generated by burning fuel.\r\nThe mix you fill in here is probably mostly
+      determined by fuel prices and environmental legislation. See also the <a href=/scenario/costs/fuel_costs/combustion-fuel>‘Costs’</a>
+      part. \r\n<br>"
+    content_nl: "Welk percentage van de industriële warmtevraag wordt ingevuld door
+      oliegestookte ketels? \r\n</br></br>\r\nIn de industrie is vooral hoge temperatuur
+      nodig. Die kan nu het best gemaakt worden door brandstoffen te verstoken. \r\nDe
+      brandstofmix die je hier invult zal waarschijnlijk het meest afhangen van je
+      verwachtingen voor brandstofprijzen. Zie ook het onderdeel <a href=/scenario/costs/fuel_costs/combustion-fuel>'Kosten'</a>.\r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 755
   key: industry_other_food_burner_network_gas_share
   share_group: other_food_heat
@@ -7256,6 +12236,17 @@
   slide_id: 203
   position: 3
   dependent_on: ''
+  description:
+    content_en: "All heat that is not generated with any of the methods below will
+      be generated using a gas-fired heating system. These systems are quite energy
+      efficient, but emit CO<sub>2</sub>. The latter is a problem if you wish to reduce
+      emissions significantly.\r\n<br>"
+    content_nl: "Alle warmte die niet wordt opgewekt met de methodes hieronder, wordt
+      door het model automatisch ingevuld met een gasketel. Dit zijn behoorlijk efficiënte
+      systemen, maar ze stoten wel CO<sub>2</sub> uit. Dat kan een probleem zijn als
+      je hele grote reducties van broeikasgasemissies wilt halen.\r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 756
   key: industry_other_food_burner_wood_pellets_share
   share_group: other_food_heat
@@ -7279,6 +12270,19 @@
   slide_id: 203
   position: 6
   dependent_on: ''
+  description:
+    content_en: "What percentage of heat demand in industry is met by biomass-firing?
+      \r\n</br></br>\r\nThis can be used to generate high-grade heat, which is the
+      kind most in demand in industry.\r\nThe mix you fill in here is probably mostly
+      determined by fuel prices and environmental legislation. See also the <a href=/scenario/costs/fuel_costs/combustion-fuel>‘Costs’</a>
+      part.\r\n<br>"
+    content_nl: "Welk percentage van de industriële warmtevraag wordt ingevuld door
+      biomassa? \r\n</br></br>\r\nIn de industrie is vooral hoge temperatuur nodig.
+      Die kan nu het best gemaakt worden door brandstoffen te verstoken.\r\nDe brandstofmix
+      die je hier invult zal waarschijnlijk het meest afhangen van je verwachtingen
+      voor brandstofprijzen. Zie ook het onderdeel <a href=/scenario/costs/fuel_costs/combustion-fuel>'Kosten'</a>.\r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 757
   key: industry_final_demand_for_other_food_steam_hot_water_share
   share_group: other_food_heat
@@ -7302,6 +12306,17 @@
   slide_id: 203
   position: 9
   dependent_on: ''
+  description:
+    content_en: District heating is heat supplied by a heat network. The heat can
+      be produced by local heat plants / large-scale burners or the heat can be imported
+      from outside your region. You can set the heat sources in the Supply-section
+      under the header <a href="/scenario/supply/heat" >"Heat networks"</a>.
+    content_nl: Warmte uit een warmtenet kan geproduceerd worden door lokale warmtecentrales
+      / grootschalige warmteketels óf de warmte kan worden geïmporteerd van buiten
+      jouw gebied. Kies de warmtebronnen in het Aanbod-gedeelte onder het kopje <a
+      href="/scenario/supply/heat" >"Warmtenetten"</a>.
+    short_content_en:
+    short_content_nl:
 - id: 758
   key: industry_other_food_heater_electricity_share
   share_group: other_food_heat
@@ -7325,6 +12340,21 @@
   slide_id: 203
   position: 8
   dependent_on: ''
+  description:
+    content_en: "Industrial electric boilers are massively enlarged and more sophisticated
+      versions of the common household electric boiler. These boilers can deliver
+      heat of a temperature up to 300 <sup>o</sup>C. Since the temperature of the
+      heat demand varies widely between industries, they can only be implemented as
+      a heating solution in those industries in which all heat demand is of a relatively
+      low temperature.\r\n<br>"
+    content_nl: "Industriële elektrische boilers zijn geavanceerde en enorm vergrote
+      versies van de alledaagse elektrische boiler die in huishoudens te vinden is.
+      Deze boilers kunnen warmte leveren tot een temperatuur van 300 <sup>o</sup>C.
+      Aangezien de temperatuur van de warmtevraag tussen diverse industrieën sterk
+      kan verschillen, kunnen zij enkel ingezet worden in industrieën waarbij alle
+      warmtevraag van een relatief lage temperatuur is.\r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 759
   key: industry_other_paper_burner_network_gas_share
   share_group: other_paper_heat
@@ -7348,6 +12378,17 @@
   slide_id: 204
   position: 3
   dependent_on: ''
+  description:
+    content_en: "All heat that is not generated with any of the methods below will
+      be generated using a gas-fired heating system. These systems are quite energy
+      efficient, but emit CO<sub>2</sub>. The latter is a problem if you wish to reduce
+      emissions significantly.\r\n<br>"
+    content_nl: "Alle warmte die niet wordt opgewekt met de methodes hieronder, wordt
+      door het model automatisch ingevuld met een gasketel. Dit zijn behoorlijk efficiënte
+      systemen, maar ze stoten wel CO<sub>2</sub> uit. Dat kan een probleem zijn als
+      je hele grote reducties van broeikasgasemissies wilt halen.\r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 760
   key: industry_other_paper_burner_crude_oil_share
   share_group: other_paper_heat
@@ -7371,6 +12412,19 @@
   slide_id: 204
   position: 4
   dependent_on: ''
+  description:
+    content_en: "What percentage of heat demand in industry is met by oil-fired heaters?
+      \r\n</br></br>\r\nIndustrial heat demand tends to be for high-grade heat, which
+      is best generated by burning fuel.\r\nThe mix you fill in here is probably mostly
+      determined by fuel prices and environmental legislation. See also the <a href=/scenario/costs/fuel_costs/combustion-fuel>‘Costs’</a>
+      part. \r\n<br>"
+    content_nl: "Welk percentage van de industriële warmtevraag wordt ingevuld door
+      oliegestookte ketels? \r\n</br></br>\r\nIn de industrie is vooral hoge temperatuur
+      nodig. Die kan nu het best gemaakt worden door brandstoffen te verstoken. \r\nDe
+      brandstofmix die je hier invult zal waarschijnlijk het meest afhangen van je
+      verwachtingen voor brandstofprijzen. Zie ook het onderdeel <a href=/scenario/costs/fuel_costs/combustion-fuel>'Kosten'</a>.\r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 761
   key: industry_other_paper_burner_wood_pellets_share
   share_group: other_paper_heat
@@ -7394,6 +12448,19 @@
   slide_id: 204
   position: 6
   dependent_on: ''
+  description:
+    content_en: "What percentage of heat demand in industry is met by biomass-firing?
+      \r\n</br></br>\r\nThis can be used to generate high-grade heat, which is the
+      kind most in demand in industry.\r\nThe mix you fill in here is probably mostly
+      determined by fuel prices and environmental legislation. See also the <a href=/scenario/costs/fuel_costs/combustion-fuel>‘Costs’</a>
+      part.\r\n<br>"
+    content_nl: "Welk percentage van de industriële warmtevraag wordt ingevuld door
+      biomassa? \r\n</br></br>\r\nIn de industrie is vooral hoge temperatuur nodig.
+      Die kan nu het best gemaakt worden door brandstoffen te verstoken.\r\nDe brandstofmix
+      die je hier invult zal waarschijnlijk het meest afhangen van je verwachtingen
+      voor brandstofprijzen. Zie ook het onderdeel <a href=/scenario/costs/fuel_costs/combustion-fuel>'Kosten'</a>.\r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 762
   key: industry_other_paper_burner_coal_share
   share_group: other_paper_heat
@@ -7417,6 +12484,22 @@
   slide_id: 204
   position: 5
   dependent_on: ''
+  description:
+    content_en: "What percentage of heat demand in industry is met by coal-firing?
+      \r\n</br></br>\r\nCoal (or cokes) are mainly used in the steel manufacturing
+      industry to produce the heat to smelt iron ore.\r\nThe mix you fill in here
+      is probably mostly determined by fuel prices and environmental legislation.
+      See also the <a href=/scenario/costs/fuel_costs/combustion-fuel>‘Costs’</a>
+      part.\r\n<br>"
+    content_nl: "Welk percentage van de industriële warmtevraag wordt ingevuld door
+      kolen? \r\n</br></br>\r\nIn de industrie is vooral hoge temperatuur nodig. Die
+      kan nu het best gemaakt worden door brandstoffen te verstoken. Kolen (of cokes)
+      worden vooral in de staalindustrie ingezet. \r\nDe brandstofmix die je hier
+      invult zal waarschijnlijk het meest afhangen van je verwachtingen voor brandstofprijzen.
+      Zie ook het onderdeel <a href=/scenario/costs/fuel_costs/combustion-fuel>'Kosten'</a>.
+      \r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 763
   key: industry_final_demand_for_other_paper_steam_hot_water_share
   share_group: other_paper_heat
@@ -7440,6 +12523,17 @@
   slide_id: 204
   position: 9
   dependent_on: ''
+  description:
+    content_en: District heating is heat supplied by a heat network. The heat can
+      be produced by local heat plants / large-scale burners or the heat can be imported
+      from outside your region. You can set the heat sources in the Supply-section
+      under the header <a href="/scenario/supply/heat" >"Heat networks"</a>.
+    content_nl: Warmte uit een warmtenet kan geproduceerd worden door lokale warmtecentrales
+      / grootschalige warmteketels óf de warmte kan worden geïmporteerd van buiten
+      jouw gebied. Kies de warmtebronnen in het Aanbod-gedeelte onder het kopje <a
+      href="/scenario/supply/heat" >"Warmtenetten"</a>.
+    short_content_en:
+    short_content_nl:
 - id: 764
   key: industry_other_paper_heater_electricity_share
   share_group: other_paper_heat
@@ -7463,6 +12557,21 @@
   slide_id: 204
   position: 8
   dependent_on: ''
+  description:
+    content_en: "Industrial electric boilers are massively enlarged and more sophisticated
+      versions of the common household electric boiler. These boilers can deliver
+      heat of a temperature up to 300 <sup>o</sup>C. Since the temperature of the
+      heat demand varies widely between industries, they can only be implemented as
+      a heating solution in those industries in which all heat demand is of a relatively
+      low temperature.\r\n<br>"
+    content_nl: "Industriële elektrische boilers zijn geavanceerde en enorm vergrote
+      versies van de alledaagse elektrische boiler die in huishoudens te vinden is.
+      Deze boilers kunnen warmte leveren tot een temperatuur van 300 <sup>o</sup>C.
+      Aangezien de temperatuur van de warmtevraag tussen diverse industrieën sterk
+      kan verschillen, kunnen zij enkel ingezet worden in industrieën waarbij alle
+      warmtevraag van een relatief lage temperatuur is.\r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 766
   key: transport_car_using_electricity_fast_charging_share
   share_group: flexibility_demand_response_electric_vehicle_profiles
@@ -7486,6 +12595,19 @@
   slide_id: 212
   position: 3
   dependent_on: ''
+  description:
+    content_en: "Which fraction of electricity used by electric vehicles is supplied
+      by so-called 'fast charging'? This type of charging typically happens at charging
+      capacities between 11 to 22 kW.\r\n<br>\r\n<br>\r\nThe profile used to describe
+      this type of charging behaviour has been taken from the <a href=\"https://refman.energytransitionmodel.com/publications/2055\"
+      target=\"_blank\">Movares study \"Laadstrategie elektrisch wegvervoer (2013)\"</a>."
+    content_nl: "Welke fractie van het elektriciteitsgebruik van elektrische auto's
+      wordt door 'snelladen' voldaan? Snelladen gebeurt typisch met laadcapaciteiten
+      tussen de 11 en 22 kW.\r\n<br>\r\n<br>\r\nHet profiel dat dit type laadgedrag
+      beschrijft is beschreven in de <a href=\"https://refman.energytransitionmodel.com/publications/2055\"
+      target=\"_blank\">Movares studie \"Laadstrategie elektrisch wegvervoer (2013)\"</a>."
+    short_content_en:
+    short_content_nl:
 - id: 767
   key: transport_car_using_electricity_hybrid_charging_share
   share_group: flexibility_demand_response_electric_vehicle_profiles
@@ -7509,6 +12631,18 @@
   slide_id: 212
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Which fraction of electricity used by electric vehicles is supplied
+      by a charging profile which describes people charging at the office as well
+      as at home?\r\n<br>\r\n<br>\r\nThe profile used to describe this type of charging
+      behaviour has been taken from the <a href=\"https://refman.energytransitionmodel.com/publications/2055\"
+      target=\"_blank\">Movares study \"Laadstrategie elektrisch wegvervoer (2013)\"</a>."
+    content_nl: "Welke fractie van het elektriciteitsgebruik van elektrische auto's
+      wordt voldaan door zowel op het werk als thuis te laden?\r\n<br>\r\n<br>\r\nHet
+      profiel dat dit type laadgedrag beschrijft is beschreven in de <a href=\"https://refman.energytransitionmodel.com/publications/2055\"
+      target=\"_blank\">Movares studie \"Laadstrategie elektrisch wegvervoer (2013)\"</a>."
+    short_content_en:
+    short_content_nl:
 - id: 768
   key: transport_car_using_electricity_home_charging_share
   share_group: flexibility_demand_response_electric_vehicle_profiles
@@ -7532,6 +12666,19 @@
   slide_id: 212
   position: 1
   dependent_on: ''
+  description:
+    content_en: "Which fraction of electricity used by electric vehicles is supplied
+      by people charging exclusively at home? Charging at home typically happens at
+      a capacity of 3.7 kW.\r\n<br>\r\n<br>\r\nThe profile used to describe this type
+      of charging behaviour has been taken from the <a href=\"https://refman.energytransitionmodel.com/publications/2055\"
+      target=\"_blank\">Movares study \"Laadstrategie elektrisch wegvervoer (2013)\"</a>."
+    content_nl: "Welke fractie van het elektriciteitsgebruik van elektrische auto's
+      wordt voldaan door uitsluitend thuis te laden? Thuisladen gebeurt veelal met
+      een laadcapaciteit van 3.7 kW.\r\n<br>\r\n<br>\r\nHet profiel dat dit type laadgedrag
+      beschrijft is beschreven in de <a href=\"https://refman.energytransitionmodel.com/publications/2055\"
+      target=\"_blank\">Movares studie \"Laadstrategie elektrisch wegvervoer (2013)\"</a>."
+    short_content_en:
+    short_content_nl:
 - id: 769
   key: transport_truck_using_hydrogen_share
   share_group: transport_truck_tech
@@ -7555,6 +12702,33 @@
   slide_id: 26
   position: 2
   dependent_on: ''
+  description:
+    content_en: "What percentage of all trucks will be hydrogen fuelled vehicles in
+      the future?<br/><br/>\r\nHydrogen is an energy carrier - not an energy source
+      -, so it has to be produced first. In the <a href=\"/scenario/supply/hydrogen/hydrogen-production\"
+      >hydrogen production section</a> you can determine how this is done - through
+      steam reforming of methane (a powerful greenhouse gas) or through green electrolysis.\r\n<br/><br/>\r\nHydrogen
+      trucks (in the ETM) are fuel cell electric vehicles (FCEVs). Hydrogen in consumer
+      vehicles is stored at a very high pressure of 350 bar in order to ensure a long
+      driving range (of typically 500 km). FCEVs are electric vehicles, but they differ
+      from electric vehicles in the sense that the electricity is not stored on board
+      in a battery, but instead generated in the car itself. \r\n<br/><br/>\r\nSee
+      the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used."
+    content_nl: "Welk percentage van alle vrachtwagens zal op waterstof rijden in
+      de toekomst? <br/><br/>\r\nWaterstof is een energiedrager - geen energiebron
+      -,  dus het zal eerst geproduceerd moeten worden. In de <a href=\"/scenario/supply/hydrogen/hydrogen-production\"
+      >waterstofproductiesectie</a> kun je bepalen hoe dat gedaan wordt - door het
+      reformen van methaan (een krachtig broeikasgas) of door groene elektrolyse.\r\n
+      <br/><br/>\r\nWaterstofvrachtwagens (in het ETM) zijn Fuel Cell Electric Vehicles
+      (FCEVs), ofwel elektrische vrachtwagens met een brandstofcel. Waterstof wordt
+      onder een hele hoge druk van 350 bar opgeslagen in vrachtwagens. Waterstofvoertuigen
+      zijn daarom elektrische voertuigen, maar zij verschillen van elektrische voertuigen
+      in de zin dat de elektriciteit niet aan boord in een accu opgeslagen is, maar
+      tijdens het gebruik gegenereerd wordt.\r\n<br/><br/>\r\nZie onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en:
+    short_content_nl:
 - id: 770
   key: industry_chemicals_other_steam_recompression_electricity_share
   share_group: chemical_other_heat
@@ -7578,6 +12752,27 @@
   slide_id: 202
   position: 11
   dependent_on: ''
+  description:
+    content_en: "Which percentage of the heat demand of the chemical sector will be
+      supplied by mechanical vapour recompression?\r\n<br></br>\r\nThis technology
+      uses waste steam as input. Through compression both pressure and temperature
+      of the waste steam increase. The required compression energy is very small compared
+      to the amount of latent heat present in the recycled steam. The full process
+      has a COP of 9.8.\r\n<br></br>\r\nCaution, not all heat demand of the chemical
+      sector requires steam. More information about this can be found in the Dutch
+      report <a href=\"https://refman.energytransitionmodel.com/publications/2052\"
+      target=\"_blank\">Denktank Energiemarkt Industriële warmtemarkt\"</a>.\r\n<br>"
+    content_nl: "Welk percentage van de warmtevraag van de chemische industrie wordt
+      ingevuld door stoomrecompressie? \r\n<br></br>\r\nDeze technologie gebruikt
+      \"afvalstoom\" van lage temperatuur en druk. Door compressie worden zowel de
+      druk als de temperatuur verhoogd. De energie die nodig is voor compressie is
+      klein in vergelijking met de restwarmte die in de \"afvalstoom\" nog aanwezig
+      is. Het totale proces heeft een COP van 9.8.\r\n<br></br>\r\nLet op, niet alle
+      warmtevraag van de chemische sector bestaat uit stoomvraag. Meer informatie
+      over de verdeling van de warmtevraag is te vinden in de CE Delft studie <a href=\"https://refman.energytransitionmodel.com/publications/2052\"
+      target=\"_blank\">Denktank Energiemarkt Industriële warmtemarkt\"</a>.\r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 771
   key: industry_chemicals_other_heatpump_water_water_electricity_share
   share_group: chemical_other_heat
@@ -7601,6 +12796,29 @@
   slide_id: 202
   position: 12
   dependent_on: ''
+  description:
+    content_en: "Which percentage of the heat demand of the chemical sector will be
+      supplied by industrial heat pumps?\r\n<br></br>\r\nThe end product of this process
+      is steam. The steam generation is carried out in two process steps. Within the
+      first step, hot water (T < 100 °C) is prepared by a heat pump. In the next step
+      low-pressure for vaporization is produced by a vapour steam compressor, a compressor
+      is used to compress the steam to the desired level. The COP of the complete
+      process is 2.8.\r\n<br></br>\r\nCaution, not all heat demand of the chemical
+      sector requires steam. More information about this can be found in the Dutch
+      report <a href=\"https://refman.energytransitionmodel.com/publications/2052\"
+      target=\"_blank\">Denktank Energiemarkt Industriële warmtemarkt\"</a>.\r\n<br>"
+    content_nl: "Welk percentage van de warmtevraag van de chemische industrie wordt
+      ingevuld door industriële warmtepompen? \r\n<br></br>\r\nHet eindproduct van
+      dit proces is stoom. De stoomgeneratie bestaat uit twee stappen. In de eerste
+      stap wordt water verwarmd door een warmtepomp. Dit water wordt vervolgens bij
+      lage druk verdampt. De stoom die hierbij ontstaat wordt door een compressor
+      op de gewenste druk gebracht. De COP van het totale proces is 2.8.\r\n<br></br>\r\nLet
+      op, niet alle warmtevraag van de chemische sector bestaat uit stoomvraag. Meer
+      informatie over de verdeling van de warmtevraag is te vinden in de CE Delft
+      studie <a href=\"https://refman.energytransitionmodel.com/publications/2052\"
+      target=\"_blank\">Denktank Energiemarkt Industriële warmtemarkt\"</a>.\r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 772
   key: capacity_of_industry_chemicals_other_flexibility_p2h_electricity
   share_group: ''
@@ -7624,6 +12842,27 @@
   slide_id: 202
   position: 13
   dependent_on: ''
+  description:
+    content_en: "Power-to-heat (P2H) boilers convert <strong>excess</strong> electricity
+      into heat. These boilers can be installed as an add-on for the existing gas
+      and hydrogen burners. During moments of excess electricity gas and hydrogen
+      burners will then lower their production (when these boilers are present). The
+      average FLH of P2H boilers in industry can be seen in the 'Flexibility options'-table
+      (go to the entire chart list in the upper right corner -> click on 'see more
+      charts\"). There are more technologies that use excess electricity. Therefore,
+      the order in which the flexibility technologies have to be applied can be chosen
+      <a href=\"/scenario/flexibility/excess_electricity/order-of-flexibility-options\">here</a>.\r\n</br>"
+    content_nl: "Power-to-heat (P2H) boilers produceren warmte met elektriciteitsoverschotten.
+      Deze boilers kunnen worden geïnstalleerd als een add-on bij bestaande gas- en
+      waterstofketels. Tijdens elektriciteitsoverschotten zal de productie van gas-
+      en waterstofketels verlaagd worden wanneer P2H wordt ingezet. De gemiddelde
+      vollasturen van de P2H boilers in de industrie zijn te zien in de 'Flexibiliteitsopties'-tabel
+      (ga hiervoor naar de complete grafiekenlijst rechtsbovenaan -> klik op 'meer
+      grafieken bekijken'). Er zijn meer technoloigieën die elektriciteitsoverschotten
+      gebruiken, daarom is het mogelijk om <a href=\"/scenario/flexibility/excess_electricity/order-of-flexibility-options\">hier</a>
+      de volgorde te bepalen waarin de technologieën worden ingezet.\r\n</br>"
+    short_content_en:
+    short_content_nl:
 - id: 773
   key: capacity_of_industry_chemicals_refineries_flexibility_p2h_electricity
   share_group: ''
@@ -7647,6 +12886,27 @@
   slide_id: 199
   position: 10
   dependent_on: ''
+  description:
+    content_en: "Power-to-heat (P2H) boilers convert <strong>excess</strong> electricity
+      into heat. These boilers can be installed as an add-on for the existing gas
+      and hydrogen burners. During moments of excess electricity gas and hydrogen
+      burners will then lower their production (when these boilers are present). The
+      average FLH of P2H boilers in industry can be seen in the 'Flexibility options'-table
+      (go to the entire chart list in the upper right corner -> click on 'see more
+      charts\"). There are more technologies that use excess electricity. Therefore,
+      the order in which the flexibility technologies have to be applied can be chosen
+      <a href=\"/scenario/flexibility/excess_electricity/order-of-flexibility-options\">here</a>.\r\n</br>"
+    content_nl: "Power-to-heat (P2H) boilers produceren warmte met elektriciteitsoverschotten.
+      Deze boilers kunnen worden geïnstalleerd als een add-on bij bestaande gas- en
+      waterstofketels. Tijdens elektriciteitsoverschotten zal de productie van gas-
+      en waterstofketels verlaagd worden wanneer P2H wordt ingezet. De gemiddelde
+      vollasturen van de P2H boilers in de industrie zijn te zien in de 'Flexibiliteitsopties'-tabel
+      (ga hiervoor naar de complete grafiekenlijst rechtsbovenaan -> klik op 'meer
+      grafieken bekijken'). Er zijn meer technoloigieën die elektriciteitsoverschotten
+      gebruiken, daarom is het mogelijk om <a href=\"/scenario/flexibility/excess_electricity/order-of-flexibility-options\">hier</a>
+      de volgorde te bepalen waarin de technologieën worden ingezet.\r\n</br>"
+    short_content_en:
+    short_content_nl:
 - id: 774
   key: capacity_of_industry_other_food_flexibility_p2h_electricity
   share_group: ''
@@ -7670,6 +12930,27 @@
   slide_id: 203
   position: 10
   dependent_on: ''
+  description:
+    content_en: "Power-to-heat (P2H) boilers convert <strong>excess</strong> electricity
+      into heat. These boilers can be installed as an add-on for the existing gas
+      and hydrogen burners. During moments of excess electricity gas and hydrogen
+      burners will then lower their production (when these boilers are present). The
+      average FLH of P2H boilers in industry can be seen in the 'Flexibility options'-table
+      (go to the entire chart list in the upper right corner -> click on 'see more
+      charts\"). There are more technologies that use excess electricity. Therefore,
+      the order in which the flexibility technologies have to be applied can be chosen
+      <a href=\"/scenario/flexibility/excess_electricity/order-of-flexibility-options\">here</a>.\r\n</br>"
+    content_nl: "Power-to-heat (P2H) boilers produceren warmte met elektriciteitsoverschotten.
+      Deze boilers kunnen worden geïnstalleerd als een add-on bij bestaande gas- en
+      waterstofketels. Tijdens elektriciteitsoverschotten zal de productie van gas-
+      en waterstofketels verlaagd worden wanneer P2H wordt ingezet. De gemiddelde
+      vollasturen van de P2H boilers in de industrie zijn te zien in de 'Flexibiliteitsopties'-tabel
+      (ga hiervoor naar de complete grafiekenlijst rechtsbovenaan -> klik op 'meer
+      grafieken bekijken'). Er zijn meer technoloigieën die elektriciteitsoverschotten
+      gebruiken, daarom is het mogelijk om <a href=\"/scenario/flexibility/excess_electricity/order-of-flexibility-options\">hier</a>
+      de volgorde te bepalen waarin de technologieën worden ingezet.\r\n</br>"
+    short_content_en:
+    short_content_nl:
 - id: 775
   key: capacity_of_industry_other_paper_flexibility_p2h_electricity
   share_group: ''
@@ -7693,6 +12974,27 @@
   slide_id: 204
   position: 10
   dependent_on: ''
+  description:
+    content_en: "Power-to-heat (P2H) boilers convert <strong>excess</strong> electricity
+      into heat. These boilers can be installed as an add-on for the existing gas
+      and hydrogen burners. During moments of excess electricity gas and hydrogen
+      burners will then lower their production (when these boilers are present). The
+      average FLH of P2H boilers in industry can be seen in the 'Flexibility options'-table
+      (go to the entire chart list in the upper right corner -> click on 'see more
+      charts\"). There are more technologies that use excess electricity. Therefore,
+      the order in which the flexibility technologies have to be applied can be chosen
+      <a href=\"/scenario/flexibility/excess_electricity/order-of-flexibility-options\">here</a>.\r\n</br>"
+    content_nl: "Power-to-heat (P2H) boilers produceren warmte met elektriciteitsoverschotten.
+      Deze boilers kunnen worden geïnstalleerd als een add-on bij bestaande gas- en
+      waterstofketels. Tijdens elektriciteitsoverschotten zal de productie van gas-
+      en waterstofketels verlaagd worden wanneer P2H wordt ingezet. De gemiddelde
+      vollasturen van de P2H boilers in de industrie zijn te zien in de 'Flexibiliteitsopties'-tabel
+      (ga hiervoor naar de complete grafiekenlijst rechtsbovenaan -> klik op 'meer
+      grafieken bekijken'). Er zijn meer technoloigieën die elektriciteitsoverschotten
+      gebruiken, daarom is het mogelijk om <a href=\"/scenario/flexibility/excess_electricity/order-of-flexibility-options\">hier</a>
+      de volgorde te bepalen waarin de technologieën worden ingezet.\r\n</br>"
+    short_content_en:
+    short_content_nl:
 - id: 776
   key: industry_chemicals_other_heater_electricity_share
   share_group: chemical_other_heat
@@ -7716,6 +13018,24 @@
   slide_id: 202
   position: 9
   dependent_on: ''
+  description:
+    content_en: "Industrial electric boilers are massively enlarged and more sophisticated
+      versions of the common household electric boiler. These boilers can deliver
+      heat of a temperature up to 300 <sup>o</sup>C. Since the temperature of the
+      heat demand varies widely between and within industries, they can only be implemented
+      as a heating solution for the part of the heating demand which require relatively
+      low temperatures.\r\n<br>"
+    content_nl: "Industriële elektrische boilers zijn geavanceerde en enorm vergrote
+      versies van de alledaagse elektrische boiler die in huishoudens te vinden is.
+      Deze boilers kunnen warmte leveren tot een temperatuur van 300 <sup>o</sup>C.
+      Aangezien de temperatuur van de warmtevraag tussen diverse industrieën en binnen
+      een industrie sterk kan verschillen, kunnen zij enkel ingezet worden voor dat
+      gedeelte van de vraag waar relatief lage temperatuur nodig is.\r\n<br></br>\r\nMeer
+      informatie over de verdeling van de warmtevraag is te vinden in de CE Delft
+      studie <a href=\"https://refman.energytransitionmodel.com/publications/2052\"
+      target=\"_blank\">Denktank Energiemarkt Industriële warmtemarkt\"</a>.\r\n<br>"
+    short_content_en:
+    short_content_nl:
 - id: 777
   key: households_flexibility_space_heating_buffer_size_heatpump_air_water_electricity
   share_group: ''
@@ -7739,6 +13059,23 @@
   slide_id: 216
   position: 1
   dependent_on: ''
+  description:
+    content_en: "Currently most heat pumps (air) are installed without a buffer for
+      space heating. \r\n</p>\r\nMost heat pumps (air) require a buffer to prevent
+      unnecessarily\r\nfrequent on and off switching of the compressors. In the default
+      settings of the ETM the buffer for hot water takes care of this.\r\n</p>\r\nIn
+      the future buffers can also be used to store larger amounts of heat. For example
+      through an <a href=\"http://www.ecovat.eu/?lang=en\">Ecovat</a>\r\n</p>\r\nHere
+      you can indicate the buffer size you expect in the future per heat pumps (air)."
+    content_nl: "In de huidige situatie worden de meeste luchtwarmtepompen zonder
+      buffer voor ruimteverwarming geïnstalleerd.  \r\n</p>\r\nDe meeste luchtwarmtepompen
+      hebben een buffer nodig om te voorkomen dat de compressor gaat \"pendelen\".
+      In de standaardinstelling van het ETM voorziet de buffer voor warm water hierin.\r\n</p>\r\nEen
+      buffer kan echter ook gebruikt worden om grotere hoeveelheden warmte op te slaan.
+      Bijvoorbeeld via een <a href=\"http://www.ecovat.eu/?lang=en\">Ecovat</a>. \r\n</p>\r\nGeef
+      hier aan hoe groot de buffer voor warm water is per luchtwarmtepomp."
+    short_content_en:
+    short_content_nl:
 - id: 778
   key: households_flexibility_water_heating_buffer_size_heatpump_air_water_electricity
   share_group: ''
@@ -7762,6 +13099,17 @@
   slide_id: 216
   position: 1
   dependent_on: ''
+  description:
+    content_en: "In the current situation this buffer represents a tank of 100 liter,
+      the typical tank size for a Dutch household.\r\n</p>\r\nIn the future buffers
+      can also be used to store larger amounts of heat.\r\n</p>\r\nHere you can indicate
+      the buffer size you expect in the future per heat pump (air)."
+    content_nl: "De standaard buffergrootte representeert een watertank van 100 liter.
+      Dit is de typische grootte van een tank voor een Nederlands gezin.\r\n</p>\r\nEen
+      buffer kan echter ook gebruikt worden om grotere hoeveelheden warmte op te slaan.
+      \r\n</p>\r\nGeef hier aan hoe groot de buffer voor ruimteverwarming is per luchtwarmtepomp."
+    short_content_en:
+    short_content_nl:
 - id: 779
   key: households_flexibility_space_heating_cop_cutoff
   share_group: ''
@@ -7785,6 +13133,19 @@
   slide_id: 216
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Here you indicate the threshold COP of hybrid heat pumps for space
+      heating.\r\n<p>\r\nThe default setting is that the electric part of the HHP
+      is used maximally for space heating.\r\n<p>\r\nWith the current gas and electricity
+      price financial optimization for the user is achieved with a threshold COP of
+      \ 3.6.\r\nFor calculations see <a href=\"https://github.com/quintel/documentation/blob/bd77c99e145958613a8c2e45116e887a1d01a39a/general/heat_pumps.md\">Documentation</a>"
+    content_nl: "Geef hier aan wat de omslag-COP van het hybride warmtepompen is voor
+      ruimteverwarming.\r\n<p>\r\nMet de standaardinstelling voor de omslag-COP wordt
+      het elektrische deel van de hybride warmtepomp maximal gebruikt voor ruimteverwarming.\r\n<p>\r\nMet
+      de huidige gas- en elektriciteitsprijs wordt financiële optimalisatie voor de
+      gebruiker bereikt met een omslag-COP van 3.6. Voor meer informatie zie: <a href=\"https://github.com/quintel/documentation/blob/bd77c99e145958613a8c2e45116e887a1d01a39a/general/heat_pumps.md\">Documentatie</a>"
+    short_content_en:
+    short_content_nl:
 - id: 780
   key: households_flexibility_water_heating_cop_cutoff
   share_group: ''
@@ -7808,6 +13169,19 @@
   slide_id: 216
   position: 3
   dependent_on: ''
+  description:
+    content_en: "Here you indicate the threshold COP of hybrid heat pumps for hot
+      water.\r\n<p>\r\nThe default setting is that the gas part of the HHP is used
+      for hot water.\r\n<p>\r\nWith the current gas and electricity price financial
+      optimization for the user is achieved with a threshold COP of  3.1.\r\nFor calculations
+      see <a href=\"https://github.com/quintel/documentation/blob/bd77c99e145958613a8c2e45116e887a1d01a39a/general/heat_pumps.md\">Documentation</a>"
+    content_nl: "Geef hier aan wat de omslag-COP van het hybride warmtepompen is voor
+      warm water.\r\n<p>\r\nMet de standaardinstelling voor de omslag-COP wordt het
+      gasdeel van de hybride warmtepomp maximal gebruikt voor verwarmen van tapwater.\r\n<p>\r\nMet
+      de huidige gas- en elektriciteitsprijs wordt financiële optimalisatie voor de
+      gebruiker bereikt met een omslag-COP van 3.1. Voor meer informatie zie: <a href=\"https://github.com/quintel/documentation/blob/bd77c99e145958613a8c2e45116e887a1d01a39a/general/heat_pumps.md\">Documentatie</a>"
+    short_content_en:
+    short_content_nl:
 - id: 781
   key: investment_costs_households_storage_space_heating
   share_group:
@@ -7877,6 +13251,23 @@
   slide_id: 216
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Currently most ground heat pumps are installed without a buffer for
+      space heating. \r\n</p>\r\nMost ground heat pumps require a buffer to prevent
+      unnecessarily\r\nfrequent on and off switching of the compressors. In the default
+      settings of the ETM the buffer for hot water takes care of this.\r\n</p>\r\nIn
+      the future buffers can also be used to store larger amounts of heat. For example
+      through an <a href=\"http://www.ecovat.eu/?lang=en\">Ecovat</a>\r\n</p>\r\nHere
+      you can indicate the buffer size you expect in the future per ground heat pump."
+    content_nl: "In de huidige situatie worden de meeste bodemwarmtepompen zonder
+      buffer voor ruimteverwarming geïnstalleerd.  \r\n</p>\r\nDe meeste bodemwarmtepompen
+      hebben een buffer nodig om te voorkomen dat de compressor gaat \"pendelen\".
+      In de standaardinstelling van het ETM voorziet de buffer voor warm water hierin.\r\n</p>\r\nEen
+      buffer kan echter ook gebruikt worden om grotere hoeveelheden warmte op te slaan.
+      Bijvoorbeeld via een <a href=\"http://www.ecovat.eu/?lang=en\">Ecovat</a>. \r\n</p>\r\nGeef
+      hier aan hoe groot de buffer voor warm water is per bodemwarmtepomp."
+    short_content_en:
+    short_content_nl:
 - id: 784
   key: households_flexibility_space_heating_buffer_size_hybrid_heatpump_air_water_electricity
   share_group: ''
@@ -7900,6 +13291,18 @@
   slide_id: 216
   position: 3
   dependent_on: ''
+  description:
+    content_en: "Most hybrid heat pumps are self-regulating. They don't need a buffer
+      to protect the compressor.\r\n</p>\r\nIn the future buffers can also be used
+      to store larger amounts of heat. For example through an <a href=\"http://www.ecovat.eu/?lang=en\">Ecovat</a>\r\n</p>\r\nHere
+      you can indicate the buffer size you expect in the future per hybrid heat pump."
+    content_nl: "Omdat de meeste hybride warmtepompen modulerend zijn hebben ze geen
+      buffer nodig om te compressor the beschermen.\r\n</p>\r\nEen buffer kan echter
+      ook gebruikt worden om grotere hoeveelheden warmte op te slaan. Bijvoorbeeld
+      via een <a href=\"http://www.ecovat.eu/?lang=en\">Ecovat</a>. \r\n</p>\r\nGeef
+      hier aan hoe groot de buffer voor warm water is per hybride warmtepomp."
+    short_content_en:
+    short_content_nl:
 - id: 785
   key: settings_weather_curve_set
   share_group: ''
@@ -7923,6 +13326,11 @@
   slide_id: 163
   position: 7
   dependent_on: has_weather_curves
+  description:
+    content_en: ''
+    content_nl: ''
+    short_content_en:
+    short_content_nl:
 - id: 786
   key: households_flexibility_water_heating_buffer_size_heatpump_ground_water_electricity
   share_group: ''
@@ -7946,6 +13354,17 @@
   slide_id: 216
   position: 2
   dependent_on: ''
+  description:
+    content_en: "In the current situation this buffer represents a tank of 100 liter,
+      the typical tank size for a Dutch household.\r\n</p>\r\nIn the future buffers
+      can also be used to store larger amounts of heat.\r\n</p>\r\nHere you can indicate
+      the buffer size you expect in the future per heat pump ground."
+    content_nl: "De standaard buffergrootte representeert een watertank van 100 liter.
+      Dit is de typische grootte van een tank voor een Nederlands gezin.\r\n</p>\r\nEen
+      buffer kan echter ook gebruikt worden om grotere hoeveelheden warmte op te slaan.
+      \r\n</p>\r\nGeef hier aan hoe groot de buffer voor ruimteverwarming is per bodemwarmtepomp."
+    short_content_en:
+    short_content_nl:
 - id: 787
   key: households_flexibility_water_heating_buffer_size_hybrid_heatpump_air_water_electricity
   share_group: ''
@@ -7969,6 +13388,24 @@
   slide_id: 216
   position: 3
   dependent_on: ''
+  description:
+    content_en: "With the default settings the hybrid heat pump supplies hot water
+      with gas. In that case a buffer for hot water is not needed.\r\n</p>\r\nBy lowering
+      the threshold COP the electric part of the hybrid heat pump can also supply
+      hot water. This is generally done through a buffer vessel.\r\n</p>\r\nFor a
+      normal Dutch household a buffer of 100 liter (5 kWh) is sufficient. In the future
+      buffers can also be used to store larger amounts of heat.\r\n</p>\r\nHere you
+      can indicate the buffer size you expect in the future per heat pump (air)."
+    content_nl: "Met de standaardinstelling levert het gasdeel van de hybride warmtepomp
+      direct warm water. Er is dan geen buffer nodig voor warm water.\r\n</p>\r\nDoor
+      de omslag-COP te verlagen kan het elektrische deel van de hybride warmtepomp
+      ook warm water leveren. Dit gebeurt over het algemeen via een buffervat.\r\n</p>\r\nVoor
+      een standaard Nederlands huishouden is een buffervat van 100 liter (5 kWh) voldoende.
+      Een buffer kan echter ook gebruikt worden om grotere hoeveelheden warmte op
+      te slaan. \r\n</p>\r\nGeef hier aan hoe groot de buffer voor ruimteverwarming
+      is per hybride warmtepomp."
+    short_content_en:
+    short_content_nl:
 - id: 789
   key: bunkers_useful_demand_planes
   share_group: ''
@@ -7992,6 +13429,13 @@
   slide_id: 222
   position: 1
   dependent_on: ''
+  description:
+    content_en: Please indicate how the number of international flights will change
+      every year in the future.
+    content_nl: 'Geef hier aan hoe je verwacht dat het aantal internationale vluchten
+      per jaar zal gaan veranderen in de toekomst. '
+    short_content_en:
+    short_content_nl:
 - id: 790
   key: bunkers_plane_using_kerosene_share
   share_group: bunkers_aviation
@@ -8015,6 +13459,14 @@
   slide_id: 220
   position: 1
   dependent_on: ''
+  description:
+    content_en: 'For international aviation mainly large aircrafts are used and they
+      consume primarily kerosene. '
+    content_nl: 'Er zijn verschillende fossiele brandstoffen om op te vliegen, maar
+      verreweg het grootste volume bestaat uit kerosine. Alle grote vliegtuigen vliegen
+      op kerosine. '
+    short_content_en:
+    short_content_nl:
 - id: 791
   key: bunkers_plane_using_bio_kerosene_share
   share_group: bunkers_aviation
@@ -8038,6 +13490,24 @@
   slide_id: 220
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Instead of using fossil kerosene also bio-kerosene can be used in
+      the same type of engines; it is a so-called \"drop-in fuel\". At the moment
+      four technologies are certified to supply bio-kerosene to commercial aviation,
+      of which the Hydrotreated Esters and Fatty Acids (HEFA) technology is used in
+      90% of the cases. Do consider the impact on land (and sea) use for growing the
+      required crops. \r\n</br></br>\r\nCurrently, it is possible to tank bio-kerosene
+      at two airports: Los Angeles and Oslo. "
+    content_nl: "Naast fossiele kerosine kan ook bio-kerosine gebruikt worden in dezelfde
+      vliegtuigmotoren; het is een zogenaamde \"drop-in brandstof\". Op dit moment
+      zijn er vier gecertificieerde technologiën die bio-kerosine mogen leveren aan
+      de commerciële luchtvaart, waarvan in 90% van de gevallen de Hydrotreated Esters
+      and Fatty Acids (HEFA) technologie gebruikt wordt. Houd rekening met de impact
+      op landgebruik (of zeegebruik) als hiervoor gewassen geteeld moeten worden.
+      </br></br>\r\nOp dit moment kan bio-kerosine getankt worden op twee vliegvelden:
+      Los Angeles en Oslo."
+    short_content_en:
+    short_content_nl:
 - id: 792
   key: bunkers_useful_demand_ships
   share_group: ''
@@ -8061,6 +13531,13 @@
   slide_id: 222
   position: 2
   dependent_on: ''
+  description:
+    content_en: Please indicate how the number of international shipping trades will
+      change every year in the future.
+    content_nl: Geef hier aan hoe je verwacht dat de internationale scheepvaart per
+      jaar zal gaan veranderen in de toekomst.
+    short_content_en:
+    short_content_nl:
 - id: 793
   key: bunkers_ship_using_heavy_fuel_oil_share
   share_group: bunkers_shipping
@@ -8084,6 +13561,13 @@
   slide_id: 223
   position: 1
   dependent_on: ''
+  description:
+    content_en: 'Large international cargo ships generally operate on HFO, which is
+      the heaviest commercial fuel that can be obtained from crude oil. '
+    content_nl: 'Grote internationale vrachtschepen verbruiken over het algemeen zware
+      stookolie, wat de zwaarste brandstof is dat van ruwe olie verkregen kan worden. '
+    short_content_en:
+    short_content_nl:
 - id: 794
   key: bunkers_ship_using_lng_share
   share_group: bunkers_shipping
@@ -8107,6 +13591,29 @@
   slide_id: 223
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Ships transporting large cargo over long distances require very powerful
+      engines and energy-rich fuels. Natural gas is an unsuitable shipping fuel as
+      its energetic density is very low, but through liquefaction it increases by
+      a factor 600 - more than enough to compete with HFO. LNG engines are a rather
+      novel ship engine technology. These ships carry spark-ignited engines which
+      operate at low pressures and are optimized for LNG. As a result, these engines
+      can only run on LNG.\r\n</br></br>\r\nCompared to HFO, LNG generates 20% less
+      GHG emissions due to its lower carbon content. Additionally, LNG emits significantly
+      less air pollutants than HFO, like NO<sub>x</sub>, SO<sub>x</sub> and particulate
+      matter. Therefore, it is an alternative shipping fuel worth considering. "
+    content_nl: "Vloeibaar aardgas (LNG) is een opkomende brandstof in de scheepvaart.
+      Internationale schepen transporteren zware ladingen over grote afstanden en
+      hebben daarom zeer krachtige motoren en energierijke brandstoffen nodig. Aardgas
+      is een ongeschikte brandstof voor de scheepvaart doordat de energetische dichtheid
+      erg laag is, maar door het vloeibaar te maken wordt deze dichtheid met een factor
+      600 vergroot - meer dan genoeg om te concurreren met HFO. \r\n</br></br>\r\nVergeleken
+      met HFO, stoot LNG 20% minder broeikasgassen uit door de lagere koolstofinhoud.
+      Daarbij veroorzaakt LNG minder luchtvervuiling; er komt bijvoorbeeld minder
+      NO<sub>x</sub>, SO<sub>x</sub> en fijnstof vrij bij de verbranding. Kortom,
+      LNG is een interessant alternatief voor conventionele brandstoffen."
+    short_content_en:
+    short_content_nl:
 - id: 795
   key: bunkers_allocated_percentage_aviation
   share_group: ''
@@ -8130,6 +13637,40 @@
   slide_id: 219
   position: 1
   dependent_on: ''
+  description:
+    content_en: "What percentage of the energy demand for international aviation should
+      be included in your scenario? The total energy demand includes deliveries of
+      aviation fuels to aircraft for international aviation. Fuels used by airlines
+      for their road vehicles are excluded. The domestic/international split should
+      be determined on the basis of departure and landing locations and not by the
+      nationality of the airline. \r\n<br/><br/>\r\nInternational aviation is not
+      included in the Paris Agreement. Meanwhile, the direct emissions from aviation
+      represent 3% of EU’s GHG emissions and more than 2% of emissions worldwide.
+      Some people see the international aviation as a country on its own, if that
+      would be the case, then it would rank in the top 10 emitters. (<a href=\"https://ec.europa.eu/clima/policies/transport/aviation_en\">EC
+      Climate Action</a>)\r\n<br/><br/>\r\nNote that this slider takes a percentage
+      of the total national energy demand of international aviation. This makes it
+      possible to for example allocated the total national energy demand for international
+      aviation to the specific region where the international airport is located. "
+    content_nl: "Welke percentage van het energiegebruik van internationale luchtvaart
+      moet meegenomen worden in jouw scenario? Het totale energiegebruik omvat alle
+      vliegtuigbrandstoffen die zijn getankt voor internationale luchtvaart en dus
+      niet de brandstoffen die gebruikt zijn door luchtvaartmaatschappijen voor hun
+      wegtransport. De verdeling nationaal/internationaal wordt bepaald op basis van
+      de vertrek- en landingslocaties en niet op basis van de nationaliteit van de
+      luchtvaartmaatschappij.\r\n<br/><br/>\r\nInternationale luchtvaart is niet opgenomen
+      in het Parijse Klimaatakkoord.  Ondertussen is internationale luchtvaart verantwoordelijk
+      voor 3% van de broeikasgassen die Europa uitstoot en meer dan 2% van de wereldwijde
+      broeikasgassen. Sommige mensen beschouwen internationale luchtvaart als een
+      land op zich, als dat het geval zou zijn, dan zou het in de top 10 grootste
+      uitstoters vallen. (<a href=\"https://ec.europa.eu/clima/policies/transport/aviation_en\">EC
+      Climate Action</a>)\r\n<br/><br/>\r\nMerk op dat deze slider een percentage
+      neemt van de totale nationale energievraag van internationale luchtvaart. Dit
+      maakt het mogelijk om bijvoorbeeld de totale nationale energievraag van internationale
+      luchtvaart toe te kennen aan de gemeente waar het internationale vliegveld zich
+      bevindt."
+    short_content_en:
+    short_content_nl:
 - id: 796
   key: bunkers_allocated_percentage_shipping
   share_group: ''
@@ -8153,6 +13694,36 @@
   slide_id: 219
   position: 2
   dependent_on: ''
+  description:
+    content_en: "What percentage of the energy demand for international navigation
+      should be included in your scenario? The total energy demand covers those quantities
+      delivered to ships of all flags that are engaged in international navigation.
+      The domestic/international split is determined on the basis of port of departure
+      and port of arrival, and not by the flag or nationality of the ship.\r\n<br/><br/>\r\nInternational
+      shipping is a very important method for transporting goods all around the world.
+      This sector accounts for about 2.5% of global GHG emissions. From 2018 large
+      ships that use EU ports have to report their annual verified emissions, which
+      is the first step in the global approach to reduce their emissions. (<a href=\"https://ec.europa.eu/clima/policies/transport/shipping_en\">EC
+      Climate Action</a>)\r\n<br/><br/>\r\nNote that this slider takes a percentage
+      of the total national energy demand of international navigation. This makes
+      it possible to for example allocated the total national energy demand for international
+      navigation to the specific region where the international seaport is located. "
+    content_nl: "Welke percentage van het energiegebruik van internationale scheepvaart
+      moet meegenomen worden in jouw scenario? Het totale energieverbruik omvat alle
+      brandstoffen die getankt worden voor internationale scheepvaart. De verdeling
+      nationaal/internationaal wordt bepaald op basis van de aankomsthaven en vertrekhaven
+      en niet door de herkomst van het schip.\r\n<br/><br/>\r\nInternationale scheepvaart
+      is ontzettend belangrijk voor het transporteren van goederen over de hele wereld.
+      Deze sector is dan ook verantwoordelijk voor ongeveer 2.5% van de GHG emissions
+      wereldwijd. Vanaf 2018 moeten grote schepen die gebruikmaken van Europese havens
+      hun jaarlijkse emissies rapporteren; dit is de eerste stap in de aanpak om hun
+      uitstoot te reduceren. \r\n(<a href=\"https://ec.europa.eu/clima/policies/transport/shipping_en\">EC
+      Climate Action</a>)\r\n<br/><br/>\r\nMerk op dat deze slider een percentage
+      neemt van de totale nationale energievraag van internationale scheepvaart. Dit
+      maakt het mogelijk om bijvoorbeeld de totale nationale energievraag van internationale
+      luchtvaart toe te kennen aan de gemeente waar de internationale haven zich bevindt."
+    short_content_en:
+    short_content_nl:
 - id: 797
   key: capacity_of_flexibility_p2l_electricity
   share_group: ''
@@ -8176,6 +13747,34 @@
   slide_id: 225
   position: 1
   dependent_on: ''
+  description:
+    content_en: "How much synthetic kerosene do you want to produce?\r\n<br/><br/>\r\nThe
+      production of synthetic kerosene is not yet applied on a commercial scale, mostly
+      because fossil kerosene is still available and affordable. However, global regulations
+      for aviation are in place requiring airlines to offset the growth of their emissions
+      after 2020. This makes it interesting for airlines to consider synthetic kerosene.
+      \r\n<br/><br/>\r\nWith this slider you decide how many 1.9 MWe hydrogen plants
+      should be built for synthetic kerosene production. This hydrogen is produced
+      through electrolysis and to produce kerosene CO is added in the Fischer-Tropsch
+      (FT) synthesis. Note that only the hydrogen production runs on excess electricity
+      and the FT process runs on base load electricity.\r\n<br/><br/>\r\nThe input
+      of the slider (in MW) is converted to a (partial) number of the plant described
+      above."
+    content_nl: "Hoeveel synthetische kerosine wil je produceren?\r\n<br/><br/>\r\nDe
+      productie van synthetische kerosine wordt nog niet op grote schaal toegepast,
+      dit omdat fossiele kerosine nog beschikbaar en betaalbaar is. Echter zijn er
+      internationale regelgevingen die luchvaartmaatschappijen ertoe verplichten om
+      de toename van hun emissies te compenseren na 2020. Dit zal waarschijnlijk de
+      interesse in synthetische kerosine vergroten. \r\n<br/><br/>\r\nMet deze schuif
+      kan je bepalen hoeveel waterstofcentrales er moeten worden gebouwd voor de synthetische
+      kerosine productie. Het proces werkt als volgt: eerst wordt er waterstof geproduceerd
+      d.m.v. electrolyse and vervolgens wordt er kerosine gemaakt in het Fischer-Tropsch
+      (FT) proces door CO toe te voegen. Merk op dat alleen de waterstof productie
+      op elektriciteitsoverschotten draait en het FT proces op baseload elektriciteit.\r\n<br/><br/>\r\nDe
+      schuifjesinstelling wordt omgezet naar (deel)aantallen van de centrale zoals
+      hierboven omschreven."
+    short_content_en:
+    short_content_nl:
 - id: 798
   key: flexibility_p2l_direct_air_capture
   share_group: carbon_source_p2l
@@ -8199,6 +13798,35 @@
   slide_id: 225
   position: 4
   dependent_on: ''
+  description:
+    content_en: "What percentage of the carbon comes from Direct Air Capture (DAC)?\r\n<br/><br/>
+      \r\nDAC allows us to recycle CO<sub>2</sub> indefinitely and yields negative
+      emissions as we remove CO<sub>2</sub> from the atmosphere. After that, kerosene
+      synthesis and utilisation results in positive emissions, but the net CO<sub>2</sub>
+      addition to the atmosphere is close to zero under the assumption that the process
+      is powered by solar and wind electricity. In fact, we are creating a short-term
+      carbon-cycle. Although research on DAC goes back a long time, including missions
+      to outer space, the first companies aiming to build commercial DAC units and
+      plants were formed in the 2000s. Currently, DAC is a relatively expensive technology.
+      Note that this technology also requires the conversion of CO<sub>2</sub> into
+      CO just like when using a CO<sub>2</sub> point source and therefor also the
+      PEM technology is assumed.\r\n<br/><br/>\r\nIn this model the CO<sub>2</sub>
+      reduction caused by DAC will solely benefit the international aviation sector.
+      \r\n<br/>"
+    content_nl: "Welk percentage van de benodigde koolstof komt van Direct Air Capture
+      (DAC)?\r\n<br/><br/> \r\nMet DAC kan CO<sub>2</sub> oneindig worden hergebruikt
+      en kunnen negatieve emissies bewerkstelligd worden doordat CO<sub>2</sub> uit
+      de atmosfeer wordt afgevangen. Vervolgens zorgt de kerosine productie en verbranding
+      voor positieve emissies, maar de netto CO<sub>2</sub> toevoeging aan de atmosfeer
+      blijft dichtbij nul met de aanname dat hernieuwbare elektriciteit wordt gebruikt
+      voor het proces. Hoewel DAC al lange tijd wordt onderzocht, werden de eerste
+      bedrijven die DAC commercieel ging uitvoeren pas na 2000 opgericht. DAC is daarbij
+      een relatief dure techniek. Merk op dat voor DAC ook CO<sub>2</sub> naar CO
+      moet worden omgezet, netals bij de CO<sub>2</sub> puntbron. \r\n<br/><br/>\r\nIn
+      dit model wordt de CO<sub>2</sub> reductie door het gebruik van DAC in zijn
+      geheel toegeschreven aan de internationale luchtvaart sector. \r\n<br/>"
+    short_content_en:
+    short_content_nl:
 - id: 799
   key: flexibility_p2l_point_source_CO
   share_group: carbon_source_p2l
@@ -8222,6 +13850,32 @@
   slide_id: 225
   position: 2
   dependent_on: ''
+  description:
+    content_en: "What percentage of the carbon comes from point sources of CO?\r\n<br/><br/>
+      \r\nCompared to using sources of CO<sub>2</sub> for kerosene synthesis, point
+      sources of CO have the advantage that no conversion to CO is needed anymore.
+      However, CO point sources are not abundant, but can be found, especially in
+      steel plants. Another downside is that CO is considered a more useful molecule
+      than CO<sub>2</sub>, so it typically already serves some purpose, although this
+      is usually combustion for heat or electricity generation. Since it can have
+      a higher value, academics and engineers alike have looked into separating CO
+      (from flue gases) for synthesis purposes. This is considered more difficult
+      than CO<sub>2</sub> capture, as CO molecule size is similar to N<sub>2</sub>,
+      but attempts have been successful.\r\n<br/><br/> \r\nIn this model only CO from
+      the steel industry is taken into account.\r\n<br/>"
+    content_nl: "Welk percentage of de benodigde koolstof komt van CO puntbronnen?\r\n<br/><br/>
+      \r\nVergeleken met het gebruik van CO<sub>2</sub> bronnen voor het produceren
+      van kerosine, hebben CO puntbronnen het voordeel dat er geen conversie meer
+      plaats hoeft te vinden van CO<sub>2</sub> naar CO. Echter zijn CO puntbronnen
+      niet volop beschikbaar; ze zijn voornamelijk in staalfabrieken te vinden. Een
+      ander nadeel is dat CO beschouwd wordt als een waardevoller molecuul dan CO<sub>2</sub>,
+      waardoor het meestal al gebruikt wordt, echter is dit meestal voor warmte of
+      elektriciteitsopwekking. Ook is de scheiding van CO van rookgassen lastiger
+      dan het scheiden van CO<sub>2</sub> doordat CO een klein molecuul is (net zo
+      klein als N<sub>2</sub>), maar zeker niet onmogelijk\r\n<br/><br/> \r\nIn dit
+      model wordt alleen CO van de staalindustrie meegenomen.\r\n<br/>"
+    short_content_en:
+    short_content_nl:
 - id: 800
   key: flexibility_p2l_point_source_CO2
   share_group: carbon_source_p2l
@@ -8245,6 +13899,36 @@
   slide_id: 225
   position: 3
   dependent_on: ''
+  description:
+    content_en: "What percentage of the carbon comes from point sources of CO<sub>2</sub>?\r\n<br/><br/>
+      \r\nMany industrial and power plants emit waste gasses containing mainly CO<sub>2</sub>.
+      There exist various CO<sub>2</sub> separation techniques, of which adsorption
+      onto a solvent is most common and thus modelled here. Note that starting kerosene
+      synthesis with CO<sub>2</sub> is not optimal; it has to be converted to CO before
+      going into the Fischer-Tropsch process. In this model we have chosen to use
+      electrochemical reduction for this step, also known as the proton-exchange membrane
+      (PEM) technology. \r\n<br/><br/> \r\nThis route is for now a relatively cheap
+      way to capture CO<sub>2</sub> in comparison to DAC. It could be an economic
+      way of starting up production of synthetic kerosene and start reducing emissions
+      by close to 50%. In this model only the steel industry is considered as CO<sub>2</sub>
+      point source, although point sources of CO<sub>2</sub> are readily available
+      in many more industries.\r\n<br/>"
+    content_nl: "Welk percentage van de koolstof komt van een CO<sub>2</sub> puntbron?\r\n<br/><br/>
+      \r\nVeel fabrieken en energiecentrales stoten restgassen uit die voornamelijk
+      uit CO<sub>2</sub> bestaan. Er zijn verschillende CO<sub>2</sub> scheidingstechnieken,
+      waarvan adsorptie m.b.v. een oplosmiddel de meest gebruikelijke is en dus gebruikt
+      is in dit model. Merk op dat het starten met CO<sub>2</sub> als koolstofbron
+      niet optimaal is, omdat het eerst nog moet worden omgezet in CO voordat het
+      kan worden gebruikt in het Fischer-Tropsch proces. In dit model hebben we gekozen
+      om dit te bewerkstelligen door CO<sub>2</sub> elektrochemisch te reduceren tot
+      CO, ookwel bekend als de proton-exchange membrane (PEM) technologie.\r\n<br/><br/>\r\nDeze
+      route is tot nu toe vergeleken met DAC een relatief goedkope manier om CO<sub>2</sub>
+      af te vangen. Het zou een aantrekkelijke technologie zijn om de productie van
+      synthetische kerosine op te starten en emissies te reduceren tot wel 50%. In
+      dit model wordt alleen de staalindustrie als puntbron CO<sub>2</sub> beschouwd,
+      ookal zijn er meer veel industriën die CO<sub>2</sub> uitstoten.\r\n<br/>"
+    short_content_en:
+    short_content_nl:
 - id: 841
   key: transport_useful_demand_passenger_kms
   share_group: ''
@@ -8268,6 +13952,15 @@
   slide_id: 24
   position: 1
   dependent_on: ''
+  description:
+    content_en: Do you believe people will travel more or less in the future? Please
+      indicate here by what percentage you think the number of 'passenger kilometres'
+      will change each year.
+    content_nl: Denk jij dat mensen meer of minder zullen gaan reizen in de toekomst?
+      Hier geef je aan met hoeveel procent per jaar het aantal reizigerskilometers
+      zal veranderen.
+    short_content_en:
+    short_content_nl:
 - id: 842
   key: transport_useful_demand_freight_tonne_kms
   share_group: ''
@@ -8291,6 +13984,15 @@
   slide_id: 229
   position: 1
   dependent_on: ''
+  description:
+    content_en: Do you believe that more or less freight will be transported in the
+      future? Please indicate by what percentage per year you think the number of
+      'freight tonne kilometres' will change.
+    content_nl: Denk jij dat er meer of minder goederen zullen worden getransporteerd?
+      Hier kan je aangeven met hoeveel procent per jaar het aantal 'ladingtonkilometers'
+      zal veranderen.
+    short_content_en:
+    short_content_nl:
 - id: 843
   key: transport_busses_share
   share_group: passenger_transport
@@ -8314,6 +14016,13 @@
   slide_id: 24
   position: 5
   dependent_on: ''
+  description:
+    content_en: Please indicate what percentage of the kilometres we travel is covered
+      by busses.
+    content_nl: Hier kun je aangeven hoeveel procent van de kilometers die we reizen
+      afgelegd wordt met de bus.
+    short_content_en:
+    short_content_nl:
 - id: 844
   key: transport_trams_share
   share_group: passenger_transport
@@ -8337,6 +14046,13 @@
   slide_id: 24
   position: 4
   dependent_on: ''
+  description:
+    content_en: Please indicate what percentage of the kilometres we travel is covered
+      by trams and metros.
+    content_nl: Hier kun je aangeven hoeveel procent van de kilometers die we reizen
+      afgelegd wordt met tram en metro.
+    short_content_en:
+    short_content_nl:
 - id: 845
   key: transport_bicycles_share
   share_group: passenger_transport
@@ -8360,6 +14076,13 @@
   slide_id: 24
   position: 7
   dependent_on: ''
+  description:
+    content_en: Please indicate what percentage of the kilometres we travel is covered
+      by bicycles.
+    content_nl: Hier kun je aangeven hoeveel procent van de kilometers die we reizen
+      afgelegd wordt met de fiets.
+    short_content_en:
+    short_content_nl:
 - id: 846
   key: transport_motorcycles_share
   share_group: passenger_transport
@@ -8383,6 +14106,13 @@
   slide_id: 24
   position: 6
   dependent_on: ''
+  description:
+    content_en: Please indicate what percentage of the kilometres we travel is covered
+      by motorcycles and mopeds
+    content_nl: Hier kun je aangeven hoeveel procent van de kilometers die we reizen
+      afgelegd wordt met motors en scooters.
+    short_content_en:
+    short_content_nl:
 - id: 847
   key: transport_freight_trains_share
   share_group: freight_transport
@@ -8406,6 +14136,14 @@
   slide_id: 229
   position: 3
   dependent_on: ''
+  description:
+    content_en: What do you think will happen to freight transport by rail? Trains
+      are relatively energy-efficient, but depend on the presence of high-quality
+      infrastructure.
+    content_nl: Denk jij dat het vrachtvervoer per trein gaat toenemen of afnemen?
+      Treinen zijn erg efficiënt, maar afhankelijk van goede infrastructuur.
+    short_content_en:
+    short_content_nl:
 - id: 848
   key: transport_bus_using_electricity_share
   share_group: transport_bus_tech
@@ -8429,6 +14167,26 @@
   slide_id: 226
   position: 1
   dependent_on: ''
+  description:
+    content_en: "What percentage of all busses will be fully electric in the future?
+      \r\n<br/><br/>\r\nGovernments and other regulatory boards in many countries
+      are now trying to push electric busses as one of the primary modes of public
+      transport as part of new energy targets and policies. Electric busses are also
+      becoming more affordable as the prices for lithium-ion batteries continue to
+      drop. \r\n<br/><br/>\r\nFactors such as these will play in a role in determining
+      the growth in demand for electric busses, how do you expect the current share
+      of electric busses to change?\r\n<br/><br/>\r\nSee the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used."
+    content_nl: "Welke percentage bussen zal volledig elektrisch worden in de toekomst?\r\n<br/><br/>\r\nElektrische
+      bussen worden vanuit verschillende landelijke overheden gestimuleerd om één
+      van de primaire vervoersmiddelen te worden. Daarbij worden elektrische bussen
+      ook betaalbaarder doordat de prijs van lithium-ion batterijen blijft afnemen.
+      \r\n<br/><br/>\r\nDeze beide factoren spelen een rol bij het bepalen van het
+      aantal elektrische bussen in de toekomst. Hoe verwacht jij dat het huidige aandeel
+      van elektrische bussen zal veranderen?\r\n<br/><br/>\r\nZie onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en:
+    short_content_nl:
 - id: 849
   key: transport_bus_using_hydrogen_share
   share_group: transport_bus_tech
@@ -8452,6 +14210,46 @@
   slide_id: 226
   position: 2
   dependent_on: ''
+  description:
+    content_en: "What percentage of all busses will be hydrogen fuelled vehicles in
+      the future? \r\n<br/><br/>\r\nThe use of hydrogen for transport has been hyped
+      as well as criticised a lot, and as with many choices, their value depends on
+      other choices you make. Hydrogen is an energy carrier - not an energy source
+      -, so it has to be produced first. In the <a href=\"/scenario/supply/hydrogen/hydrogen-production\"
+      >hydrogen production section</a> you can determine how this is done - through
+      steam reforming of methane (a powerful greenhouse gas) or through green electrolysis.\r\n<br/><br/>\r\nHydrogen
+      busses (in the ETM) are fuel cell electric vehicles (FCEVs). Hydrogen is fed
+      to a stack of fuel cells, where it undergoes a chemical (redox) reaction with
+      oxygen,  generates a current and releases water. It thus produces electricity
+      that drives the (electric) engine. FCEVs are therefore electric vehicles, but
+      they differ from electric vehicles in the sense that the electricity is not
+      stored on board in a battery, but instead generated in the bus itself. \r\n<br/><br/>\r\nCombined
+      with smart grid systems and energy storage technologies, electric vehicles could
+      not only potentially reduce our dependence on fossil fuels but even function
+      as a storage medium or production technology. \r\n<br/><br/>\r\nSee the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used."
+    content_nl: "Welk percentage van alle bussen zal op waterstof rijden in de toekomst?
+      \r\n<br/><br/>\r\nHet gebruik van waterstof voor transport wordt aan de ene
+      kant veel geprezen, maar aan de andere kant ook stevig bekritiseerd. Zoals voor
+      veel keuzes, hangt de waarde van een waterstofbus af van andere keuzes die je
+      maakt. Waterstof is een energiedrager - geen energiebron -,  dus het zal eerst
+      geproduceerd moeten worden. In de <a href=\"/scenario/supply/hydrogen/hydrogen-production\"
+      >waterstofproductiesectie</a> kun je bepalen hoe dat gedaan wordt - door het
+      reformen van methaan (een krachtig broeikasgas) of door groene elektrolyse.\r\n<br/><br/>\r\nWaterstofbussen
+      (in het ETM) zijn Fuel Cell Electric Vehicles (FCEVs), ofwel elektrische voertuigen
+      met een brandstofcel. Waterstof wordt gevoed aan geschakelde groep brandstofcellen,
+      waar het een chemische (redox) reactie ondergaat met zuurstof, elektriciteit
+      genereert en water uitstoot. Op deze manier produceert de brandstofcel de elektriciteit
+      die de (elektro)motor aandrijft. Waterstofbussen zijn daarom ook elektrische
+      bussen, maar zij verschillen van elektrische bussen in de zin dat de elektriciteit
+      niet aan boord in een accu opgeslagen is, maar tijdens het gebruik gegenereerd
+      wordt.\r\n<br/><br/>\r\nIn combinatie met slimme stroomnetten en energieopslag-technologiën,
+      kunnen elektrische bussen en waterstofbussen niet alleen mogelijk onze afhankelijkheid
+      van fossiele brandstoffen flink verlagen, maar zelfs functioneren als energieopslag
+      medium of productie technologie.\r\n<br/><br/>\r\nZie onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en:
+    short_content_nl:
 - id: 850
   key: transport_bus_using_diesel_mix_share
   share_group: transport_bus_tech
@@ -8475,6 +14273,20 @@
   slide_id: 226
   position: 3
   dependent_on: ''
+  description:
+    content_en: "What percentage of all cars will use conventional diesel fueled internal
+      combustion engine (ICE) technology? \r\n<br/><br/>\r\nToday, nearly all of the
+      busses use diesel as the primary source of fuel; however, competition with alternative
+      technologies will most likely induce a change in the demand share for diesel
+      powered busses. \r\n<br/><br/>\r\nSee the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used."
+    content_nl: "Welk percentage van alle bussen zal op diesel blijven rijden in de
+      toekomst? \r\n<br/><br/>\r\nOp dit moment rijden bijna alle bussen op diesel,
+      maar wellicht heeft de concurrentie van alternatieve aandrijvingstechnologiën
+      invloed op het aantal dieselbussen.\r\n<br/><br/>\r\nZie onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en:
+    short_content_nl:
 - id: 851
   key: transport_bus_using_gasoline_mix_share
   share_group: transport_bus_tech
@@ -8498,6 +14310,21 @@
   slide_id: 226
   position: 4
   dependent_on: ''
+  description:
+    content_en: "What percentage of all busses will be using gasoline fuelled internal
+      combustion engine (ICE) technology in the future?  \r\n<br/><br/>\r\nCompetition
+      from zero-emissions technologies, like electric and hydrogen vehicles is pushing
+      innovation in the field of efficiency improvement in gasoline powered transport.
+      \r\n<br/><br/>\r\nThis and other such factors will play a role in shaping the
+      demand for gasoline fuelled busses in the future, how do you suppose the demand
+      will change?"
+    content_nl: "Welk percentage van alle bussen zal op benzine blijven rijden in
+      de toekomst? <br/><br/> \r\nHet is mogelijk dat de efficiëntie van deze bussen
+      sneller zal verbeteren als de concurrentie van elektrische bussen sterker wordt.
+      \r\n<br/><br/>\r\nZie onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en:
+    short_content_nl:
 - id: 852
   key: transport_bus_using_lng_share
   share_group: transport_bus_tech
@@ -8521,6 +14348,25 @@
   slide_id: 226
   position: 5
   dependent_on: ''
+  description:
+    content_en: "What percentage of all busses will be using liquefied natural gas
+      (LNG) technology in the future?\r\n<br/><br/>\r\nAs environmental concerns become
+      a prime factor in shaping the demand for fuels in the transport sector, LNG
+      can be expected to increase its demand share with respect to other fuels that
+      are currently dominating the fuel-mix in the transport sector. LNG's higher
+      energy density as compared to diesel and relatively stable projected prices
+      will also play a hand in determining its share in the fuel-mix in the near future.\r\n<br/><br/>\r\nSee
+      the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used."
+    content_nl: "Welke percentage van alle bussen zullen rijden op vloeibaar aardgas
+      (liquefied natural gas = LNG)?\r\n<br/><br/>\r\nNaarmate de milieuaspecten steeds
+      zwaarder zullen wegen in de transportsector, kan het zo zijn dat LNG meer gebruikt
+      gaat worden omdat het een hogere energiedichtheid heeft vergeleken met diesel.
+      Daarbij is het zo dat LNG een relatief stabielere prijscurve heeft dan andere
+      (fossiele) brandstoffen.  \r\n<br/><br/>\r\nZie onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en:
+    short_content_nl:
 - id: 853
   key: transport_bus_using_compressed_natural_gas_share
   share_group: transport_bus_tech
@@ -8544,6 +14390,40 @@
   slide_id: 226
   position: 6
   dependent_on: ''
+  description:
+    content_en: "What percentage of all busses will use compressed natural gas fueled
+      internal combustion engine (ICE) technology? \r\n<br/><br/>\r\nGas fueled busses
+      are relatively clean compared to gasoline or diesel fueled ones. In terms of
+      efficiency, one might say that gas is better used for generating heat and electricity
+      (co-generation) at the location it is needed. ICE technology is likely to progress,
+      but will never rival the efficiency of such a process. In terms of pollution,
+      one might say that it is better to use gas to generate electricity at a central
+      location (where exhaust gases can be cleaned or even captured and stored) and
+      to use the electricity to power electric busses.\r\n<br/><br/>\r\nCompressed
+      natural gas in these busses comes from the gas network. This means it can contain
+      green gas if in the current scenario this is mixed in with natural gas on the
+      gas network.\r\n<br/><br/>\r\nIn the Middle East, for example, transport authorities
+      are also promoting CNG by setting up conversion centers which enable cars and
+      busses to switch from gasoline or diesel powered engines to CNG powered ones.\r\n<br/><br/>\r\nSee
+      the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used.\r\nNatural
+      gas fueled engines are already commercially available. "
+    content_nl: "Welk percentage van alle bussen zal op aardgas onder druk rijden
+      in de toekomst? \r\n<br/><br/>\r\nAardgasbussen zijn schoner dan benzine of
+      dieselbussen, die momenteel het meest gebruikt worden. Wat energie-efficiëntie
+      betreft, zou je kunnen zeggen dat gas het best kan worden gebruikt om warmte
+      en elektriciteit te maken (WKK) op de plaats waar het gebruikt wordt, dan voor
+      transport. Verbrandingsmotoren zullen nog wel wat efficiënter worden, maar kunnen
+      nooit zo efficiënt worden als WKK's. Wat vervuiling betreft, zou je kunnen zeggen
+      dat gas het beste gebruikt kan worden om centraal elektriciteit te maken, zodat
+      verbrandingsgassen kunnen worden gezuiverd of zelf afgevangen. De geproduceerde
+      elektriciteit kan dan gebruikt worden om bijvoorbeeld bussen aan te drijven.\r\n<br/><br/>\r\nAardgas
+      onder druk komt van het gasnetwerk. Als in dit scenario groengas wordt bijgemengd
+      in het gasnetwerk dan zullen deze voertuigen ook deels op groengas rijden.\r\n<br/><br/>\r\nZie
+      onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en:
+    short_content_nl:
 - id: 854
   key: transport_bicycle_using_human_power_share
   share_group: transport_bicycle_tech
@@ -8567,6 +14447,17 @@
   slide_id: 227
   position: 1
   dependent_on: ''
+  description:
+    content_en: "How do you suppose the demand for bicycles will change in the future?
+      Will it increase or decrease?\r\n<br/><br/>\r\nBicycles are one of the most
+      traditional forms of transport and are rapidly coming back into style as people
+      become more aware of the environmental as well as health benefits.\r\n"
+    content_nl: "Welk percentage van de fietsen zullen nog klassieke door de mens
+      aangedreven fietsen zijn in de toekomst?\r\n<br/><br/>\r\nFietsen is ouderwetse
+      maar nog steeds erg populaire vorm van transport en komt misschien zelfs meer
+      in trek door zijn gezonde en milieuvriendelijke karakter."
+    short_content_en:
+    short_content_nl:
 - id: 855
   key: transport_bicycle_using_electricity_share
   share_group: transport_bicycle_tech
@@ -8590,6 +14481,25 @@
   slide_id: 227
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Will the share of electric bikes (e-bikes) expand in the future?\r\n<br/><br/>\r\nElectric
+      bikes play a big role in expanding the existing market for bicycles as they
+      provide speed and reduced effort which stretches the market to include parts
+      of the market, such as the elderly, who benefit greatly from these benefits.
+      Several food delivery companies are also investing in electric bikes not only
+      due to the economic benefits but also as a part of green marketing.\r\n<br/><br/>\r\nSee
+      the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used."
+    content_nl: "Zal het aandeel van elektrische bikes (e-bikes) toenemen in de toekomst?\r\n<br/><br/>\r\nElektrische
+      fietsen spelen een belangrijk rol in het uitbreiden van de markt voor fietsen,
+      omdat ze twee voordelen hebben t.o.v. de traditionele fiets: meer snelheid met
+      minder moeite. Hierdoor fietsen op dit moment o.a. veel oudere mensen op e-bikes.
+      Maar ook bedrijven die bijv. eten bezorgen investeren in e-bikes vanwege de
+      financiële voordelen maar ook voor het vergroten van hun groene imago.\r\n<br/><br/>\r\nZie
+      onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en:
+    short_content_nl:
 - id: 856
   key: transport_motorcycle_using_gasoline_mix_share
   share_group: transport_motorcycle_tech
@@ -8613,6 +14523,29 @@
   slide_id: 228
   position: 1
   dependent_on: ''
+  description:
+    content_en: "What percentage of all motorcycles will be using gasoline fuelled
+      technology in the future?\r\n<br/><br/>\r\nMany areas of the world are experiencing
+      a rapid demand in motorcycle usage as this form of personal transport provides
+      ease and convenience especially in developing countries where the transport
+      infrastructure is not very suitable to cars and other larger vehicles. Currently,
+      almost all of the motorcycles run on gasoline, however as zero-emissions technologies
+      and priorities on environmental effects of such fuels are being placed higher
+      up, one can expect a change in this share in the future.\r\n<br/><br/>\r\nSee
+      the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used.\r\nNatural
+      gas fueled engines are already commercially available. "
+    content_nl: "Welk percentage van alle motorfietsen zal benzine gebruiken in de
+      toekomst?\r\n<br/><br/>\r\nHet overgrote deel van alle motorfietsen gebruikt
+      benzine als brandstof. Met name in ontwikkelende steden neemt het aantal benzinemotorfietsen
+      toe, omdat ze gemakkelijk te gebruiken zijn op plekken waar auto's vaak teveel
+      ruimte in nemen. Maar tegelijkertijd komt er ook steeds strengere wetgeving
+      voor benzinemotorfietsen in steden, omdat ze een bijdragen aan luchtvervuiling.
+      Er wordt bijvoorbeeld per 2018 in Amsterdam een milieuzone voor brom- en snorfietsen
+      uit 2010 en ouder ingevoerd.\r\n<br/><br/>\r\nZie onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en:
+    short_content_nl:
 - id: 857
   key: transport_motorcycle_using_electricity_share
   share_group: transport_motorcycle_tech
@@ -8636,6 +14569,28 @@
   slide_id: 228
   position: 2
   dependent_on: ''
+  description:
+    content_en: "How do you think the demand for electric motorcycles will change
+      in the future?\r\n<br/><br/>\r\nAs of today, electric motorcycles aren't yet
+      used very often. Competition with cars at charging stations as well as a smaller
+      market audience as compared to cars may be some among the reasons which is holding
+      back the number of electric motorcycles on the road. However, new innovative
+      electric motorcycles are entering the market, which could potentially be a hype.
+      Especially areas with high population densities could benefit from an increase
+      in electric motorcycles, as motorcycles in such areas comprise quite a significant
+      share of the road transport. \r\n<br/><br/>\r\nSee the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used.\r\nNatural
+      gas fueled engines are already commercially available. "
+    content_nl: "Welk percentage van alle motorfietsen zal elektrisch zijn in de toekomst?\r\n<br/><br/>\r\nOp
+      dit moment is het aantal elektrische motorfietsen nog niet zo hoog. De competitie
+      met auto's bij oplaadstations en ook de relatief kleine afzetmarkt zouden redenen
+      hiervoor kunnen zijn. Tegelijkertijd komen er nieuwe innovatieve motorfietsen
+      op de markt, die wellicht populair kunnen worden. Met name in dichtbevolkte
+      steden hebben elektrische motorfietsen veel potentie.\r\n<br/><br/>\r\nZie onze
+      <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en:
+    short_content_nl:
 - id: 858
   key: transport_freight_train_using_electricity_share
   share_group: transport_freight_train_share
@@ -8659,6 +14614,21 @@
   slide_id: 230
   position: 1
   dependent_on: ''
+  description:
+    content_en: "Electric trains are the standard in all developed regions of the
+      world. They are a very energy efficient and rather clean form of transport.
+      They are not particularly flexible of course, and rely on expensive electric
+      infrastructure, so they will never fully replace diesel trains.\r\n<br/><br/>\r\nSee
+      the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used."
+    content_nl: "Elektrische treinen zijn de standaard in alle ontwikkelde gebieden
+      in de wereld. Ze zijn zeer energie-efficiënt en schoon, maar niet erg flexibel.
+      Bovendien zijn ze afhankelijk van dure elektrische infrastructuur en daarom
+      zullen ze nooit volledig de dieseltrein vervangen.\r\n<br/><br/>\r\nZie onze
+      <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en:
+    short_content_nl:
 - id: 859
   key: transport_freight_train_using_diesel_mix_share
   share_group: transport_freight_train_share
@@ -8682,6 +14652,22 @@
   slide_id: 230
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Diesel-powered trains are not uncommon as they do not rely on expensive
+      electricity infrastructure. They are ideal for very remote and sparsely populated
+      regions, or for international transport of goods. Because Europe is a patchwork
+      of differing standards for powerlines, electric trains often cannot cross borders
+      in Europe. \r\n<br/><br/>\r\nSee the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+      on GitHub</a> for detailed information on the numbers and sources used."
+    content_nl: "Dieseltreinen komen nog redelijk veel voor, omdat ze niet afhankelijk
+      zijn van een dure elektrische infrastructuur. Ze zijn zeer geschikt voor afgelegen
+      en dunbevolkte gebieden, of voor internationaal goederentransport. Omdat Europa
+      nog een lappendeken van standaarden is voor elektrische bovenleidingen, kunnen
+      elektrische treinen vaak niet probleemloos nationale grenzen passeren.\r\n<br/><br/>\r\nZie
+      onze <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentatie
+      op GitHub</a> voor meer informatie over de gebruikte getallen en bronnen."
+    short_content_en:
+    short_content_nl:
 - id: 861
   key: flexibility_p2l_co2_reduction_industry
   share_group: co2_reduction_p2l
@@ -8705,6 +14691,19 @@
   slide_id: 225
   position: 5
   dependent_on: ''
+  description:
+    content_en: "Which sector should benefit from the CO<sub>2</sub> reduction when
+      CO/CO<sub>2</sub> from industrial flue gasses are used?\r\n<br/><br/> \r\nThe
+      steel industry delivers the CO/CO<sub>2</sub> for the synthetic kerosene production.
+      What percentage of the CO<sub>2</sub> reduction is therefor appropriate to allocate
+      to them?"
+    content_nl: "Welke sector zal moeten profiteren van de CO<sub>2</sub> reductie
+      als CO/CO<sub>2</sub> van industriële rookgassen zal worden gebruikt?\r\n<br/><br/>
+      \r\nDe staalindustrie levert de CO/CO<sub>2</sub> voor de synthetische kerosine
+      productie. Welk percentage van de CO<sub>2</sub> reductie moet als gevolg hiervan
+      worden toegekend aan hun?"
+    short_content_en:
+    short_content_nl:
 - id: 862
   key: flexibility_p2l_co2_reduction_bunkers
   share_group: co2_reduction_p2l
@@ -8728,6 +14727,20 @@
   slide_id: 225
   position: 6
   dependent_on: ''
+  description:
+    content_en: "Which sector should benefit from the CO<sub>2</sub> reduction when
+      CO/CO<sub>2</sub> from industrial flue gasses are used?\r\n<br/><br/> \r\nThe
+      international aviation sector has chosen to use synthetic kerosene instead of
+      fossil kerosene or bio-kerosene. What percentage of the CO<sub>2</sub> reduction
+      is therefor appropriate to allocate to them?"
+    content_nl: "Welke sector zal moeten profiteren van de CO<sub>2</sub> reductie
+      als CO/CO<sub>2</sub> van industriële rookgassen zal worden gebruikt?\r\n<br/><br/>
+      \r\nDe internationale luchtvaart sector kiest ervoor om synthetische kerosine
+      te gebruiken in plaats van fossiele kerosine of bio-kerosine. Welk percentage
+      van de CO<sub>2</sub> reductie moet als gevolg hiervan worden toegekend aan
+      hun?"
+    short_content_en:
+    short_content_nl:
 - id: 863
   key: co2_emissions_of_imported_electricity_present
   share_group: ''
@@ -8752,6 +14765,25 @@
   slide_id: 236
   position: 0
   dependent_on: ''
+  description:
+    content_en: "The average emission in gram CO<sub>2</sub> emissions per kWh of
+      the Dutch electricity grid is 527 gram  <a href=\"https://www.cbs.nl/nl-nl/achtergrond/2017/06/rendementen-en-co2-emissie-elektriciteitsproductie-2015\"
+      target =\"_blank\">(CBS, 2015)</a>.\r\n\r\n</p>\r\n\r\nThe European electricity
+      mix has an average of 275.9  gram CO<sub>2</sub> emissions per kWh <a href=\"https://www.eea.europa.eu/data-and-maps/daviz/co2-emission-intensity-3#tab-googlechartid_chart_11_filters=%7B%22rowFilters%22%3A%7B%7D%3B%22columnFilters%22%3A%7B%22pre_config_ugeo%22%3A%5B%22European%20Union%20(28%20countries)%22%5D%7D%7D\"
+      target =\"_blank\">(EEA, 2014)</a>. \r\n\r\n</p>\r\n\r\nYou can find more information
+      about carrier, technology, and country specific emissions per kWh in our <a
+      href=\"https://github.com/quintel/documentation/blob/master/general/CO2_emissions_of_imported_electricity.md\"
+      target =\"_blank\">documentation</a>. "
+    content_nl: "De gemiddelde emissie van de Nederlandse elektriciteitsmix is 527
+      gram CO<sub>2</sub> per kWh  <a href=\"https://www.cbs.nl/nl-nl/achtergrond/2017/06/rendementen-en-co2-emissie-elektriciteitsproductie-2015\"
+      target =\"_blank\">(CBS, 2015)</a>.\r\n\r\n</p>\r\n\r\nDe Europese elektriciteitsmix
+      heeft een gemiddelde emissie van 275.9 gram CO<sub>2</sub> per kWh <a href=\"https://www.eea.europa.eu/data-and-maps/daviz/co2-emission-intensity-3#tab-googlechartid_chart_11_filters=%7B%22rowFilters%22%3A%7B%7D%3B%22columnFilters%22%3A%7B%22pre_config_ugeo%22%3A%5B%22European%20Union%20(28%20countries)%22%5D%7D%7D\"
+      target =\"_blank\">(EEA, 2014)</a>. \r\n\r\n</p>\r\n\r\nJe kan meer emissies
+      in gram CO<sub>2</sub> per kWh vinden per type drager, technologie en land in
+      onze <a href=\"https://github.com/quintel/documentation/blob/master/general/CO2_emissions_of_imported_electricity.md\"
+      target =\"_blank\">documentation</a>. "
+    short_content_en:
+    short_content_nl:
 - id: 864
   key: co2_emissions_of_imported_electricity_future
   share_group: ''
@@ -8775,6 +14807,31 @@
   slide_id: 236
   position: 1
   dependent_on: ''
+  description:
+    content_en: "What will be the related emissions of imported electricity in the
+      future? \r\n\r\n</p>\r\nThis electricity could come from renewable sources like
+      sun and wind, with an emission close to 0 gram CO<sub>2</sub>/kWh. \r\n\r\n</p>\r\n\r\nOn
+      the other hand, this imported electricity could also be a peek demand just when
+      there is not much wind and sun available. In this case this electricity could
+      come from gas (380 -1000 gCO<sub>2</sub>/kWh), coal (660 -1050 gCO<sub>2</sub>/kWh),
+      or even lignite (800 -1300 gCO<sub>2</sub>/kWh) with quite high CO<sub>2</sub>
+      emissions per kWh. <a href=\"https://github.com/quintel/documentation/blob/master/general/CO2_emissions_of_imported_electricity.md\"
+      target =\"_blank\">(Turconi et al, 2013)</a>. \r\n\r\n\r\n</p>\r\n\r\nYou can
+      find more information about carrier, technology, and country specific emissions
+      per kWh in our <a href=\"https://github.com/quintel/documentation/blob/master/general/CO2_emissions_of_imported_electricity.md\"
+      target =\"_blank\">documentation</a>. "
+    content_nl: "Wat zijn de emissies voor geïmporteerde elektriciteit in de toekomst?
+      \r\n\r\n</p>\r\nKomt dit met name van hernieuwbaar zon of wind, dan gaan de
+      emissies richting de 0 gram CO<sub>2</sub>/kWh.   \r\n\r\n</p>\r\n\r\nOf moet
+      er tijdens de piekvraag met weinig zon en wind juist elektriciteit van bijvoorbeeld
+      van gas (380 -1000 gCO<sub>2</sub>/kWh), kolen (660 -1050 gCO<sub>2</sub>/kWh),
+      of bruinkolen (800 -1300 gCO<sub>2</sub>/kWh) geïmporteerd worden. <a href=\"https://github.com/quintel/documentation/blob/master/general/CO2_emissions_of_imported_electricity.md\"
+      target =\"_blank\">(Turconi et al, 2013)</a>. \r\n\r\n\r\n</p>\r\n\r\nJe kan
+      meer emissies in gram CO<sub>2</sub> per kWh vinden per type drager, technologie
+      en land in onze <a href=\"https://github.com/quintel/documentation/blob/master/general/CO2_emissions_of_imported_electricity.md\"
+      target =\"_blank\">documentation</a>. "
+    short_content_en:
+    short_content_nl:
 - id: 868
   key: costs_imported_electricity
   share_group: ''
@@ -8798,6 +14855,27 @@
   slide_id: 238
   position: 0
   dependent_on: ''
+  description:
+    content_en: "Do you think that when you have to import electricity that on average
+      it will be cheap because of peak production, or will it be expensive because
+      of peak demand?\r\n</p>\r\n\r\nThe average costs of electricity at the Central
+      West European market was around 35 €/MWh in 2015. However this fluctuates a
+      lot. <a href=\"https://github.com/quintel/documentation/general/costs_imported_electricity.md\"
+      target =\"_blank\">(European Commission, 2015)</a>. \r\n\r\n\r\n</p>\r\n\r\nFor
+      more information about the fluctuating prices see the <a href=\"https://github.com/quintel/documentation/blob/master/general/costs_imported_electricity.md\"
+      target =\"_blank\">documentation</a>. "
+    content_nl: "Denk jij dat de geïmporteerde elektriciteit gemiddeld goedkoop is
+      door overschotten in de productie, of denk jij dat het juist duur is doordat
+      de import vooral is tijdens de piekvraag? \r\n</p>\r\n\r\nDe gemiddelde kosten
+      van elektriciteit op de Centraal West Europese markt waren rond de 35 €/MWh
+      in 2015. Alhoewel dit enorm kan verschillen per maand, dag, of zelfs uur. <a
+      href=\"https://github.com/quintel/documentation/general/costs_imported_electricity.md\"
+      target =\"_blank\">(European Commission, 2015)</a>. \r\n\r\n</p>\r\n\r\n\r\nJe
+      kunt een beter beeld krijgen van de fluctuerende prijs door te kijken in de
+      <a href=\"https://github.com/quintel/documentation/blob/master/general/costs_imported_electricity.md\"
+      target =\"_blank\">documentatie</a>. "
+    short_content_en:
+    short_content_nl:
 - id: 871
   key: capacity_of_energy_hydrogen_wind_turbine_offshore
   share_group: ''
@@ -8821,6 +14899,35 @@
   slide_id: 193
   position: 1
   dependent_on: ''
+  description:
+    content_en: "How many wind turbines will produce electricity that will directly
+      be converted into hydrogen with electrolysers?\r\n</br></br>\r\nThere are a
+      number of plans for building wind parks far out on sea. For these parks it will
+      probably be economically more viable to convert the electricity directly into
+      hydrogen instead of transporting the electricity to land first. This has to
+      do with the high electricity cabling costs relative to the low gas piping costs.
+      \r\n</br></br>\r\nThis slider sets the installed capacity of offshore wind turbines
+      dedicated to hydrogen production and a corresponding amount of electrolysis
+      capacity to convert the produced electricity into hydrogen. <br /><br />\r\nNote:
+      The technical and financial specifications below are only the specifications
+      of the electrolyser, not the wind turbines. The specifications of the wind turbines
+      can be found in the <a href=\"/scenario/supply/electricity_renewable/wind-turbines\">Renewable
+      electricity section</a>.<br />"
+    content_nl: "Hoeveel windmolens zullen elektriciteit produceren dat direct zal
+      worden omgezet in waterstof met electrolysers?\r\n</br></br>\r\nEr bestaan verschillende
+      plannen voor windparken ver op zee. Voor deze windparken zal het waarschijnlijk
+      economisch haalbaarder zijn om de elektriciteit ter plekke om te zetten in waterstof
+      in plaats van de elektriciteit eerst naar land te transporteren. Dit heeft te
+      maken met de relatief hoge kosten voor elektriciteitskabels vergeleken met de
+      gaspijpkosten. \r\n</br></br>\r\nDeze schuif zet het vermogen van windmolens
+      op zee dat ingezet wordt voor waterstofproductie en het benodigde vermogen van
+      elektrolyse-installaties om de geproduceerde elektriciteit om te zetten in waterstof.
+      <br /><br />\r\n\r\nOpmerking: De technische en financiële specificaties hieronder
+      zijn alleen voor de elektrolyser, niet voor de windmolens. De specificaties
+      van de windmolens kun je vinden in het tabblad <a href=\"/scenario/supply/electricity_renewable/wind-turbines\">Hernieuwbare
+      elektriciteit</a>.<br />"
+    short_content_en:
+    short_content_nl:
 - id: 872
   key: capacity_of_energy_hydrogen_solar_pv_solar_radiation
   share_group: ''
@@ -8844,6 +14951,38 @@
   slide_id: 193
   position: 2
   dependent_on: ''
+  description:
+    content_en: "How many solar pv plants will be build in the future for hydrogen
+      production using electrolysers?\r\n<br/><br/>\r\nThis slider sets installed
+      solar PV capacity and the installed capacity of electrolysis plants to produce
+      hydrogen. The capacity of the electrolysers relative to the capacity of the
+      solar PV plants depends on the hours of sunshine in a country. More information
+      about this can be found in our <a href=\"https://github.com/quintel/etdataset-public/blob/master/source_analyses/nl/2015/2_power_and_heat_plant/hydrogen_solar_pv_analysis.xlsx\"
+      >documentation on Github</a>.\r\n</br></br>\r\nIn the ETM solar PV panels have
+      867 full load hours by default. Because of technological developments it is
+      likely that future solar PV panels may produce more electricity per installed
+      capacity than today. You can adjust the full load hours of solar panels <a href=\"/scenario/supply/electricity_renewable/solar-power\"
+      >here</a><br /><br />\r\n\r\nNote: The technical and financial specifications
+      below are only the specifications of the electrolyser, not the solar panels.
+      The specifications of the solar panels can be found in the <a href=\"/scenario/supply/electricity_renewable/solar-power\">Renewable
+      electricity section</a>.<br />"
+    content_nl: "Hoeveel zonneparken zullen er in de toekomst gebouwd worden voor
+      de productie van waterstof met behulp van electrolysers?\r\n<br/><br/>\r\nDeze
+      schuif zet het vermogen van zonneparken dat ingezet wordt voor waterstofproductie
+      en het benodigde vermogen van elektrolyse-installaties om de geproduceerde elektriciteit
+      om te zetten in waterstof. Het vermogen van de elektrolyse-installaties ten
+      opzichte van het vermogen van de zonneparken is afhankelijk van het aantal zonuren
+      en het zonprofiel van een land. Meer informatie hierover staat in de <a href=\"https://github.com/quintel/etdataset-public/blob/master/source_analyses/nl/2015/2_power_and_heat_plant/hydrogen_solar_pv_analysis.xlsx\"
+      >documentatie op Github</a>.\r\n</br></br>\r\nIn het ETM heeft een zonnepaneel
+      standaard 867 vollasturen. Het is aannemelijk dat toekomstige zonnepanelen meer
+      elektriciteit zullen produceren per geïnstalleerd vermogen dan nu. Je kunt het
+      aantal vollasturen voor zonnepanelen <a href=\"/scenario/supply/electricity_renewable/solar-power\"
+      >hier</a> aanpassen.\r\n<br /><br />\r\n\r\nOpmerking: De technische en financiële
+      specificaties hieronder zijn alleen voor de elektrolyser, niet voor de zonneparken.
+      De specificaties van de zonneparken kun je vinden in het tabblad <a href=\"/scenario/supply/electricity_renewable/solar-power\">Hernieuwbare
+      elektriciteit</a>.<br />"
+    short_content_en:
+    short_content_nl:
 - id: 873
   key: industry_chemicals_fertilizers_steam_methane_reformer_hydrogen_share
   share_group: hydrogen_production
@@ -8867,6 +15006,26 @@
   slide_id: 201
   position: 4
   dependent_on: ''
+  description:
+    content_en: "The fertilizers industry uses non-energetic hydrogen for the production
+      of ammonia. Currently, fertilizer plants typically produce this hydrogen in-house
+      using natural gas. In the future this 'fossil' hydrogen may be replaced by sustainble
+      hydrogen. The ETM offers this option via a 'central' hydrogen network. How this
+      central network is supplied can be specified <a href=\"/scenario/supply/hydrogen/hydrogen-production\">
+      here</a>. <br /><br />\r\n\r\nThis slider allows you to set how much non-energetic
+      hydrogen is produced locally using natural gas and how much is drawn from the
+      central hydrogen network."
+    content_nl: "In de kunstmestsector wordt niet-energetische waterstof gebruikt
+      voor de productie van ammoniak. Op dit moment produceren kunstmestfabrieken
+      deze waterstof veelal zelf met behulp van aardgas (SMR). In de toekomst kan
+      hier wellicht duurzaam geproduceerde waterstof voor in de plaats komen. Het
+      ETM biedt deze optie via een 'centraal' waterstofnet. Hoe dit waterstofnet gevoed
+      wordt, kun je instellen bij <a href=\"/scenario/supply/hydrogen/hydrogen-production\">
+      Aanbod</a>. <br /><br />\r\nMet deze schuif kun je aangeven hoeveel procent
+      van de niet-energetische waterstof lokaal met aardgas gemaakt wordt en hoeveel
+      procent van het centrale net wordt gehaald."
+    short_content_en:
+    short_content_nl:
 - id: 874
   key: industry_chemicals_fertilizers_hydrogen_network_share
   share_group: hydrogen_production
@@ -8890,6 +15049,26 @@
   slide_id: 201
   position: 5
   dependent_on: ''
+  description:
+    content_en: "The fertilizers industry uses non-energetic hydrogen for the production
+      of ammonia. Currently, fertilizer plants typically produce this hydrogen in-house
+      using natural gas. In the future this 'fossil' hydrogen may be replaced by sustainble
+      hydrogen. The ETM offers this option via a 'central' hydrogen network. How this
+      central network is supplied can be specified <a href=\"/scenario/supply/hydrogen/hydrogen-production\">
+      here</a>. <br /><br />\r\n\r\nThis slider allows you to set how much non-energetic
+      hydrogen is produced locally using natural gas and how much is drawn from the
+      central hydrogen network."
+    content_nl: "In de kunstmestsector wordt niet-energetische waterstof gebruikt
+      voor de productie van ammoniak. Op dit moment produceren kunstmestfabrieken
+      deze waterstof veelal zelf met behulp van aardgas (SMR). In de toekomst kan
+      hier wellicht duurzaam geproduceerde waterstof voor in de plaats komen. Het
+      ETM biedt deze optie via een 'centraal' waterstofnet. Hoe dit waterstofnet gevoed
+      wordt, kun je instellen bij <a href=\"/scenario/supply/hydrogen/hydrogen-production\">
+      Aanbod</a>. <br /><br />\r\nMet deze schuif kun je aangeven hoeveel procent
+      van de niet-energetische waterstof lokaal met aardgas gemaakt wordt en hoeveel
+      procent van het centrale net wordt gehaald."
+    short_content_en:
+    short_content_nl:
 - id: 875
   key: capacity_of_energy_power_turbine_hydrogen
   share_group: ''
@@ -8913,6 +15092,30 @@
   slide_id: 239
   position: 1
   dependent_on: ''
+  description:
+    content_en: "Here you can build hydrogen turbine power plants. At the moment,
+      these turbines are not used (yet) on a large scale. Because hydrogen turbine
+      technology is very similar to natural gas turbines, we assume that both plants
+      have the same specifications. <br /><br />\r\n\r\nHydrogen turbines are less
+      efficient than combined cycle gas turbines (CCGT), but have the advantage that
+      their production can be scaled up or down very quickly. These turbines are therefore
+      very suitable for providing power during demand peaks. Although the number of
+      operating hours and total electricity production of these plants is typically
+      limited, they can play an important role in balancing the energy system. <br
+      />"
+    content_nl: "Met deze schuif kun je waterstofturbines bouwen die elektriciteit
+      produceren met waterstof. Omdat waterstofturbines op dit moment (nog) niet op
+      grote schaal gebruikt worden, veronderstellen we dat de specificaties gelijk
+      zijn aan die van gasturbines. De technologie van waterstof- en gasturbines lijkt
+      namelijk sterk op elkaar. <br /><br />\r\n\r\nEen waterstofturbine is niet zo
+      efficiënt als een twee-staps Stoom- en Gascentrale (STEG), maar heeft als voordeel
+      dat een turbine zeer snel op- en af kan schakelen. Daarom zijn deze centrales
+      geschikt voor het leveren van stroom bij zogenaamde piekvraag. Hoewel het aantal
+      draaiuren en de jaarproductie van deze centrales dus vaak beperkt is, kunnen
+      ze een belangrijke rol spelen in het balanceren van het elektriciteitsnet. <br
+      />"
+    short_content_en:
+    short_content_nl:
 - id: 876
   key: industry_chemicals_refineries_burner_hydrogen_share
   share_group: chemical_refineries_heat
@@ -8936,6 +15139,19 @@
   slide_id: 199
   position: 8
   dependent_on: ''
+  description:
+    content_en: "What percentage of heat demand in industry is supplied by hydrogen
+      burners? <br /><br />\r\n\r\nThis burner can be used to generate high-grade
+      heat, which is the kind most in demand in industry. You can specify how this
+      hydrogen is produced in the <a href=\"/scenario/supply/hydrogen/hydrogen-production\">
+      Supply section </a>. <br />"
+    content_nl: "Welk percentage van de industriële warmtevraag wordt ingevuld door
+      waterstofketels? <br /> <br />\r\n\r\nDeze ketel is in staat om hogetemperatuurwarmte
+      te maken, waar in de industrie veel behoefte aan is. In de <a href=\"/scenario/supply/hydrogen/hydrogen-production\">
+      Aanbodsectie</a> kun je specificeren hoe de gebruikte waterstof wordt geproduceerd.
+      <br />"
+    short_content_en:
+    short_content_nl:
 - id: 877
   key: industry_chemicals_fertilizers_burner_hydrogen_share
   share_group: chemical_fertilizers_heat
@@ -8959,6 +15175,19 @@
   slide_id: 201
   position: 10
   dependent_on: ''
+  description:
+    content_en: "What percentage of heat demand in industry is supplied by hydrogen
+      burners? <br /><br />\r\n\r\nThis burner can be used to generate high-grade
+      heat, which is the kind most in demand in industry. You can specify how this
+      hydrogen is produced in the <a href=\"/scenario/supply/hydrogen/hydrogen-production\">
+      Supply section </a>. <br />"
+    content_nl: "Welk percentage van de industriële warmtevraag wordt ingevuld door
+      waterstofketels? <br /> <br />\r\n\r\nDeze ketel is in staat om hogetemperatuurwarmte
+      te maken, waar in de industrie veel behoefte aan is. In de <a href=\"/scenario/supply/hydrogen/hydrogen-production\">
+      Aanbodsectie</a> kun je specificeren hoe de gebruikte waterstof wordt geproduceerd.
+      <br />"
+    short_content_en:
+    short_content_nl:
 - id: 878
   key: industry_chemicals_other_burner_hydrogen_share
   share_group: chemical_other_heat
@@ -8982,6 +15211,19 @@
   slide_id: 202
   position: 8
   dependent_on: ''
+  description:
+    content_en: "What percentage of heat demand in industry is supplied by hydrogen
+      burners? <br /><br />\r\n\r\nThis burner can be used to generate high-grade
+      heat, which is the kind most in demand in industry. You can specify how this
+      hydrogen is produced in the <a href=\"/scenario/supply/hydrogen/hydrogen-production\">
+      Supply section </a>. <br />"
+    content_nl: "Welk percentage van de industriële warmtevraag wordt ingevuld door
+      waterstofketels? <br /> <br />\r\n\r\nDeze ketel is in staat om hogetemperatuurwarmte
+      te maken, waar in de industrie veel behoefte aan is. In de <a href=\"/scenario/supply/hydrogen/hydrogen-production\">
+      Aanbodsectie</a> kun je specificeren hoe de gebruikte waterstof wordt geproduceerd.
+      <br />"
+    short_content_en:
+    short_content_nl:
 - id: 879
   key: industry_other_food_burner_hydrogen_share
   share_group: other_food_heat
@@ -9005,6 +15247,19 @@
   slide_id: 203
   position: 7
   dependent_on: ''
+  description:
+    content_en: "What percentage of heat demand in industry is supplied by hydrogen
+      burners? <br /><br />\r\n\r\nThis burner can be used to generate high-grade
+      heat, which is the kind most in demand in industry. You can specify how this
+      hydrogen is produced in the <a href=\"/scenario/supply/hydrogen/hydrogen-production\">
+      Supply section </a>. <br />"
+    content_nl: "Welk percentage van de industriële warmtevraag wordt ingevuld door
+      waterstofketels? <br /> <br />\r\n\r\nDeze ketel is in staat om hogetemperatuurwarmte
+      te maken, waar in de industrie veel behoefte aan is. In de <a href=\"/scenario/supply/hydrogen/hydrogen-production\">
+      Aanbodsectie</a> kun je specificeren hoe de gebruikte waterstof wordt geproduceerd.
+      <br />"
+    short_content_en:
+    short_content_nl:
 - id: 880
   key: industry_other_paper_burner_hydrogen_share
   share_group: other_paper_heat
@@ -9028,6 +15283,19 @@
   slide_id: 204
   position: 7
   dependent_on: ''
+  description:
+    content_en: "What percentage of heat demand in industry is supplied by hydrogen
+      burners? <br /><br />\r\n\r\nThis burner can be used to generate high-grade
+      heat, which is the kind most in demand in industry. You can specify how this
+      hydrogen is produced in the <a href=\"/scenario/supply/hydrogen/hydrogen-production\">
+      Supply section </a>. <br />"
+    content_nl: "Welk percentage van de industriële warmtevraag wordt ingevuld door
+      waterstofketels? <br /> <br />\r\n\r\nDeze ketel is in staat om hogetemperatuurwarmte
+      te maken, waar in de industrie veel behoefte aan is. In de <a href=\"/scenario/supply/hydrogen/hydrogen-production\">
+      Aanbodsectie</a> kun je specificeren hoe de gebruikte waterstof wordt geproduceerd.
+      <br />"
+    short_content_en:
+    short_content_nl:
 - id: 881
   key: agriculture_burner_hydrogen_share
   share_group: agri_heat
@@ -9051,6 +15319,13 @@
   slide_id: 31
   position: 4
   dependent_on: ''
+  description:
+    content_en: What percentage of heat demand in agriculture (greenhouses) is met
+      by hydrogen heaters? <br />
+    content_nl: Welk percentage van de warmte die nodig is in de land- en tuinbouw
+      komt van het verbranden van waterstof? <br />
+    short_content_en:
+    short_content_nl:
 - id: 886
   key: energy_transport_hydrogen_compressed_trucks_share
   share_group: hydrogen_transport
@@ -9074,6 +15349,19 @@
   slide_id: 240
   position: 2
   dependent_on: ''
+  description:
+    content_en: What percentage of the total central hydrogen production in your scenario
+      is transported via trucks? Truck transport is flexible and can be scaled up
+      or down relatively easily. As such, it is a suitable option when hydrogen demand
+      is more dispersed and when volumes are lower. This may for example be the case
+      for hydrogen delivery to refuelling stations.
+    content_nl: Welk percentage van de centraal geproduceerde waterstof in je scenario
+      wordt vervoerd met vrachtwagens? Vragenwachtentransport is flexibel en kan gemakkelijk
+      af- en opgeschaald worden. Het is daarmee een geschikte optie als de vraag naar
+      waterstof in je scenario klein is of als de vraag verspreid is over een groter
+      gebied. Het is bijvoorbeeld een goede optie voor de bevoorrading van tankstations.
+    short_content_en:
+    short_content_nl:
 - id: 887
   key: energy_transport_hydrogen_pipelines_share
   share_group: hydrogen_transport
@@ -9097,6 +15385,24 @@
   slide_id: 240
   position: 1
   dependent_on: ''
+  description:
+    content_en: What percentage of the total central hydrogen production in your scenario
+      is transported via pipelines? Pipeline transport can be relatively cheap but
+      requires large investments up-front. As such, this option seems to be the most
+      viable when hydrogen demand is concentrated and hydrogen volumes are large.
+      This may for example be the case if large industrial sites switch to hydrogen.
+      In the future it may be possible to repurpose (parts of) the existing gas networks,
+      which can reduce investment costs.
+    content_nl: Welk percentage van de centraal geproduceerde waterstof in je scenario
+      wordt vervoerd via pijpleidingen? Pijpleidingtransport kan een relatief goedkope
+      manier zijn om waterstof te vervoeren, maar vraagt wel om grote investeringen
+      vooraf. Een waterstofnet wordt waarschijnlijk alleen aangelegd als de vraag
+      naar waterstof geconcentreerd is en het volume groot genoeg is. Dit kan bijvoorbeeld
+      het geval zijn als een groot industriegebied overschakelt op waterstof. In de
+      toekomst is het wellicht mogelijk om (een deel van) het bestaande aardgasnetwerk
+      te gebruiken voor waterstoftransport. Dit kan leiden tot lagere kosten.
+    short_content_en:
+    short_content_nl:
 - id: 888
   key: costs_hydrogen
   share_group: ''
@@ -9120,6 +15426,48 @@
   slide_id: 253
   position: 1
   dependent_on: ''
+  description:
+    content_en: "This slider sets the future wholesale price of hydrogen (in €/MWh).
+      This slider affects the costs of imported hydrogen and influences the position
+      of hydrogen fired gas turbines in the merit order of the electricity market.
+      The costs of domestically produced hydrogen are determined by your choices in
+      the <a href=\"/scenario/supply/hydrogen/hydrogen-production\">'hydrogen production'</a>
+      section.<br /><br />\r\n\r\nBelow you can find reference values for the current
+      costs of some common hydrogen production technologies (in €/MWh hydrogen): <br
+      /><br />\r\n<ul>\r\n<li>Steam Methane Reforming (SMR): € 40.5 <sup>1</sup></li>\r\n<li>Steam
+      Methane Reforming (SMR) + CCS: € 46.9 <sup>2</sup></li>\r\n<li>Autothermal Reforming
+      (ATR): € 109.6 <sup>1</sup></li>\r\n<li>Coal gasification: € 45.0 <sup>1</sup></li>\r\n<li>Electrolysis
+      (wind): € 273.3 <sup>1</sup></li>\r\n<li>Electrolysis (solar): € 747.7 <sup>1</sup></li>\r\n<li>Combined
+      wind and sun (North sea): € 157.4 <sup>2</sup></li>\r\n<li>Combined wind and
+      sun (Morocco): € 124.0 <sup>2</sup></li>\r\n</ul> <br />\r\nNote that the above
+      numbers are production costs only. To determine the wholesale price additional
+      costs have to be taken into account such as transporting hydrogen to your area.
+      For tanker ship transport these costs are roughly € 21.0 per MWh. <br /> <br
+      />\r\nSources:<br />   \r\n1. Gnanapragasam, N.V. & Rosen M.A. (2017). A review
+      of hydrogen production using coal, biomass and other solid fuels. In: Biofuels
+      (8), pp.725-745 <br />\r\n2. CE Delft (2018). Waterstofroutes Nederland\r\n"
+    content_nl: "Deze schuif stelt de toekomstige groothandelsprijs voor waterstof
+      in, uitgedrukt in €/MWh. De schuif bepaalt de kosten voor geïmporteerde waterstof
+      en heeft invloed op de positie van waterstofturbines in de 'merit order' van
+      de elektriciteitsmarkt. De kosten van waterstof die je zelf produceert, zijn
+      afhankelijk van de gekozen productiemethoden bij <a href=\"/scenario/supply/hydrogen/hydrogen-production\">'waterstofproductie'</a>.<br
+      /><br />\r\n\r\nHieronder vind je referentiewaarden voor de kosten van enkele
+      waterstofproductietechnieken (in €/MWh waterstof): <br /><br />\r\n<ul>\r\n<li>Steam
+      Methane Reforming (SMR): € 40.5 <sup>1</sup></li> \r\n<li>Steam Methane Reforming
+      (SMR) + CCS: € 46.9 <sup>2</sup></li>\r\n<li>Autothermal Reforming (ATR): €
+      109.6 <sup>1</sup></li>\r\n<li>Kolenvergassing: € 45.0 <sup>1</sup></li>\r\n<li>Elektrolyse
+      (windstroom): € 273.3 <sup>1</sup></li>\r\n<li>Elektrolyse (zonnestroom): €
+      747.7 <sup>1</sup></li>\r\n<li>Gecombineerde wind en zon (Noordzee): € 157.4
+      <sup>2</sup></li>\r\n<li>Gecombineerde wind en zon (Marokko): € 124.0 <sup>2</sup></li>\r\n</ul>
+      <br />\r\nDe bovenstaande getallen zijn kale productiekosten. Om de groothandelsprijs
+      te bepalen, moeten bijkomende kosten (zoals de kosten voor het vervoeren van
+      waterstof naar jouw gebied) worden meegenomen. De kosten voor transport via
+      tankers zijn grofweg € 21.0 per MWh. <br /> <br />\r\nBronnen:<br /> \r\n1.
+      Gnanapragasam, N.V. & Rosen M.A. (2017). A review of hydrogen production using
+      coal, biomass and other solid fuels. In: Biofuels (8), pp.725-745\r\n<br />
+      <br />\r\n2. CE Delft (2018). Hydrogen routes Netherlands"
+    short_content_en:
+    short_content_nl:
 - id: 890
   key: co2_emissions_of_imported_hydrogen_present
   share_group: ''
@@ -9143,6 +15491,33 @@
   slide_id: 242
   position: 1
   dependent_on: ''
+  description:
+    content_en: "Below you can find reference values for the CO<sub>2</sub> emissions
+      of some common hydrogen production technologies (kg CO<sub>2</sub> per MWh H2):
+      <br /><br />\r\n<ul>\r\n<li>Steam Methane Reforming (SMR): 281 kg</li>\r\n<li>Autothermal
+      Reforming (ATR): 281 kg</li>\r\n<li>Coal gasification: 540 kg</li>\r\n<li>Electrolysis
+      (coal): 1320 kg</li>\r\n<li>Electrolysis (nuclear): 30 kg</li>\r\n<li>Electrolysis
+      (solar/wind): 0 kg</li>\r\n</ul> <br />\r\nNote that these numbers do not take
+      into account any CO<sub>2</sub> emissions that result from transporting hydrogen
+      to your area. Supply chain emissions, such as the emissions resulting from building
+      the hydrogen production plants or mining the required natural resources, are
+      also not taken into account. <br /> <br />\r\n\r\nSource: Gnanapragasam, N.V.
+      & M.A. Rosen (2017). A review of hydrogen production using coal, biomass and
+      other solid fuels. In: Biofuels (8), pp.725-745\r\n"
+    content_nl: "Hieronder vind je referentiewaarden voor de CO<sub>2</sub>-uitstoot
+      van enkele waterstofproductietechnieken (in kg CO<sub>2</sub> per MWh waterstof):
+      <br /><br />\r\n<ul>\r\n<li>Steam Methane Reforming (SMR): 281 kg</li>\r\n<li>Autothermal
+      Reforming (ATR): 281 kg</li>\r\n<li>Kolenvergassing: 540 kg</li>\r\n<li>Elektrolyse
+      (kolenstroom): 1320 kg</li>\r\n<li>Elektrolyse (nucleaire stroom): 30 kg</li>\r\n<li>Elektrolyse
+      (zonne-/windstroom): 0 kg</li>\r\n</ul><br />\r\nDe bovenstaande getallen zijn
+      exclusief eventuele CO<sub>2</sub>-uitstoot veroorzaakt door het vervoeren van
+      waterstof naar jouw gebied. Ook ketenemissies, zoals de emissies die vrijkomen
+      bij het bouwen van een waterstoffabriek of het delven van grondstoffen die gebruikt
+      worden bij waterstofproductie, zijn niet meegenomen. <br /> <br />\r\n\r\nBron:
+      Gnanapragasam, N.V. & M.A. Rosen (2017). A review of hydrogen production using
+      coal, biomass and other solid fuels. In: Biofuels (8), pp.725-745"
+    short_content_en:
+    short_content_nl:
 - id: 891
   key: co2_emissions_of_imported_hydrogen_future
   share_group: ''
@@ -9166,6 +15541,33 @@
   slide_id: 242
   position: 2
   dependent_on: ''
+  description:
+    content_en: "Below you can find reference values for the CO<sub>2</sub> emissions
+      of some common hydrogen production technologies (kg CO<sub>2</sub> per MWh H2):
+      <br /><br />\r\n<ul>\r\n<li>Steam Methane Reforming (SMR): 281 kg</li>\r\n<li>Autothermal
+      Reforming (ATR): 281 kg</li>\r\n<li>Coal gasification: 540 kg</li>\r\n<li>Electrolysis
+      (coal): 1320 kg</li>\r\n<li>Electrolysis (nuclear): 30 kg</li>\r\n<li>Electrolysis
+      (solar/wind): 0 kg</li>\r\n</ul> <br />\r\nNote that these numbers do not take
+      into account any CO<sub>2</sub> emissions that result from transporting hydrogen
+      to your area. Supply chain emissions, such as the emissions resulting from building
+      the hydrogen production plants or mining the required natural resources, are
+      also not taken into account. <br /> <br />\r\n\r\nSource: Gnanapragasam, N.V.
+      & M.A. Rosen (2017). A review of hydrogen production using coal, biomass and
+      other solid fuels. In: Biofuels (8), pp.725-745"
+    content_nl: "Hieronder vind je referentiewaarden voor de CO<sub>2</sub>-uitstoot
+      van enkele waterstofproductietechnieken (in kg CO<sub>2</sub> per MWh waterstof):
+      <br /><br />\r\n<ul>\r\n<li>Steam Methane Reforming (SMR): 281 kg</li>\r\n<li>Autothermal
+      Reforming (ATR): 281 kg</li>\r\n<li>Kolenvergassing: 540 kg</li>\r\n<li>Elektrolyse
+      (kolenstroom): 1320 kg</li>\r\n<li>Elektrolyse (nucleaire stroom): 30 kg</li>\r\n<li>Elektrolyse
+      (zonne-/windstroom): 0 kg</li>\r\n</ul><br />\r\nDe bovenstaande getallen zijn
+      exclusief eventuele CO<sub>2</sub>-uitstoot veroorzaakt door het vervoeren van
+      waterstof naar jouw gebied. Ook ketenemissies, zoals de emissies die vrijkomen
+      bij het bouwen van een waterstoffabriek of het delven van grondstoffen die gebruikt
+      worden bij waterstofproductie, zijn niet meegenomen. <br /> <br />\r\n\r\nBron:
+      Gnanapragasam, N.V. & M.A. Rosen (2017). A review of hydrogen production using
+      coal, biomass and other solid fuels. In: Biofuels (8), pp.725-745"
+    short_content_en:
+    short_content_nl:
 - id: 893
   key: costs_infrastructure_electricity_lv_net
   share_group: ''
@@ -9189,6 +15591,16 @@
   slide_id: 243
   position: 1
   dependent_on: ''
+  description:
+    content_en: These sliders allow you to change the future (average) grid expansion
+      costs for each voltage level. The default settings for the Netherlands are based
+      on the current average expansion costs as reported in the study 'Grid for the
+      Future', CE Delft (2017).
+    content_nl: Met deze schuifjes kun je de gemiddelde kosten voor netuitbreiding
+      instellen voor elk spanningsniveau. De standaardinstellingen voor Nederland
+      zijn gebaseerd op de studie 'Net voor de Toekomst', CE Delft (2017).
+    short_content_en:
+    short_content_nl:
 - id: 894
   key: costs_infrastructure_electricity_lv_mv_trafo
   share_group: ''
@@ -9212,6 +15624,16 @@
   slide_id: 243
   position: 2
   dependent_on: ''
+  description:
+    content_en: These sliders allow you to change the future (average) grid expansion
+      costs for each voltage level. The default settings for the Netherlands are based
+      on the current average expansion costs as reported in the study 'Grid for the
+      Future', CE Delft (2017).
+    content_nl: Met deze schuifjes kun je de gemiddelde kosten voor netuitbreiding
+      instellen voor elk spanningsniveau. De standaardinstellingen voor Nederland
+      zijn gebaseerd op de studie 'Net voor de Toekomst', CE Delft (2017).
+    short_content_en:
+    short_content_nl:
 - id: 895
   key: costs_infrastructure_electricity_mv_net
   share_group: ''
@@ -9235,6 +15657,16 @@
   slide_id: 243
   position: 3
   dependent_on: ''
+  description:
+    content_en: These sliders allow you to change the future (average) grid expansion
+      costs for each voltage level. The default settings for the Netherlands are based
+      on the current average expansion costs as reported in the study 'Grid for the
+      Future', CE Delft (2017).
+    content_nl: Met deze schuifjes kun je de gemiddelde kosten voor netuitbreiding
+      instellen voor elk spanningsniveau. De standaardinstellingen voor Nederland
+      zijn gebaseerd op de studie 'Net voor de Toekomst', CE Delft (2017).
+    short_content_en:
+    short_content_nl:
 - id: 896
   key: costs_infrastructure_electricity_mv_hv_trafo
   share_group: ''
@@ -9258,6 +15690,16 @@
   slide_id: 243
   position: 4
   dependent_on: ''
+  description:
+    content_en: These sliders allow you to change the future (average) grid expansion
+      costs for each voltage level. The default settings for the Netherlands are based
+      on the current average expansion costs as reported in the study 'Grid for the
+      Future', CE Delft (2017).
+    content_nl: Met deze schuifjes kun je de gemiddelde kosten voor netuitbreiding
+      instellen voor elk spanningsniveau. De standaardinstellingen voor Nederland
+      zijn gebaseerd op de studie 'Net voor de Toekomst', CE Delft (2017).
+    short_content_en:
+    short_content_nl:
 - id: 897
   key: costs_infrastructure_electricity_hv_net
   share_group: ''
@@ -9281,6 +15723,16 @@
   slide_id: 243
   position: 5
   dependent_on: ''
+  description:
+    content_en: These sliders allow you to change the future (average) grid expansion
+      costs for each voltage level. The default settings for the Netherlands are based
+      on the current average expansion costs as reported in the study 'Grid for the
+      Future', CE Delft (2017).
+    content_nl: Met deze schuifjes kun je de gemiddelde kosten voor netuitbreiding
+      instellen voor elk spanningsniveau. De standaardinstellingen voor Nederland
+      zijn gebaseerd op de studie 'Net voor de Toekomst', CE Delft (2017).
+    short_content_en:
+    short_content_nl:
 - id: 898
   key: costs_infrastructure_electricity_interconnector_net
   share_group: ''
@@ -9304,6 +15756,16 @@
   slide_id: 243
   position: 6
   dependent_on: ''
+  description:
+    content_en: These sliders allow you to change the future (average) grid expansion
+      costs for each voltage level. The default settings for the Netherlands are based
+      on the current average expansion costs as reported in the study 'Grid for the
+      Future', CE Delft (2017).
+    content_nl: Met deze schuifjes kun je de gemiddelde kosten voor netuitbreiding
+      instellen voor elk spanningsniveau. De standaardinstellingen voor Nederland
+      zijn gebaseerd op de studie 'Net voor de Toekomst', CE Delft (2017).
+    short_content_en:
+    short_content_nl:
 - id: 899
   key: costs_infrastructure_electricity_offshore_net
   share_group: ''
@@ -9327,6 +15789,16 @@
   slide_id: 243
   position: 7
   dependent_on: ''
+  description:
+    content_en: These sliders allow you to change the future (average) grid expansion
+      costs for each voltage level. The default settings for the Netherlands are based
+      on the current average expansion costs as reported in the study 'Grid for the
+      Future', CE Delft (2017).
+    content_nl: Met deze schuifjes kun je de gemiddelde kosten voor netuitbreiding
+      instellen voor elk spanningsniveau. De standaardinstellingen voor Nederland
+      zijn gebaseerd op de studie 'Net voor de Toekomst', CE Delft (2017).
+    short_content_en:
+    short_content_nl:
 - id: 900
   key: costs_infrastructure_useable_spare_capacity
   share_group: ''
@@ -9350,6 +15822,11 @@
   slide_id: 244
   position: 1
   dependent_on: ''
+  description:
+    content_en: ''
+    content_nl: ''
+    short_content_en:
+    short_content_nl:
 - id: 901
   key: costs_ccs_per_ton_in_industry
   share_group: ''
@@ -9373,6 +15850,15 @@
   slide_id: 245
   position: 1
   dependent_on: has_detailed_chemical_industry
+  description:
+    content_en: 'The costs of CCS depend on many factors, including but not limited
+      to: the process CO2 is captured from, how it is captured, how it is transported,
+      over what distance it is transported and how it is stored.'
+    content_nl: 'CCS kosten zijn afhankelijk van veel factoren, waaronder: het proces
+      waarvan CCS afgevangen wordt, hoe CO2 afgevangen wordt, hoe het wordt getransporteerd,
+      over welke afstand het wordt getransporteerd en hoe het wordt opgeslagen.'
+    short_content_en:
+    short_content_nl:
 - id: 902
   key: industry_ccs_in_industry
   share_group: ''
@@ -9396,6 +15882,15 @@
   slide_id: 246
   position: 1
   dependent_on: has_detailed_chemical_industry
+  description:
+    content_en: Which percentage of direct CO2 emissions in industry will be captured
+      and stored? Note that the additional electricity and heat required has only
+      been taken into account financially, not energetically.
+    content_nl: 'Welk percentage van de directe CO2 emissies in de industrie zal worden
+      afgevangen en opgeslagen? N.b.: de additionele elektriciteit- en warmtevraag
+      wordt alleen financieel meegenomen, niet energetisch.'
+    short_content_en:
+    short_content_nl:
 - id: 903
   key: flh_of_energy_power_wind_turbine_coastal
   share_group: ''
@@ -9419,6 +15914,31 @@
   slide_id: 163
   position: 3
   dependent_on: has_coastline
+  description:
+    content_en: In the ETM coastal wind turbines have 2550 full load hours by default.
+      Because of technological developments it is likely that future wind turbines
+      may produce more electricity per installed capacity than today. By increasing
+      the full load hours for this type of wind turbine, more electricity will be
+      produced with the same number of turbines and the same load on the electricity
+      infrastructure. To make this happen, the slider not only increases the number
+      of full load hours but also changes the shape of the hourly production profile
+      for this type of wind turbine. Typically, the peaks will become broader and
+      flatter with increasing full load hours as the turbine spends more time running
+      at higher capacity. Take a look at the ‘Electricity production per hour’-chart
+      to see the effect of your changes on the coastal wind profile.
+    content_nl: In het ETM wordt een windmolen aan de kust standaard gemodelleerd
+      met 2550 vollasturen. Het is aannemelijk dat toekomstige windmolens meer elektriciteit
+      zullen produceren per geïnstalleerd vermogen dan nu. Door de vollasturen te
+      verhogen voor dit type windmolen zal er meer elektriciteit geproduceerd worden
+      met hetzelfde aantal windmolens en dezelfde belasting op het elektriciteitsnetwerk.
+      Om dit mogelijk te maken neemt niet alleen het aantal vollasturen toe met dit
+      schuifje, maar verandert tegelijkertijd ook het productieprofiel per uur voor
+      dit type windmolen. Bij een toenemend aantal vollasturen zullen de pieken breder
+      en platter worden doordat de windmolen vaker draait op hogere capaciteit. Bekijk
+      de 'Elektriciteitsproductie op uurbasis'-grafiek voor meer inzicht in het effect
+      van het aantal vollasturen op het windprofiel.
+    short_content_en:
+    short_content_nl:
 - id: 904
   key: flh_of_energy_power_wind_turbine_inland
   share_group: ''
@@ -9442,6 +15962,31 @@
   slide_id: 163
   position: 2
   dependent_on: ''
+  description:
+    content_en: In the ETM inland wind turbines have 1920 full load hours by default.
+      Because of technological developments it is likely that future wind turbines
+      may produce more electricity per installed capacity than today. By increasing
+      the full load hours for this type of wind turbine, more electricity will be
+      produced with the same number of turbines and the same load on the electricity
+      infrastructure. To make this happen, the slider not only increases the number
+      of full load hours but also changes the shape of the hourly production profile
+      for this type of wind turbine. Typically, the peaks will become broader and
+      flatter with increasing full load hours as the turbine spends more time running
+      at higher capacity. Take a look at the ‘Electricity production per hour’-chart
+      to see the effect of your changes on the inland wind profile.
+    content_nl: In het ETM wordt een windmolen op land standaard gemodelleerd met
+      1920 vollasturen. Het is aannemelijk dat toekomstige windmolens meer elektriciteit
+      zullen produceren per geïnstalleerd vermogen dan nu. Door de vollasturen te
+      verhogen voor dit type windmolen zal er meer elektriciteit geproduceerd worden
+      met hetzelfde aantal windmolens en dezelfde belasting op het elektriciteitsnetwerk.
+      Om dit mogelijk te maken neemt niet alleen het aantal vollasturen toe met dit
+      schuifje, maar verandert tegelijkertijd ook het productieprofiel per uur voor
+      dit type windmolen. Bij een toenemend aantal vollasturen zullen de pieken breder
+      en platter worden doordat de windmolen vaker draait op hogere capaciteit. Bekijk
+      de 'Elektriciteitsproductie op uurbasis'-grafiek voor meer inzicht in het effect
+      van het aantal vollasturen op het windprofiel op land.
+    short_content_en:
+    short_content_nl:
 - id: 905
   key: flh_of_energy_power_wind_turbine_offshore
   share_group: ''
@@ -9465,6 +16010,31 @@
   slide_id: 163
   position: 4
   dependent_on: ''
+  description:
+    content_en: In the ETM offshore wind turbines have 3500 full load hours by default.
+      Because of technological developments it is likely that future wind turbines
+      may produce more electricity per installed capacity than today. By increasing
+      the full load hours for this type of wind turbine, more electricity will be
+      produced with the same number of turbines and the same load on the electricity
+      infrastructure. To make this happen, the slider not only increases the number
+      of full load hours but also changes the shape of the hourly production profile
+      for this type of wind turbine. Typically, the peaks will become broader and
+      flatter with increasing full load hours as the turbine spends more time running
+      at higher capacity. Take a look at the ‘Electricity production per hour’-chart
+      to see the effect of your changes on the offshore wind profile.
+    content_nl: In het ETM wordt een windmolen op zee standaard gemodelleerd met 3500
+      vollasturen. Het is aannemelijk dat toekomstige windmolens meer elektriciteit
+      zullen produceren per geïnstalleerd vermogen dan nu. Door de vollasturen te
+      verhogen voor dit type windmolen zal er meer elektriciteit geproduceerd worden
+      met hetzelfde aantal windmolens en dezelfde belasting op het elektriciteitsnetwerk.
+      Om dit mogelijk te maken neemt niet alleen het aantal vollasturen toe met dit
+      schuifje, maar verandert tegelijkertijd ook het productieprofiel per uur voor
+      dit type windmolen. Bij een toenemend aantal vollasturen zullen de pieken breder
+      en platter worden doordat de windmolen vaker draait op hogere capaciteit. Bekijk
+      de 'Elektriciteitsproductie op uurbasis'-grafiek voor meer inzicht in het effect
+      van het aantal vollasturen op het windprofiel op zee.
+    short_content_en:
+    short_content_nl:
 - id: 906
   key: flh_of_energy_hydrogen_wind_turbine_offshore
   share_group: ''
@@ -9488,6 +16058,19 @@
   slide_id: 163
   position: 5
   dependent_on: ''
+  description:
+    content_en: In the ETM offshore wind turbines have 3500 full load hours by default.
+      Because of technological developments it is likely that future wind turbines
+      may produce more electricity per installed capacity than today. By increasing
+      the full load hours for this type of wind turbine, more electricity will be
+      produced with the same number of turbines.
+    content_nl: 'In het ETM wordt een windmolen op zee standaard gemodelleerd met
+      3500 vollasturen. Het is aannemelijk dat toekomstige windmolens meer elektriciteit
+      zullen produceren per geïnstalleerd vermogen dan nu. Door de vollasturen te
+      verhogen voor dit type windmolen zal er meer elektriciteit geproduceerd worden
+      met hetzelfde aantal windmolens. '
+    short_content_en:
+    short_content_nl:
 - id: 907
   key: flh_of_solar_pv_solar_radiation
   share_group: ''
@@ -9511,6 +16094,35 @@
   slide_id: 163
   position: 6
   dependent_on: ''
+  description:
+    content_en: "In the ETM solar PV panels have 867 full load hours by default. Because
+      of technological developments it is likely that future solar PV panels may produce
+      more electricity per installed capacity than today. By increasing the full load
+      hours for these panels, more electricity will be produced with the same number
+      of panels and the same load on the electricity infrastructure. To make this
+      happen, the slider not only increases the number of full load hours but also
+      changes the shape of the hourly production profile for solar PV panels. Typically,
+      the peaks will become broader and flatter with increasing full load hours as
+      the solar PV panels spend more time at higher capacity. Take a look at the ‘Electricity
+      production per hour’-chart to see the effect of your changes on the solar PV
+      production profile.\r\n</br></br>\r\nNote that this slider adjusts the full
+      load hours for all solar PV panels modelled in the ETM; both for de-central
+      panels installed on roofs as for solar PV panels in central solar power plants."
+    content_nl: "In het ETM heeft een zonnepaneel standaard 867 vollasturen. Het is
+      aannemelijk dat toekomstige zonnepanelen meer elektriciteit zullen produceren
+      per geïnstalleerd vermogen dan nu. Door de vollasturen te verhogen voor zonnepanelen
+      zal er meer elektriciteit geproduceerd worden met hetzelfde aantal panelen en
+      dezelfde belasting op het elektriciteitsnetwerk. Om dit mogelijk te maken neemt
+      niet alleen het aantal vollasturen toe met dit schuifje, maar verandert tegelijkertijd
+      ook het productieprofiel per uur voor de zonnepanelen. Bij een toenemend aantal
+      vollasturen zullen de pieken breder en platter worden doordat het paneel langer
+      op hogere capaciteit elektriciteit produceert. Bekijk de 'Elektriciteitsproductie
+      op uurbasis'-grafiek voor meer inzicht in het effect van het aantal vollasturen
+      op het zonneprofiel.\r\n</br></br>\r\nMerk op dat dit schuifje de vollasturen
+      aanpast voor alle zonnepanelen die gemodelleerd worden in het ETM; zowel voor
+      decentrale zonnepanelen op daken als voor zonnepalen in centrale zonneparken. "
+    short_content_en:
+    short_content_nl:
 - id: 909
   key: capacity_of_energy_flexibility_pumped_storage_electricity
   share_group: ''
@@ -9534,6 +16146,27 @@
   slide_id: 166
   position: 30
   dependent_on: has_mountains
+  description:
+    content_en: "Pumped storage provides a cheap way for large-scale storage of electricity.
+      Electricity can be used to pump water from the lower reservoir to a higher reservoir.
+      At times of high electricity demand electricity is generated by realising the
+      stored water through turbines.\r\n<br/><br/>\r\nPumped storage facilities come
+      in many different sizes. The ETM contains a 500 MW facility as a typical plant.
+      You can set fractional plants to include the desired total capacity of pumped
+      storage. The storage volume of the typical facility is 3 GWh.\r\n<br/><br/>\r\nThe
+      input of the slider (in MW) is converted to a (partial) number of the plant
+      described above."
+    content_nl: "Stuwmeren zijn een goedkope, grootschalige manier om elektriciteit
+      op te slaan. Elektriciteit wordt gebruikt om water omhoog te pompen van een
+      lager gelegen naar een hoger gelegen stuwmeer. Als de elektriciteitsvraag hoog
+      is kan het opgeslagen water via turbines ontsnappen waarmee elektriciteit wordt
+      opgewekt.\r\n<br/><br/>\r\nStuwmeren zijn er in verschillende formaten. Het
+      ETM bevat een 500 MW faciliteit als typische centrale. Je kunt echter ook een
+      fractie van een centrale neerzetten. Het opslagvolume van de typische faciliteit
+      is 3 GWh.\r\n<br/><br/>\r\nDe schuifjesinstelling wordt omgezet naar (deel)aantallen
+      van de centrale zoals hierboven omschreven."
+    short_content_en:
+    short_content_nl:
 - id: 910
   key: costs_hydrogen_transport_compressed_trucks
   share_group: ''
@@ -9557,6 +16190,19 @@
   slide_id: 255
   position: 2
   dependent_on: ''
+  description:
+    content_en: "The costs of hydrogen transport with trucks is mostly depended on
+      labour costs, which is almost half of the total costs. So technology improvement
+      (bigger trucks/higher pressure) will only have little influence on the total
+      costs. \r\n<br><br>\r\nFor the costs calculation an average transport distance
+      of 100km is assumed."
+    content_nl: "De kosten van waterstoftransport met vrachtwagens is voornamelijk
+      afhankelijk van arbeidskosten, welke bijna de helft van de totale kosten zijn.
+      Dus technologische vooruitgang (grotere vrachtwagens/hogere druk) zal slechts
+      geringe invloed hebben op de totale kosten.\r\n<br><br> \r\nVoor de kostenberekening
+      is een gemiddelde transport afstand van 100 km aangenomen."
+    short_content_en:
+    short_content_nl:
 - id: 911
   key: costs_hydrogen_transport_pipelines
   share_group: ''
@@ -9580,6 +16226,28 @@
   slide_id: 255
   position: 1
   dependent_on: ''
+  description:
+    content_en: "The costs for hydrogen transport through pipelines depend on whether
+      already existing gas pipelines will be reused or whether new pipelines will
+      be constructed. Existing pipelines could be reused in two ways; the hydrogen
+      could flow directly through the pipeline with extra sealings or a new pipeline
+      is pushed into the existing gas pipeline, so-called pipe in pipe. This last
+      option is about 10x cheaper than constructing a new pipeline and has the advantage
+      that material is being reused instead of discarded.\r\n<br><br>\r\nFor the costs
+      calculation an average transport distance of 100km is assumed. The default setting
+      of the slider is based on the construction of new dedicated hydrogen pipelines."
+    content_nl: "De kosten van waterstoftransport door leidingen zijn afhankelijk
+      van of bestaande gasleidingen worden hergebruikt of nieuwe leidingen worden
+      aangelegd. Bestaande leidingen kunnen op twee manieren worden hergebrukt, de
+      waterstof kan direct worden getransporteerd door de leiding (mits deze leiding
+      extra wordt afgedicht) of een nieuwe leiding kan worden geschoven in de bestaande
+      leiding, zogenaamde pipe-in-pipe. Deze laatste optie is ongeveer 10x goedkoper
+      dan het aanleggen van een nieuwe leiding en heeft als voordeel dat het materiaal
+      wordt hergebruikt in plaats van vernietigd.\r\n<br><br>\r\nVoor de kostenberekening
+      is een gemiddelde transport afstand van 100 km aangenomen. De beginwaarde van
+      deze schuif is gebaseerd op het plaatsing van nieuwe waterstofleidingen."
+    short_content_en:
+    short_content_nl:
 - id: 912
   key: costs_hydrogen_storage
   share_group: ''
@@ -9603,6 +16271,26 @@
   slide_id: 254
   position: 1
   dependent_on: ''
+  description:
+    content_en: "The default setting of the slider is based hydrogen storage in salt
+      caverns. Hydrogen storage in salt caverns is a cheap way to store large quantities
+      of hydrogen over a long period of time. The total costs of hydrogen storage
+      in salt caverns ranges between 2.5 and 3.4 euro/MWh, while the total costs of
+      hydrogen storage in pressurized tanks for example are typically four times higher.<sup>1</sup>
+      However, for small energy-storage capacities storage in salt caverns is not
+      cost-efficient due to the fixed construction costs. \r\n<br><br>\r\nSources:<br
+      />   \r\n1. Berenschot (2017). CO<sub>2</sub>-free hydrogen production from
+      gas"
+    content_nl: "De startwaarde van deze schuif is gebaseerd op waterstofopslag in
+      zoutcavernes. Waterstofopslag in zoutcavernes is een goedkope manier of grote
+      hoeveelheden waterstof over lange periodes op te slaan. De total kosten van
+      waterstofopslag in zoutcavernes variëren tussen 2.5 en 3.4 euro/MWh, terwijl
+      de totale kosten van waterstofopslag in hogedruk-tanks bijvoorbeeld wel 4x hoger
+      liggen. <sup>1</sup> Echter, voor kleine opslagcapaciteiten is opslag in zoutcavernes
+      niet kostenefficiênt door de vaste bouwkosten.\r\n<br><br>\r\nSources:<br />
+      \  \r\n1. Berenschot (2017). CO<sub>2</sub>-vrije waterstofproductie uit gas"
+    short_content_en:
+    short_content_nl:
 - id: 913
   key: capacity_of_energy_imported_hydrogen_baseload
   share_group: ''
@@ -9626,6 +16314,27 @@
   slide_id: 193
   position: 6
   dependent_on: ''
+  description:
+    content_en: "How much hydrogen will be imported in the future?\r\n<br><br>\r\nThis
+      slider sets the amount of hydrogen that is imported from outside your area.
+      The hydrogen can originate from different countries and can be produced with
+      different technologies, which both influence the accompanied CO<sub>2</sub>-emissions.
+      Therefore, it is possible to adjust the CO<sub>2</sub>-emissions of imported
+      hydrogen in the <a href=\"/scenario/supply/hydrogen/co-sub-2-sub-emissions-of-imported-hydrogen\"
+      >slide below</a>. Additionally, it is possible to set the costs of imported
+      hydrogen in the <a href=\"/scenario/costs/costs_hydrogen/hydrogen-import\" >costs
+      section</a>."
+    content_nl: "Hoeveel waterstof zal er in de toekomst wordem geïmporteerd?\r\n<br><br>\r\nDe
+      schuif bepaalt de hoeveelheid geïmporteerde waterstof van buiten jouw gebied.
+      Deze waterstof kan uit verschillende landen komen en met verschillende technologieën
+      geproduceerd zijn; deze factoren hebben beide invloed op de bijbehorende CO<sub>2</sub>-uitstoot.
+      Daarom is er voor gekozen om de CO<sub>2</sub>-emissies van geïmporteerde waterstof
+      zelf in te kunnen stellen in de <a href=\"/scenario/supply/hydrogen/co-sub-2-sub-emissions-of-imported-hydrogen\"
+      >onderstaande slide</a>. Ook is het mogelijk om de kosten van geïmporteerde
+      waterstof aan te passen bij <a href=\"/scenario/costs/costs_hydrogen/hydrogen-import\"
+      >kosten</a>."
+    short_content_en:
+    short_content_nl:
 - id: 914
   key: industry_aggregated_other_industry_wood_pellets_share
   share_group: other_industry_energetic
@@ -9649,6 +16358,13 @@
   slide_id: 205
   position: 1
   dependent_on: ''
+  description:
+    content_en: What will the share of biomass be in total energy demand of the 'other
+      industry' sector?
+    content_nl: Welk aandeel zal biomassa hebben in het toekomstige energiegebruik
+      van de overige industriesector?
+    short_content_en:
+    short_content_nl:
 - id: 915
   key: industry_aggregated_other_industry_electricity_share
   share_group: other_industry_energetic
@@ -9672,6 +16388,13 @@
   slide_id: 205
   position: 2
   dependent_on: ''
+  description:
+    content_en: What will the share of electricity be in total energy demand of the
+      'other industry' sector?
+    content_nl: Welk aandeel zal elektriciteit hebben in het toekomstige energiegebruik
+      van de overige industriesector?
+    short_content_en:
+    short_content_nl:
 - id: 916
   key: industry_aggregated_other_industry_crude_oil_share
   share_group: other_industry_energetic
@@ -9695,6 +16418,13 @@
   slide_id: 205
   position: 3
   dependent_on: ''
+  description:
+    content_en: What will the share of oil be in total energy demand of the 'other
+      industry' sector?
+    content_nl: Welk aandeel zal olie hebben in het toekomstige energiegebruik van
+      de overige industriesector?
+    short_content_en:
+    short_content_nl:
 - id: 917
   key: industry_aggregated_other_industry_network_gas_share
   share_group: other_industry_energetic
@@ -9718,6 +16448,13 @@
   slide_id: 205
   position: 4
   dependent_on: ''
+  description:
+    content_en: What will the share of gas be in total energy demand of the 'other
+      industry' sector?
+    content_nl: Welk aandeel zal gas hebben in het toekomstige energiegebruik van
+      de overige industriesector?
+    short_content_en:
+    short_content_nl:
 - id: 918
   key: industry_aggregated_other_industry_coal_share
   share_group: other_industry_energetic
@@ -9741,6 +16478,13 @@
   slide_id: 205
   position: 5
   dependent_on: ''
+  description:
+    content_en: What will the share of coal be in total energy demand of the 'other
+      industry' sector?
+    content_nl: Welk aandeel zal kolen hebben in het toekomstige energiegebruik van
+      de overige industriesector?
+    short_content_en:
+    short_content_nl:
 - id: 919
   key: industry_aggregated_other_industry_useable_heat_share
   share_group: other_industry_energetic
@@ -9764,6 +16508,13 @@
   slide_id: 205
   position: 6
   dependent_on: ''
+  description:
+    content_en: What will the share of central heat be in total energy demand of the
+      'other industry' sector?
+    content_nl: Welk aandeel zal centrale warmte hebben in het toekomstige energiegebruik
+      van de overige industriesector?
+    short_content_en:
+    short_content_nl:
 - id: 920
   key: industry_useful_demand_for_aggregated_other
   share_group: ''
@@ -9787,6 +16538,13 @@
   slide_id: 205
   position: 1
   dependent_on: ''
+  description:
+    content_en: Here you can indicate the total size of the 'Other industry' sector
+      in the future.
+    content_nl: Geef hier aan hoe de overige industrie in de toekomst zal groeien
+      of krimpen.
+    short_content_en:
+    short_content_nl:
 - id: 921
   key: households_apartments_share
   share_group: housing_stock
@@ -9810,6 +16568,11 @@
   slide_id: 171
   position: 2
   dependent_on: ''
+  description:
+    content_en: How many apartments will there be in the future?
+    content_nl: 'Hoeveel appartementen zullen er in de toekomst zijn? '
+    short_content_en:
+    short_content_nl:
 - id: 922
   key: households_corner_houses_share
   share_group: housing_stock
@@ -9833,6 +16596,11 @@
   slide_id: 171
   position: 3
   dependent_on: ''
+  description:
+    content_en: How many corner houses will there be in the future?
+    content_nl: Hoeveel hoekhuizen zullen er zijn in de toekomst?
+    short_content_en:
+    short_content_nl:
 - id: 923
   key: households_detached_houses_share
   share_group: housing_stock
@@ -9856,6 +16624,11 @@
   slide_id: 171
   position: 4
   dependent_on: ''
+  description:
+    content_en: How many detached houses will there be in the future?
+    content_nl: Hoeveel vrijstaande huizen zullen er zijn in de toekomst?
+    short_content_en:
+    short_content_nl:
 - id: 924
   key: households_semi_detached_houses_share
   share_group: housing_stock
@@ -9879,6 +16652,11 @@
   slide_id: 171
   position: 5
   dependent_on: ''
+  description:
+    content_en: How many semi-detached houses will there be in the future?
+    content_nl: Hoeveel twee-onder-één-kap-woningen zullen er zijn in de toekomst?
+    short_content_en:
+    short_content_nl:
 - id: 925
   key: households_terraced_houses_share
   share_group: housing_stock
@@ -9902,6 +16680,11 @@
   slide_id: 171
   position: 6
   dependent_on: ''
+  description:
+    content_en: How many terraced houses will there be in the future?
+    content_nl: Hoeveel rijtjeshuizen zullen er zijn in de toekomst?
+    short_content_en:
+    short_content_nl:
 - id: 926
   key: households_insulation_level_apartments
   share_group: ''
@@ -9925,6 +16708,46 @@
   slide_id: 1
   position: 6
   dependent_on: ''
+  description:
+    content_en: "The heat demand reduction is the percentage by which the heat demand
+      is reduced compared to a badly insulated house (characterised by label G), i.e.
+      the slider indicates how much of the potential savings has been achieved. The
+      current settings are based on the energy labels that are present within your
+      region, for the Netherlands this data is derived from <a href=\"https://bagviewer.kadaster.nl/lvbag/bag-viewer/index.html#?geometry.x=160000&geometry.y=455000&zoomlevel=0)\">\"Basisregistratie
+      Adressen en Gebouwen (BAG)\"</a>. These labels have been converted into heat
+      demand reduction percentages. The relationship between heat demand reduction
+      and energy labels per housing type can be found in our <a href=\"https://github.com/quintel/documentation/blob/master/general/insulation.md\">documentation</a>.
+      However, the mapping is ambiguous since there is no direct relationship between
+      energy labels and the insulation level. Please note that the label image above
+      the household insulation sliders shows the <i>average</i> label vs. heat demand
+      reduction mapping for all housing types. \r\n<br><br>\r\nFor the current situation
+      no insulation costs are taken into account, only when insulation measures are
+      taken. The insulation costs are based on the Ecofys <a href=\"https://refman.energytransitionmodel.com/publications/2063\">'De
+      systeemkosten van warmte voor woningen (2015)'</a> (Dutch only). We make a distinction
+      between costs for existing and newly built houses. The insulation costs for
+      houses are not fixed per % heat demand reduction, but instead the costs depend
+      on the level of insulation in the present year: e.g. going from 0 to 30% is
+      cheaper than going from 30% to 60% insulation."
+    content_nl: "De warmtevraag-reductie is het percentage waarmee de warmtevraag
+      lager is ten opzichte van een slecht geïsoleerd huis (met label G). Oftewel:
+      welk aandeel van het besparingspotentieel is al benut? Het huidige percentage
+      van de slider is gebaseerd op de energielabels die aanwezig zijn in jouw regio;
+      voor Nederland komt deze data van <a href=\"https://bagviewer.kadaster.nl/lvbag/bag-viewer/index.html#?geometry.x=160000&geometry.y=455000&zoomlevel=0)\">Basisregistratie
+      Adressen en Gebouwen (BAG)</a>. De energielabels zijn vervolgens omgezet in
+      een warmtevraag-reductie, deze berekening is terug te vinden in onze <a href=\"https://github.com/quintel/documentation/blob/master/general/insulation.md\">documentatie</a>.
+      De koppeling tussen energielabel en warmtevraag is echter moeilijk te leggen
+      omdat er geen direct verband is tussen energielabels en isolatie van de schil
+      van een huis. Let op: de legenda met energielabels (boven de schuifjes) geeft
+      de <i>gemiddelde</i> koppeling tussen energielabels en warmtevraag-reductie
+      weer voor huizen.\r\n<br><br>\r\nVoor de huidige situatie rekenen we geen isolatiekosten,
+      deze nemen we enkel mee als er wordt geïsoleerd. De isolatiekosten komen uit
+      het Ecofys rapport <a href=\"https://refman.energytransitionmodel.com/publications/2063\">'De
+      systeemkosten van warmte voor woningen (2015)'</a>. We maken onderscheid tussen
+      kosten voor bestaande en nieuwbouwhuizen. De kosten zijn geen vast bedrag per
+      % warmtevraag-reductie, maar afhankelijk van het isolatieniveau in het huidige
+      jaar: bijv. van 0 tot 30% isolatie is goedkoper dan van 30% naar 60% isolatie."
+    short_content_en:
+    short_content_nl:
 - id: 927
   key: households_insulation_level_corner_houses
   share_group: ''
@@ -9948,6 +16771,46 @@
   slide_id: 1
   position: 7
   dependent_on: ''
+  description:
+    content_en: "The heat demand reduction is the percentage by which the heat demand
+      is reduced compared to a badly insulated house (characterised by label G), i.e.
+      the slider indicates how much of the potential savings has been achieved. The
+      current settings are based on the energy labels that are present within your
+      region, for the Netherlands this data is derived from <a href=\"https://bagviewer.kadaster.nl/lvbag/bag-viewer/index.html#?geometry.x=160000&geometry.y=455000&zoomlevel=0)\">\"Basisregistratie
+      Adressen en Gebouwen (BAG)\"</a>. These labels have been converted into heat
+      demand reduction percentages. The relationship between heat demand reduction
+      and energy labels per housing type can be found in our <a href=\"https://github.com/quintel/documentation/blob/master/general/insulation.md\">documentation</a>.
+      However, the mapping is ambiguous since there is no direct relationship between
+      energy labels and the insulation level. Please note that the label image above
+      the household insulation sliders shows the <i>average</i> label vs. heat demand
+      reduction mapping for all housing types. \r\n<br><br>\r\nFor the current situation
+      no insulation costs are taken into account, only when insulation measures are
+      taken. The insulation costs are based on the Ecofys <a href=\"https://refman.energytransitionmodel.com/publications/2063\">'De
+      systeemkosten van warmte voor woningen (2015)'</a> (Dutch only). We make a distinction
+      between costs for existing and newly built houses. The insulation costs for
+      houses are not fixed per % heat demand reduction, but instead the costs depend
+      on the level of insulation in the present year: e.g. going from 0 to 30% is
+      cheaper than going from 30% to 60% insulation."
+    content_nl: "De warmtevraag-reductie is het percentage waarmee de warmtevraag
+      lager is ten opzichte van een slecht geïsoleerd huis (met label G). Oftewel:
+      welk aandeel van het besparingspotentieel is al benut? Het huidige percentage
+      van de slider is gebaseerd op de energielabels die aanwezig zijn in jouw regio;
+      voor Nederland komt deze data van <a href=\"https://bagviewer.kadaster.nl/lvbag/bag-viewer/index.html#?geometry.x=160000&geometry.y=455000&zoomlevel=0)\">Basisregistratie
+      Adressen en Gebouwen (BAG)</a>. De energielabels zijn vervolgens omgezet in
+      een warmtevraag-reductie, deze berekening is terug te vinden in onze <a href=\"https://github.com/quintel/documentation/blob/master/general/insulation.md\">documentatie</a>.
+      De koppeling tussen energielabel en warmtevraag is echter moeilijk te leggen
+      omdat er geen direct verband is tussen energielabels en isolatie van de schil
+      van een huis. Let op: de legenda met energielabels (boven de schuifjes) geeft
+      de <i>gemiddelde</i> koppeling tussen energielabels en warmtevraag-reductie
+      weer voor huizen.\r\n<br><br>\r\nVoor de huidige situatie rekenen we geen isolatiekosten,
+      deze nemen we enkel mee als er wordt geïsoleerd. De isolatiekosten komen uit
+      het Ecofys rapport <a href=\"https://refman.energytransitionmodel.com/publications/2063\">'De
+      systeemkosten van warmte voor woningen (2015)'</a>. We maken onderscheid tussen
+      kosten voor bestaande en nieuwbouwhuizen. De kosten zijn geen vast bedrag per
+      % warmtevraag-reductie, maar afhankelijk van het isolatieniveau in het huidige
+      jaar: bijv. van 0 tot 30% isolatie is goedkoper dan van 30% naar 60% isolatie."
+    short_content_en:
+    short_content_nl:
 - id: 928
   key: households_insulation_level_detached_houses
   share_group: ''
@@ -9971,6 +16834,46 @@
   slide_id: 1
   position: 8
   dependent_on: ''
+  description:
+    content_en: "The heat demand reduction is the percentage by which the heat demand
+      is reduced compared to a badly insulated house (characterised by label G), i.e.
+      the slider indicates how much of the potential savings has been achieved. The
+      current settings are based on the energy labels that are present within your
+      region, for the Netherlands this data is derived from <a href=\"https://bagviewer.kadaster.nl/lvbag/bag-viewer/index.html#?geometry.x=160000&geometry.y=455000&zoomlevel=0)\">\"Basisregistratie
+      Adressen en Gebouwen (BAG)\"</a>. These labels have been converted into heat
+      demand reduction percentages. The relationship between heat demand reduction
+      and energy labels per housing type can be found in our <a href=\"https://github.com/quintel/documentation/blob/master/general/insulation.md\">documentation</a>.
+      However, the mapping is ambiguous since there is no direct relationship between
+      energy labels and the insulation level. Please note that the label image above
+      the household insulation sliders shows the <i>average</i> label vs. heat demand
+      reduction mapping for all housing types. \r\n<br><br>\r\nFor the current situation
+      no insulation costs are taken into account, only when insulation measures are
+      taken. The insulation costs are based on the Ecofys <a href=\"https://refman.energytransitionmodel.com/publications/2063\">'De
+      systeemkosten van warmte voor woningen (2015)'</a> (Dutch only). We make a distinction
+      between costs for existing and newly built houses. The insulation costs for
+      houses are not fixed per % heat demand reduction, but instead the costs depend
+      on the level of insulation in the present year: e.g. going from 0 to 30% is
+      cheaper than going from 30% to 60% insulation."
+    content_nl: "De warmtevraag-reductie is het percentage waarmee de warmtevraag
+      lager is ten opzichte van een slecht geïsoleerd huis (met label G). Oftewel:
+      welk aandeel van het besparingspotentieel is al benut? Het huidige percentage
+      van de slider is gebaseerd op de energielabels die aanwezig zijn in jouw regio;
+      voor Nederland komt deze data van <a href=\"https://bagviewer.kadaster.nl/lvbag/bag-viewer/index.html#?geometry.x=160000&geometry.y=455000&zoomlevel=0)\">Basisregistratie
+      Adressen en Gebouwen (BAG)</a>. De energielabels zijn vervolgens omgezet in
+      een warmtevraag-reductie, deze berekening is terug te vinden in onze <a href=\"https://github.com/quintel/documentation/blob/master/general/insulation.md\">documentatie</a>.
+      De koppeling tussen energielabel en warmtevraag is echter moeilijk te leggen
+      omdat er geen direct verband is tussen energielabels en isolatie van de schil
+      van een huis. Let op: de legenda met energielabels (boven de schuifjes) geeft
+      de <i>gemiddelde</i> koppeling tussen energielabels en warmtevraag-reductie
+      weer voor huizen.\r\n<br><br>\r\nVoor de huidige situatie rekenen we geen isolatiekosten,
+      deze nemen we enkel mee als er wordt geïsoleerd. De isolatiekosten komen uit
+      het Ecofys rapport <a href=\"https://refman.energytransitionmodel.com/publications/2063\">'De
+      systeemkosten van warmte voor woningen (2015)'</a>. We maken onderscheid tussen
+      kosten voor bestaande en nieuwbouwhuizen. De kosten zijn geen vast bedrag per
+      % warmtevraag-reductie, maar afhankelijk van het isolatieniveau in het huidige
+      jaar: bijv. van 0 tot 30% isolatie is goedkoper dan van 30% naar 60% isolatie."
+    short_content_en:
+    short_content_nl:
 - id: 929
   key: households_insulation_level_semi_detached_houses
   share_group: ''
@@ -9994,6 +16897,46 @@
   slide_id: 1
   position: 9
   dependent_on: ''
+  description:
+    content_en: "The heat demand reduction is the percentage by which the heat demand
+      is reduced compared to a badly insulated house (characterised by label G), i.e.
+      the slider indicates how much of the potential savings has been achieved. The
+      current settings are based on the energy labels that are present within your
+      region, for the Netherlands this data is derived from <a href=\"https://bagviewer.kadaster.nl/lvbag/bag-viewer/index.html#?geometry.x=160000&geometry.y=455000&zoomlevel=0)\">\"Basisregistratie
+      Adressen en Gebouwen (BAG)\"</a>. These labels have been converted into heat
+      demand reduction percentages. The relationship between heat demand reduction
+      and energy labels per housing type can be found in our <a href=\"https://github.com/quintel/documentation/blob/master/general/insulation.md\">documentation</a>.
+      However, the mapping is ambiguous since there is no direct relationship between
+      energy labels and the insulation level. Please note that the label image above
+      the household insulation sliders shows the <i>average</i> label vs. heat demand
+      reduction mapping for all housing types. \r\n<br><br>\r\nFor the current situation
+      no insulation costs are taken into account, only when insulation measures are
+      taken. The insulation costs are based on the Ecofys <a href=\"https://refman.energytransitionmodel.com/publications/2063\">'De
+      systeemkosten van warmte voor woningen (2015)'</a> (Dutch only). We make a distinction
+      between costs for existing and newly built houses. The insulation costs for
+      houses are not fixed per % heat demand reduction, but instead the costs depend
+      on the level of insulation in the present year: e.g. going from 0 to 30% is
+      cheaper than going from 30% to 60% insulation."
+    content_nl: "De warmtevraag-reductie is het percentage waarmee de warmtevraag
+      lager is ten opzichte van een slecht geïsoleerd huis (met label G). Oftewel:
+      welk aandeel van het besparingspotentieel is al benut? Het huidige percentage
+      van de slider is gebaseerd op de energielabels die aanwezig zijn in jouw regio;
+      voor Nederland komt deze data van <a href=\"https://bagviewer.kadaster.nl/lvbag/bag-viewer/index.html#?geometry.x=160000&geometry.y=455000&zoomlevel=0)\">Basisregistratie
+      Adressen en Gebouwen (BAG)</a>. De energielabels zijn vervolgens omgezet in
+      een warmtevraag-reductie, deze berekening is terug te vinden in onze <a href=\"https://github.com/quintel/documentation/blob/master/general/insulation.md\">documentatie</a>.
+      De koppeling tussen energielabel en warmtevraag is echter moeilijk te leggen
+      omdat er geen direct verband is tussen energielabels en isolatie van de schil
+      van een huis. Let op: de legenda met energielabels (boven de schuifjes) geeft
+      de <i>gemiddelde</i> koppeling tussen energielabels en warmtevraag-reductie
+      weer voor huizen.\r\n<br><br>\r\nVoor de huidige situatie rekenen we geen isolatiekosten,
+      deze nemen we enkel mee als er wordt geïsoleerd. De isolatiekosten komen uit
+      het Ecofys rapport <a href=\"https://refman.energytransitionmodel.com/publications/2063\">'De
+      systeemkosten van warmte voor woningen (2015)'</a>. We maken onderscheid tussen
+      kosten voor bestaande en nieuwbouwhuizen. De kosten zijn geen vast bedrag per
+      % warmtevraag-reductie, maar afhankelijk van het isolatieniveau in het huidige
+      jaar: bijv. van 0 tot 30% isolatie is goedkoper dan van 30% naar 60% isolatie."
+    short_content_en:
+    short_content_nl:
 - id: 930
   key: households_insulation_level_terraced_houses
   share_group: ''
@@ -10017,6 +16960,46 @@
   slide_id: 1
   position: 10
   dependent_on: ''
+  description:
+    content_en: "The heat demand reduction is the percentage by which the heat demand
+      is reduced compared to a badly insulated house (characterised by label G), i.e.
+      the slider indicates how much of the potential savings has been achieved. The
+      current settings are based on the energy labels that are present within your
+      region, for the Netherlands this data is derived from <a href=\"https://bagviewer.kadaster.nl/lvbag/bag-viewer/index.html#?geometry.x=160000&geometry.y=455000&zoomlevel=0)\">\"Basisregistratie
+      Adressen en Gebouwen (BAG)\"</a>. These labels have been converted into heat
+      demand reduction percentages. The relationship between heat demand reduction
+      and energy labels per housing type can be found in our <a href=\"https://github.com/quintel/documentation/blob/master/general/insulation.md\">documentation</a>.
+      However, the mapping is ambiguous since there is no direct relationship between
+      energy labels and the insulation level. Please note that the label image above
+      the household insulation sliders shows the <i>average</i> label vs. heat demand
+      reduction mapping for all housing types. \r\n<br><br>\r\nFor the current situation
+      no insulation costs are taken into account, only when insulation measures are
+      taken. The insulation costs are based on the Ecofys <a href=\"https://refman.energytransitionmodel.com/publications/2063\">'De
+      systeemkosten van warmte voor woningen (2015)'</a> (Dutch only). We make a distinction
+      between costs for existing and newly built houses. The insulation costs for
+      houses are not fixed per % heat demand reduction, but instead the costs depend
+      on the level of insulation in the present year: e.g. going from 0 to 30% is
+      cheaper than going from 30% to 60% insulation."
+    content_nl: "De warmtevraag-reductie is het percentage waarmee de warmtevraag
+      lager is ten opzichte van een slecht geïsoleerd huis (met label G). Oftewel:
+      welk aandeel van het besparingspotentieel is al benut? Het huidige percentage
+      van de slider is gebaseerd op de energielabels die aanwezig zijn in jouw regio;
+      voor Nederland komt deze data van <a href=\"https://bagviewer.kadaster.nl/lvbag/bag-viewer/index.html#?geometry.x=160000&geometry.y=455000&zoomlevel=0)\">Basisregistratie
+      Adressen en Gebouwen (BAG)</a>. De energielabels zijn vervolgens omgezet in
+      een warmtevraag-reductie, deze berekening is terug te vinden in onze <a href=\"https://github.com/quintel/documentation/blob/master/general/insulation.md\">documentatie</a>.
+      De koppeling tussen energielabel en warmtevraag is echter moeilijk te leggen
+      omdat er geen direct verband is tussen energielabels en isolatie van de schil
+      van een huis. Let op: de legenda met energielabels (boven de schuifjes) geeft
+      de <i>gemiddelde</i> koppeling tussen energielabels en warmtevraag-reductie
+      weer voor huizen.\r\n<br><br>\r\nVoor de huidige situatie rekenen we geen isolatiekosten,
+      deze nemen we enkel mee als er wordt geïsoleerd. De isolatiekosten komen uit
+      het Ecofys rapport <a href=\"https://refman.energytransitionmodel.com/publications/2063\">'De
+      systeemkosten van warmte voor woningen (2015)'</a>. We maken onderscheid tussen
+      kosten voor bestaande en nieuwbouwhuizen. De kosten zijn geen vast bedrag per
+      % warmtevraag-reductie, maar afhankelijk van het isolatieniveau in het huidige
+      jaar: bijv. van 0 tot 30% isolatie is goedkoper dan van 30% naar 60% isolatie."
+    short_content_en:
+    short_content_nl:
 - id: 933
   key: volume_of_imported_heat
   share_group: ''
@@ -10040,6 +17023,19 @@
   slide_id: 277
   position: 4
   dependent_on: ''
+  description:
+    content_en: "How much (residual) heat can be imported from outside your region?
+      With this slider you can set the amount. \r\n</br></br>\r\nAdditionally, with
+      the slider below you can set the CO<sub>2</sub>-emissions of imported heat and
+      under <a href=\"/scenario/costs/costs_heat/imported-residual-heat\" >'Costs'</a>
+      you can set the costs for imported heat."
+    content_nl: "Hoeveel (rest)warmte kan er geïmporteerd worden van buiten jouw regio?
+      Met deze slider kan jij bepalen hoeveel dat zal zijn.\r\n</br></br>\r\nDaarbij
+      kan je met het schuifje hieronder de CO<sub>2</sub>-uitstoot van geïmporteerde
+      warmte instellen en kan je onder het kopje <a href=\"/scenario/costs/costs_heat/imported-residual-heat\"
+      >'Kosten'</a> de kosten voor geïmporteerde warmte bepalen."
+    short_content_en:
+    short_content_nl:
 - id: 934
   key: co2_emissions_of_imported_heat
   share_group: ''
@@ -10063,6 +17059,19 @@
   slide_id: 277
   position: 5
   dependent_on: ''
+  description:
+    content_en: "How much CO<sub>2</sub>-emissions are associated with the imported
+      heat? \r\n</br></br>\r\nThis strongly depends on the heat source. For reference:
+      when heat originates from a gas CCGT plant, the emissions are around 36,0 kg/GJ
+      (<a href=\"https://www.co2emissiefactoren.nl/lijst-emissiefactoren\" >source</a>(in
+      Dutch!))"
+    content_nl: "Hoeveel CO<sub>2</sub>-uitstoot hoort er bij de geïmporteerde warmte?
+      \r\n</br></br>\r\nDit afhankelijk van de warmtebron. Ter referentie: wanneer
+      de warmte van een STEG gascentrale komt, hoort hier een CO<sub>2</sub>-uitstoot
+      van 36,0 kg/GJ bij (volgens <a href=\"https://www.co2emissiefactoren.nl/lijst-emissiefactoren\"
+      >deze bron</a>)"
+    short_content_en:
+    short_content_nl:
 - id: 935
   key: costs_imported_heat
   share_group: ''
@@ -10086,6 +17095,15 @@
   slide_id: 264
   position: 8
   dependent_on: ''
+  description:
+    content_en: "How much would imported (residual) heat cost?\r\n</br></br>\r\nThe
+      start value of 11.6 €/GJ is an estimate based on the average costs for heat
+      extraction from different industrial processes. "
+    content_nl: "Hoeveel zal geïmporteerde (rest)warmte kosten?\r\n</br></br>\r\nDe
+      startwaarde van 11,60 €/GJ is een schatting gebaseerd op de gemiddelde kosten
+      van warmte-uitkoppeling van verschillende industriële processen."
+    short_content_en:
+    short_content_nl:
 - id: 1001
   key: costs_heat_infra_indoors
   share_group: ''
@@ -10109,6 +17127,20 @@
   slide_id: 263
   position: 1
   dependent_on: ''
+  description:
+    content_en: This slider sets the change in future investment and O&M costs for
+      residual heat from all industrial sectors. Costs are compared to current costs.
+      The costs in the link below depict the costs that are used for residual heat
+      from the chemical industry, refineries and fertilizer industry. For low temperature
+      heat from datacenters we use different costs.
+    content_nl: Met deze schuif stel je de toe- of afname in die je verwacht voor
+      de investeringskosten en onderhouds- en beheerkosten van het uitkoppelen van
+      industriële restwarmte. De kosten worden vergeleken met de kosten van vandaag
+      de dag. De kosten in de link hieronder zijn de kosten die we hanteren voor restwarmte
+      uit de chemische industrie, raffinaderijen en kunstmestindustrie. Voor lage
+      temperatuur restwarmte uit datacenters rekenen we met andere kosten.
+    short_content_en:
+    short_content_nl:
 - id: 1002
   key: costs_heat_infra_outdoors
   share_group: ''
@@ -10155,6 +17187,54 @@
   slide_id: 4
   position: 6
   dependent_on: ''
+  description:
+    content_en: "This heater is a combination of an electric heat pump that draws
+      its heat from the outside air and an efficient conventional hydrogen-fired boiler.\r\n<br/><br/>\r\nThis
+      works as follows:<br/>\r\nThe hydrogen-fired part takes over all of the heating
+      of the building on cold winter days, when heat demand peaks. Because of this
+      clever trick, the heat pump has less impact on the electricity grid than an
+      all-electric heat pump does. Smart use of hybrid hydrogen heat pumps may therefore
+      avoid the need to reinforce local power grids. \r\n<br/><br/>\r\nHeat pumps
+      move heat from one place to another. Refrigerators use heat pumps, for example,
+      but buildings can use them for heating and cooling too. For optimal results
+      with <em>most</em> types of heat pump, installation of under-floor and wall
+      heating instead of radiators is often required, as well as good levels of insulation.
+      The <em>hybrid</em> hydrogen heat pump is an exception, because of its hydrogen-fired
+      heater as a fall-back option. Hybrid hydrogen heat pumps can intelligently use
+      whichever part (heat pump or hydrogen-fired heater) is the most efficient or
+      cost-effective given the weather conditions and insulation level. Houses with
+      limited insulation will rely on the hydrogen-fired part more, better insulated
+      ones will make more use of the heat pump.\r\n<br/><br/>\r\nThe COP of the electric
+      part of the hybrid hydrogen heat pump is dependent of ambient temperature. When
+      the COP drops below the threshold value the hybrid hydrogen heat pump switches
+      to hydrogen. With the default value of the threshold COP space heating is as
+      much as possible supplied by the electric part of the hybrid hydrogen heat pump.
+      The threshold value can be adjusted in the section <a href=\"/scenario/flexibility/flexibility_net_load/demand-response-heat-pumps\"
+      >Demand response - Heat pumps</a>. "
+    content_nl: "Deze verwarmingsoptie is een combinatie van een elektrische warmtepomp
+      met een waterstofgestookte HR-ketel.\r\n<br/><br/>\r\nHet werkt zo:<br/>\r\nDe
+      waterstofketel verwarmt het huis op koude dagen, als de warmtevraag het hoogst
+      is. Deze slimme truc zorgt ervoor dat een hybride waterstofwarmtepomp het stroomnet
+      minder belast dan een elektrische warmtepomp alleen. Door slim gebruik te maken
+      van zulke hybride waterstofwarmtepompen kan de noodzaak om stroomnetten te verzwaren
+      vermeden worden. \r\n<br/><br/>\r\nWarmtepompen verplaatsen warmte van de ene
+      plek naar de andere. Koelkasten gebruiken bijvoorbeeld warmtepompen, maar huizen
+      kunnen dat ook doen voor verwarming of koelen. Dit werkt het eigenlijk alleen
+      als gebouwen goed geïsoleerd zijn en als ze bijvoorbeeld vloer- en muurverwarming
+      hebben in plaats van radiatoren. Hybride waterstofwarmtepompen zijn een uitzondering
+      op deze regel doordat de waterstofketel ingezet kan worden. Ze kunnen slim kiezen
+      welk deel (de warmtepomp of de waterstofketel) het meest efficiënt of kosteneffectief
+      is om aan te zetten, afhankelijk van het weer en hoe goed een huis geïsoleerd
+      is. Minder geïsoleerde huizen zullen de waterstofketel vaker nodig hebben, beter
+      geïsoleerde huizen gebruiken vooral de warmtepomp.  \r\n<br/><br/>\r\nDe COP
+      van het elektrische deel van de hybride waterstofwarmtepomp is afhankelijk van
+      de buitentemperatuur. Als de COP onder de drempelwaarde zakt schakelt de hybride
+      waterstofwarmtepomp volledig over op waterstof. De standaard-drempelwaarde zorgt
+      dat ruimteverwarming zo veel mogelijk via het elektrische gedeelte van de hybride
+      waterstofwarmtepomp gebeurt. De omslag-COP is in de sectie <a href=\"/scenario/flexibility/flexibility_net_load/demand-response-heat-pumps\"
+      >Vraagsturing - Warmtepompen</a> aan te passen. "
+    short_content_en:
+    short_content_nl:
 - id: 942
   key: capacity_of_energy_power_combined_cycle_hydrogen
   share_group: ''
@@ -10178,6 +17258,18 @@
   slide_id: 239
   position: 2
   dependent_on: ''
+  description:
+    content_en: 'Here you can build capacity of combined cycle hydrogen plants. At
+      the moment, these turbines are not used (yet) on a large scale. Because combined
+      cycle hydrogen plant technology is very similar to combined cycle gas plants,
+      we assume that both plants have the same specifications. '
+    content_nl: 'Met deze schuif kun je capaciteit van STEG-waterstofcentrales opstellen
+      die elektriciteit produceren met waterstof. Omdat STEG-waterstofcentrales op
+      dit moment (nog) niet op grote schaal gebruikt worden, veronderstellen we dat
+      de specificaties gelijk zijn aan die van STEG-gascentrales. De technologie van
+      STEG-waterstof- en -gascentrales lijkt namelijk sterk op elkaar. '
+    short_content_en:
+    short_content_nl:
 - id: 943
   key: industry_chemicals_other_wood_pellets_non_energetic_share
   share_group: chemical_other_non_energetic
@@ -10201,6 +17293,20 @@
   slide_id: 202
   position: 14
   dependent_on: ''
+  description:
+    content_en: The chemical industry traditionally uses crude oil as the main carbon
+      feedstock for the production of basic chemicals (such as methanol and ethylene).
+      In the future this oil may be replaced with other sources, like biomass or hydrogen.
+      These sliders allow you to change the future feedstock mix. What will be the
+      share of biomass feedstock in the chemical industry of the future?
+    content_nl: De chemische industrie gebruikt traditioneel veel ruwe olie als grondstofbron
+      van koolwaterstoffen. Hiermee worden chemische basisproducten gemaakt zoals
+      methanol en ethyleen. In de toekomst zou deze ruwe olie vervangen kunnen worden
+      door andere bronnen, zoals biomassa of waterstof. Met deze schuifjes kun je
+      de grondstofmix voor de chemische industrie aanpassen. Hoe groot is het aandeel
+      van biomassa in de chemische industrie van de toekomst?
+    short_content_en:
+    short_content_nl:
 - id: 944
   key: industry_chemicals_other_hydrogen_non_energetic_share
   share_group: chemical_other_non_energetic
@@ -10224,6 +17330,20 @@
   slide_id: 202
   position: 15
   dependent_on: ''
+  description:
+    content_en: The chemical industry traditionally uses crude oil as the main carbon
+      feedstock for the production of basic chemicals (such as methanol and ethylene).
+      In the future this oil may be replaced with other sources, like biomass or hydrogen.
+      These sliders allow you to change the future feedstock mix. What will be the
+      share of hydrogen feedstock in the chemical industry of the future?
+    content_nl: De chemische industrie gebruikt traditioneel veel ruwe olie als grondstofbron
+      van koolwaterstoffen. Hiermee worden chemische basisproducten gemaakt zoals
+      methanol en ethyleen. In de toekomst zou deze ruwe olie vervangen kunnen worden
+      door andere bronnen, zoals biomassa of waterstof. Met deze schuifjes kun je
+      de grondstofmix voor de chemische industrie aanpassen. Hoe groot is het aandeel
+      van waterstof in de chemische industrie van de toekomst?
+    short_content_en:
+    short_content_nl:
 - id: 945
   key: industry_chemicals_other_network_gas_non_energetic_share
   share_group: chemical_other_non_energetic
@@ -10247,6 +17367,20 @@
   slide_id: 202
   position: 16
   dependent_on: ''
+  description:
+    content_en: The chemical industry traditionally uses crude oil as the main carbon
+      feedstock for the production of basic chemicals (such as methanol and ethylene).
+      In the future this oil may be replaced with other sources, like biomass or hydrogen.
+      These sliders allow you to change the future feedstock mix. What will be the
+      share of natural gas feedstock in the chemical industry of the future?
+    content_nl: De chemische industrie gebruikt traditioneel veel ruwe olie als grondstofbron
+      van koolwaterstoffen. Hiermee worden chemische basisproducten gemaakt zoals
+      methanol en ethyleen. In de toekomst zou deze ruwe olie vervangen kunnen worden
+      door andere bronnen, zoals biomassa of waterstof. Met deze schuifjes kun je
+      de grondstofmix voor de chemische industrie aanpassen. Hoe groot is het aandeel
+      van aardgas in de chemische industrie van de toekomst?
+    short_content_en:
+    short_content_nl:
 - id: 946
   key: industry_chemicals_other_crude_oil_non_energetic_share
   share_group: chemical_other_non_energetic
@@ -10270,6 +17404,20 @@
   slide_id: 202
   position: 17
   dependent_on: ''
+  description:
+    content_en: The chemical industry traditionally uses crude oil as the main carbon
+      feedstock for the production of basic chemicals (such as methanol and ethylene).
+      In the future this oil may be replaced with other sources, like biomass or hydrogen.
+      These sliders allow you to change the future feedstock mix. What will be the
+      share of crude oil feedstock in the chemical industry of the future?
+    content_nl: De chemische industrie gebruikt traditioneel veel ruwe olie als grondstofbron
+      van koolwaterstoffen. Hiermee worden chemische basisproducten gemaakt zoals
+      methanol en ethyleen. In de toekomst zou deze ruwe olie vervangen kunnen worden
+      door andere bronnen, zoals biomassa of waterstof. Met deze schuifjes kun je
+      de grondstofmix voor de chemische industrie aanpassen. Hoe groot is het aandeel
+      van ruwe olie in de chemische industrie van de toekomst?
+    short_content_en:
+    short_content_nl:
 - id: 947
   key: industry_chemicals_other_coal_non_energetic_share
   share_group: chemical_other_non_energetic
@@ -10293,6 +17441,20 @@
   slide_id: 202
   position: 18
   dependent_on: ''
+  description:
+    content_en: The chemical industry traditionally uses crude oil as the main carbon
+      feedstock for the production of basic chemicals (such as methanol and ethylene).
+      In the future this oil may be replaced with other sources, like biomass or hydrogen.
+      These sliders allow you to change the future feedstock mix. What will be the
+      share of coal feedstock in the chemical industry of the future?
+    content_nl: De chemische industrie gebruikt traditioneel veel ruwe olie als grondstofbron
+      van koolwaterstoffen. Hiermee worden chemische basisproducten gemaakt zoals
+      methanol en ethyleen. In de toekomst zou deze ruwe olie vervangen kunnen worden
+      door andere bronnen, zoals biomassa of waterstof. Met deze schuifjes kun je
+      de grondstofmix voor de chemische industrie aanpassen. Hoe groot is het aandeel
+      van steenkool in de chemische industrie van de toekomst?
+    short_content_en:
+    short_content_nl:
 - id: 948
   key: households_number_of_residences
   share_group: ''
@@ -10316,6 +17478,12 @@
   slide_id: 171
   position: 1
   dependent_on: ''
+  description:
+    content_en: How do you expect the number of residences to develop over time?
+    content_nl: 'Hoe verwacht je dat het aantal huizen zich gaat ontwikkelen in de
+      toekomst? '
+    short_content_en:
+    short_content_nl:
 - id: 949
   key: transport_car_using_electricity_regular_charging_share
   share_group: flexibility_demand_response_electric_vehicle_profiles
@@ -10339,6 +17507,18 @@
   slide_id: 212
   position: 5
   dependent_on: ''
+  description:
+    content_en: This curve is the regular charging curve from the study [Impact of
+      Smart Charging on EVs Charging Behaviour Assessed from Real Charging Events](https://refman.energytransitionmodel.com/publications/2099)
+      by ELaad and Jedlix. This study analyses data from 10,000 charging sessions
+      of 140 cars.
+    content_nl: 'Dit profiel is het profiel dat bij type laadsessie Regulier van de
+      studie [Impact of Smart Charging on EVs Charging Behaviour Assessed from Real
+      Charging Events](https://refman.energytransitionmodel.com/publications/2099)
+      van ELaad and Jedlix hoort. Deze studie analyseert 10.000 laadsessies van 140
+      automobilisten. '
+    short_content_en:
+    short_content_nl:
 - id: 950
   key: transport_car_using_electricity_smart_charging_share
   share_group: flexibility_demand_response_electric_vehicle_profiles
@@ -10362,6 +17542,17 @@
   slide_id: 212
   position: 4
   dependent_on: ''
+  description:
+    content_en: This curve is the smart charging curve from the study [Impact of Smart
+      Charging on EVs Charging Behaviour Assessed from Real Charging Events](https://refman.energytransitionmodel.com/publications/2099)
+      by ELaad and Jedlix. This study analyses data from 10,000 charging sessions
+      of 140 cars.
+    content_nl: 'Dit profiel is het profiel dat bij type laadsessie Slim van de studie
+      [Impact of Smart Charging on EVs Charging Behaviour Assessed from Real Charging
+      Events](https://refman.energytransitionmodel.com/publications/2099) van ELaad
+      and Jedlix hoort. Deze studie analyseert 10.000 laadsessies van 140 automobilisten. '
+    short_content_en:
+    short_content_nl:
 - id: 951
   key: energy_biogas_fermentation_share
   share_group: greengas
@@ -10385,6 +17576,33 @@
   slide_id: 268
   position: 0
   dependent_on: ''
+  description:
+    content_en: "Currently green gas is mostly generated from the anaerobic digestion
+      of organic biomass and residues produced in agriculture, food production and
+      waste processing. There are two methods for biomass digestion: mono-digestion
+      (one residual flow) or co-digestion (multiple flows with at least 50% animal
+      manure). After digestion the produced biogas can be either used directly for
+      power and/or heat generation or can be converted into greengas to make it suitable
+      for the gas network.\r\n</br></br>\r\nThe ETM models one general type of digester
+      that digests wet biomass. The specifications of this technology can be found
+      below."
+    content_nl: "Biomassavergisting heeft biogas als product, dat direct kan worden
+      gebruikt voor warmte en/of elektriciteit maar ook kan worden opgewerkt tot groengas
+      alvorens het gasnetwerk in te worden geleid. Er zijn twee methoden voor biomassavergisting:
+      monovergisting (een enkele reststroom) en co-vergisting (meerdere stromen door
+      elkaar, waarvan minimaal 50% mest). De meest toegepaste vormen in Nederland
+      zijn co-vergisting van mest met restproducten en monovergisting van slib bij
+      rioolwaterzuiveringsinstallaties met elk zo rond de 100 installaties. Het aantal
+      industriële en GFT-vergisters ligt rond de 10. Sinds 2017 wordt monovergisting
+      van mest extra gestimuleerd in Nederland middels de SDE+ subsidie, hiervoor
+      zijn verschillnde argumenten. Allereerst lopen de kosten voor co-vergistingsmateriaal
+      op. Ook zorgt de aanvoer van co-vergistingsmateriaal voor een groter mestoverschot.
+      Bovendien blijkt regelmatig dat er afvalmateriaal vergist wordt, dat eigenlijk
+      gekweekt is en wellicht als veevoer had kunnen dienen.\r\n</br></br>\r\nHet
+      ETM modelleert één algemene vergister die natte biomassastromen vergist. De
+      specificaties ervan zijn hieronder te lezen."
+    short_content_en:
+    short_content_nl:
 - id: 952
   key: energy_greengas_gasification_dry_biomass_share
   share_group: greengas
@@ -10408,6 +17626,25 @@
   slide_id: 268
   position: 1
   dependent_on: ''
+  description:
+    content_en: During dry gasification dry biomass is gasified at high temperatures
+      (800 to 1000 °C), a kind of combustion with a lack of oxygen. The formation
+      of a synthesis gas is central to gasification. This synthesis gas is a flammable
+      mixture of methane, hydrogen, CO<sub>2</sub> en CO. The gasification route offers
+      flexibility when it comes to the possible follow-up routes and end products
+      to be manufactured (green gas, hydrogen, transport biofuels and more). In the
+      case of green gas production, gasification is followed by methane synthesis,
+      and reprocessing into green gas of natural gas quality.
+    content_nl: Bij droge vergassing wordt droge biomassa vergast bij hoge temperaturen
+      (800 tot 1000 °C), een soort verbranding met een ondermaat zuurstof. Bij vergassing
+      staat de vorming van een synthesegas centraal. Dit synthesegas is een brandbaar
+      mengsel van methaan, waterstof, CO<sub>2</sub> en CO. De vergassingsroute biedt
+      veel flexibiliteit als het gaat om de mogelijke vervolgroutes en te fabriceren
+      eindproducten (groengas, waterstof, transportbiobrandstoffen en meer). In het
+      geval van groengas productie wordt vergassing gevolgd door methaansynthese,
+      en opwerking tot groen gas van aardgaskwaliteit.
+    short_content_en:
+    short_content_nl:
 - id: 953
   key: energy_greengas_gasification_wet_biomass_share
   share_group: greengas
@@ -10431,6 +17668,30 @@
   slide_id: 268
   position: 2
   dependent_on: ''
+  description:
+    content_en: Wet gasification is also called Super Critical Water gasification
+      (SCW). During SCW wet biomass is converted into green gas under high pressure
+      and temperature (at least 375 °C and 221 bar). Above this critical point, water
+      achieves supercritical conditions. During this phase all organic molecules within
+      the biomass fall apart en reach a new balance in the form of synthesis gas (methane,
+      hydrogen, CO<sub>2</sub> and CO) (Gasunie, 2019). Inorganic substances crystallize
+      out simultaneously so that they can be recovered.
+    content_nl: "Een andere naam voor natte vergassing is superkritische watervergassing
+      (Super Critical Water gasification, SCW). Bij SCW wordt natte biomassa onder
+      hoger druk en temperatuur (minimaal 375 °C en 221 bar) omgezet in groen gas.
+      Het gaat op een thermo-chemische omzetting die juist gebruik maakt van de watercomponent
+      in de natte afvalstromen. Door het water, met daarin de biomassa, onder hoge
+      druk en temperatuur te brengen, ontstaat de zogenaamde superkritische fase.
+      Alle organische moleculen in de biomassa vallen dan uiteen en bereiken een nieuw
+      evenwicht in de vorm van synthese gas (methaan, waterstof, CO<sub>2</sub> en
+      CO) (Gasunie, 2019). Gelijktijdig kristalliseren anorganische stoffen uit, zodat
+      ze kunnen worden teruggewonnen.\r\n</br></br>\r\nIn Alkmaar is reeds een SCW
+      installatie gebouwd en verwacht wordt dat in 2019 het eerste groene gas aan
+      het netwerk kan worden geleverd (NRC, 2019). Naast de installatie in Alkmaar,
+      zijn er ook plannen voor twee grote installaties in Rotterdam en Groningen (van
+      150-200 MW)."
+    short_content_en:
+    short_content_nl:
 - id: 955
   key: costs_biogas
   share_group: ''
@@ -10454,6 +17715,11 @@
   slide_id: 269
   position: 2
   dependent_on: ''
+  description:
+    content_en: How much will biogas cost in the future?
+    content_nl: Hoeveel zal biogas kosten in de toekomst?
+    short_content_en:
+    short_content_nl:
 - id: 956
   key: costs_greengas
   share_group: ''
@@ -10477,6 +17743,11 @@
   slide_id: 269
   position: 1
   dependent_on: ''
+  description:
+    content_en: How much will green gas cost in the future?
+    content_nl: Hoeveel zal groengas kosten in de toekomst?
+    short_content_en:
+    short_content_nl:
 - id: 957
   key: costs_wood
   share_group: ''
@@ -10500,6 +17771,11 @@
   slide_id: 269
   position: 3
   dependent_on: ''
+  description:
+    content_en: How much will wood cost in the future?
+    content_nl: Hoeveel zal hout kosten in de toekomst?
+    short_content_en:
+    short_content_nl:
 - id: 958
   key: costs_biodiesel
   share_group: ''
@@ -10523,6 +17799,11 @@
   slide_id: 269
   position: 4
   dependent_on: ''
+  description:
+    content_en: How much will biodiesel cost in the future?
+    content_nl: Hoeveel zal biodiesel kosten in de toekomst?
+    short_content_en:
+    short_content_nl:
 - id: 959
   key: costs_bio_ethanol
   share_group: ''
@@ -10546,6 +17827,11 @@
   slide_id: 269
   position: 5
   dependent_on: ''
+  description:
+    content_en: How much will bioethanol cost in the future?
+    content_nl: Hoeveel zal bio-ethanol kosten in de toekomst?
+    short_content_en:
+    short_content_nl:
 - id: 960
   key: max_demand_of_biogenic_waste
   share_group: ''
@@ -10569,6 +17855,13 @@
   slide_id: 270
   position: 4
   dependent_on: ''
+  description:
+    content_en: With this slider you can set the potential of biogenic waste that
+      is available for combustion in waste incinerators or waste CHPs.
+    content_nl: Met deze slider zet je de potentie biogeen afval wat beschikbaar is
+      om te worden verbrand afvalverbrandingsinstallaties (AVIs) en/of afval WKKs.
+    short_content_en:
+    short_content_nl:
 - id: 961
   key: max_demand_of_wet_biomass
   share_group: ''
@@ -10592,6 +17885,15 @@
   slide_id: 270
   position: 1
   dependent_on: ''
+  description:
+    content_en: 'Wet biomass is biomass with a moisture percentage of at least 40-50%.
+      This includes: residues from the food and beverage industry, agricultural residual
+      streams, sewage sludge, aquatic biomass, cultivated grain products, etc.'
+    content_nl: 'Natte biomassa is biomassa met een vochtpercentage van minimaal 40-50%.
+      Hieronder valt: resten van de voedings- en genootmiddelindustrie (VGI), agrarische
+      reststrommen, rioolsib, aquatische biomassa, geteelde graanproducten etc.'
+    short_content_en:
+    short_content_nl:
 - id: 962
   key: max_demand_of_dry_biomass
   share_group: ''
@@ -10615,6 +17917,21 @@
   slide_id: 270
   position: 2
   dependent_on: ''
+  description:
+    content_en: 'Dry biomass consists of relatively dry organic material, like wood.
+      Dry biomass is ''simple biomass'': it requires no processing and provides a
+      high return. There is therefore a great demand for clean, woody biomass. Examples
+      of woody biomass are residual streams from forestry (tree tops, stumps, bark,
+      branches), recycled waste wood, residual streams from agriculture (straw), and
+      fast-growing bio-energy crops (elephant grass, willow, poplar).'
+    content_nl: 'Droge biomassa bestaat uit relatief droge organische stoffen, zoals
+      hout. Droge biomassa is ‘eenvoudige biomassa’: het heeft geen bewerking nodig
+      en levert een hoog rendement op. Er is dan ook veel vraag naar schone, houtige
+      biomassa. Voorbeelden van houtige biomassa zijn reststromen uit de bosbouw (boomtoppen,
+      stompen, schors, takken), gerecycled afvalhout, reststromen uit de landbouw
+      (stro), en snelgroeiende bio-energiegewassen (olifantsgras, wilg, populier). '
+    short_content_en:
+    short_content_nl:
 - id: 963
   key: max_demand_of_oily_biomass
   share_group: ''
@@ -10638,6 +17955,23 @@
   slide_id: 270
   position: 3
   dependent_on: ''
+  description:
+    content_en: 'Oil-containing biomass is biomass with seeds that contain oil. Crude
+      biodiesel is produced by pressing oil seeds. This can be converted into biodiesel
+      in an esterification process with the addition of methanol. Examples of oil-containing
+      biomass are: rapeseed, sunflower seeds, oil palm. Used frying fats also fall
+      within this category.'
+    content_nl: 'Oliehoudende biomassa is biomassa met zaden waarin olie zit. Door
+      het uitpersen van oliehoudende zaden ontstaat ruwe biodiesel. Deze olie kan
+      in een veresteringsproces met toevoeging van methanol worden omgezet in biodiesel.
+      Voorbeelden van oliehoudende biomassa zijn: koolzaad, zonnebloempitten, oliepalm.
+      Ook gebruikte frituurvetten vallen binnen deze categorie. Van alle biodiesel
+      in Nederland is rond 70 procent gemaakt uit gebruikt frituurvet. Onlangs kwam
+      aan het licht dat er met eenderde van alle biodiesel in Nederland gefraudeerd
+      is (voor meer informatie lees <a href="https://www.volkskrant.nl/nieuws-achtergrond/fraude-met-eenderde-van-alle-biodiesel-kampens-bedrijf-zou-miljoenen-hebben-verdiend~b01c604b/?referer=https%3A%2F%2Fwww.google.com%2F"
+      target="_blank">dit Volkskrant-artikel</a>)'
+    short_content_en:
+    short_content_nl:
 - id: 964
   key: capacity_of_energy_flexibility_hv_opac_electricity
   share_group: ''
@@ -10661,6 +17995,24 @@
   slide_id: 166
   position: 31
   dependent_on: ''
+  description:
+    content_en: The underground pumped hydro storage (UPHS) allows for large-scale
+      storage of electricity. It uses the height difference between two water-reservoirs
+      to store electricity as potential energy. If must-run and volatile electricity
+      production exceeds demand, the excess electricity can be used to pump water
+      to the top reservoir. At a later time, when overproduction has ended, the top
+      reservoir is emptied and the flow of water is used to generate electricity which
+      is returned to the high voltage network. This UPHS has a storage volume of 8400
+      MWh and can be completely filled in 6 hours.
+    content_nl: "De Ondergrondse Pomp Accumulatie Centrale (OPAC) is een grootschalige
+      elektriciteitsopslag met een opslagvolume van 8400 MWh. Het werkt door water
+      naar een hoger gelegen reservoir te pompen en dat water op een later moment
+      terug te laten stromen langs elektriciteitsturbines.\r\nStroom-overschotten
+      van must-run en volatiele opwek kunnen worden opgeslagen met een vermogen van
+      1400 MW. Dus de opslag kan in zes uur volledig worden gevuld.\r\nAls de overproductie
+      voorbij is wordt de opgeslagen elektriciteit teruggeleverd aan het hoogspanningsnet."
+    short_content_en:
+    short_content_nl:
 - id: 965
   key: capacity_of_energy_flexibility_mv_batteries_electricity
   share_group: ''
@@ -10684,6 +18036,19 @@
   slide_id: 166
   position: 20
   dependent_on: ''
+  description:
+    content_en: "This large-scale (129 MWh) battery can be used to store excess electricity
+      from must-run and volatile electricity production. At a later time, when overproduction
+      has ended, the stored electricity is returned to the medium voltage network.
+      \r\nAlthough the battery does not react to congestion events, its behavior can
+      help prevent capacity issues in the electricity network.\r\n"
+    content_nl: "Deze grootschalige (129 MWh) batterij kan worden gebruikt om stroom-overschotten
+      van must-run en volatiele opwek op te slaan. Als de overproductie voorbij is
+      wordt de opgeslagen elektriciteit teruggeleverd aan het elektriciteitsnet.\r\nHoewel
+      de batterij niet reageert op netwerkcongestie kan haar gedrag wel helpen om
+      capaciteitsproblemen op het middenspanningsnet te voorkomen. \r\n"
+    short_content_en:
+    short_content_nl:
 - id: 966
   key: investment_costs_energy_flexibility_hv_opac_electricity
   share_group: ''
@@ -10707,6 +18072,13 @@
   slide_id: 232
   position: 3
   dependent_on: ''
+  description:
+    content_en: This slider determines the future change in investment costs of underground
+      hydro pumped storage.
+    content_nl: Deze slider bepaalt de toekomstige verandering in investeringskosten
+      van Ondergrondse Pomp Accumulatie Centrale (OPAC).
+    short_content_en:
+    short_content_nl:
 - id: 967
   key: investment_costs_energy_flexibility_mv_batteries_electricity
   share_group: ''
@@ -10730,6 +18102,13 @@
   slide_id: 232
   position: 2
   dependent_on: ''
+  description:
+    content_en: This slider determines the future change in investment costs large-scale
+      battery storage.
+    content_nl: Deze slider bepaalt de toekomstige verandering in investeringskosten
+      van grootschalige batterijopslag.
+    short_content_en:
+    short_content_nl:
 - id: 968
   key: industry_aggregated_other_industry_hydrogen_share
   share_group: other_industry_energetic
@@ -10753,6 +18132,13 @@
   slide_id: 205
   position: 0
   dependent_on: ''
+  description:
+    content_en: What will the share of hydrogen be in total energy demand of the 'other
+      industry' sector?
+    content_nl: Welk aandeel zal waterstof hebben in het toekomstige energiegebruik
+      van de overige industriesector?
+    short_content_en:
+    short_content_nl:
 - id: 969
   key: costs_wacc_households
   share_group: ''
@@ -10776,6 +18162,15 @@
   slide_id: 274
   position: 1
   dependent_on: ''
+  description:
+    content_en: 'This category comprises all technologies used in households, including
+      solar panels and solar thermal collectors. Note: heat network infrastructure
+      and heaters belong to ''commercial / proven technologies''.'
+    content_nl: 'Binnen deze categorie vallen alle technologieën in huishoudens, inclusief
+      zonnepanelen en zonneboilers. NB: warmtenetten en warmtenetketels vallen onder
+      ''commerciële / bewezen technologieën''.'
+    short_content_en:
+    short_content_nl:
 - id: 970
   key: costs_wacc_public_infrastructure
   share_group: ''
@@ -10799,6 +18194,19 @@
   slide_id: 274
   position: 2
   dependent_on: ''
+  description:
+    content_en: This category comprises the costs of public infrastructure. For the
+      ETM this currently means the power grid costs. Costs for the hydrogen network
+      are part of the 'new technologies' category. Costs for heat networks are part
+      of the commercial technologies section. For natural gas infrastructure the ETM
+      currently uses a fixed annual sum that is unaffected by the WACC.
+    content_nl: In deze categorie valt de publieke infrastructuur. Voor het ETM betekent
+      dit op dit moment enkel het elektriciteitsnetwerk. Waterstofinfrastructuur valt
+      onder de categorie 'nieuwe technologieën'. Warmtenetten vallen onder de commerciële
+      technologieën. Voor het (aard)gasnetwerk rekent het ETM met vaste jaarlijkse
+      kosten die niet beïnvloed worden door de WACC.
+    short_content_en:
+    short_content_nl:
 - id: 971
   key: costs_wacc_proven_technologies
   share_group: ''
@@ -10822,6 +18230,14 @@
   slide_id: 274
   position: 3
   dependent_on: ''
+  description:
+    content_en: This category comprises all commercial and proven technologies. This
+      is by far the largest category.
+    content_nl: In deze categorie vallen alle commercieel verkrijgbare en bewezen
+      technologieën. Deze categorie omvat de meeste technologieën die in het ETM inzetbaar
+      zijn.
+    short_content_en:
+    short_content_nl:
 - id: 972
   key: costs_wacc_unproven_technologies
   share_group: ''
@@ -10845,6 +18261,19 @@
   slide_id: 274
   position: 4
   dependent_on: ''
+  description:
+    content_en: 'This category comprises all immature / unproven / risky technologies.
+      Currently these technologies are included: hydrogen technologies (electrolyzers,
+      power plants, infrastructure, storage), synthetic kerosene technologies, nuclear
+      plants, carbon capture and storage (CCS), supercritical water gasification (SCWG)
+      and underground pumped hydro storage.'
+    content_nl: 'Deze categorie omvat alle onvolwassen / onbewezen / risicovolle technologieën.
+      Op dit moment worden deze technologieën meegenomen: waterstoftechnologieën (electrolyzers,
+      power plants, infrastructuur, opslag), synthetische kerosine, kernenergie, carbon
+      capture and storage (CCS), supercritical water gasification (SCWG) en Ondergrondse
+      Pomp Accumulatie Centrale (OPAC).'
+    short_content_en:
+    short_content_nl:
 - id: 973
   key: capacity_of_industry_chp_wood_pellets
   share_group:
@@ -10868,6 +18297,15 @@
   slide_id: 44
   position: 5
   dependent_on:
+  description:
+    content_en: A CHP produces electricity and heat. In the industry sector this heat
+      is very often stored in steam. Here you can choose the capacity of wood pellet
+      CHPs delivering to the industrial steam network.
+    content_nl: Een WKK produceert zowel warmte als elektriciteit. In de industrie
+      is deze warmte vaak in de vorm van stoom. Kies hier het vermogen aan biomassa-WKKs
+      dat levert aan het industriële stoomnetwerk.
+    short_content_en:
+    short_content_nl:
 - id: 974
   key: capacity_of_industry_heat_burner_coal
   share_group:
@@ -10891,6 +18329,15 @@
   slide_id: 44
   position: 6
   dependent_on:
+  description:
+    content_en: A burner produces heat. In the industry sector this heat is very often
+      stored in steam. Here you can choose the capacity of coal burner delivering
+      to the industrial steam network.”
+    content_nl: Een ketel produceert warmte. In de industrie is deze warmte vaak in
+      de vorm van stoom. Kies hier het vermogen aan kolenketels dat levert aan het
+      industriële stoomnetwerk.
+    short_content_en:
+    short_content_nl:
 - id: 975
   key: capacity_of_industry_heat_burner_crude_oil
   share_group:
@@ -10914,6 +18361,15 @@
   slide_id: 44
   position: 7
   dependent_on:
+  description:
+    content_en: A burner produces heat. In the industry sector this heat is very often
+      stored in steam. Here you can choose the capacity of oil burners delivering
+      to the industrial steam network.”
+    content_nl: Een ketel produceert warmte. In de industrie is deze warmte vaak in
+      de vorm van stoom. Kies hier het vermogen aan olieketels dat levert aan het
+      industriële stoomnetwerk.
+    short_content_en:
+    short_content_nl:
 - id: 976
   key: capacity_of_industry_heat_burner_lignite
   share_group: ''
@@ -10937,6 +18393,15 @@
   slide_id: 44
   position: 8
   dependent_on: has_lignite
+  description:
+    content_en: A burner produces heat. In the industry sector this heat is very often
+      stored in steam. Here you can choose the capacity of lignite burners delivering
+      to the industrial steam network.”
+    content_nl: Een ketel produceert warmte. In de industrie is deze warmte vaak in
+      de vorm van stoom. Kies hier het vermogen aan bruinkoolketels dat levert aan
+      het industriële stoomnetwerk.
+    short_content_en:
+    short_content_nl:
 - id: 977
   key: capacity_of_industry_heat_well_geothermal
   share_group:
@@ -10960,6 +18425,18 @@
   slide_id: 44
   position: 9
   dependent_on:
+  description:
+    content_en: Geothermal heat wells extract heat from the earth. In many cases the
+      temperature of this heat is too low for industrial processes. However, in some
+      sectors like Food and Paper geothermal heat could be an interesting heat source.
+      Here you can choose the capacity of geothermal wells delivering heat to the
+      industry sector.”
+    content_nl: Geothermie maakt gebruik van warmte uit de bodem. Voor de industrie
+      is deze warmte vaak een té lage temperatuur. Toch is het in sommige sectoren
+      inzetbaar, zoals de papier- en voedselindustrie. Kies hier het vermogen aan
+      geothermieputten dat warmte levert aan de industrie.
+    short_content_en:
+    short_content_nl:
 - id: 978
   key: capacity_of_energy_heat_well_geothermal
   share_group:
@@ -10983,6 +18460,21 @@
   slide_id: 277
   position: 1
   dependent_on:
+  description:
+    content_en: 'Thermal energy from below 500 meters depth is called geothermal energy.
+      This heat can be used to heat buildings. How much heat in your scenario comes
+      from geothermal heat pumps? Caution: geothermal heat pumps typically produce
+      a (more or less) constant amount of heat year round. If your scenario makes
+      use of a lot of geothermal heat, seasonal storage is crucial to ensure that
+      heat produced in summer can be utilised in winter'
+    content_nl: 'Aardwarmte dieper dan 500 meter wordt geothermie genoemd. Deze warmte
+      kan gebruikt worden om gebouwen mee te verwarmen. Hoeveel warmte haal jij in
+      je scenario uit geothermie? Let op: geothermieputten schakelen niet makkelijk
+      op en af, maar produceren een constante hoeveelheid warmte. Als je veel geothermie
+      inzet, is seizoensopslag onmisbaar om de productie in de zomer in de winter
+      in te kunnen zetten.'
+    short_content_en:
+    short_content_nl:
 - id: 979
   key: capacity_of_energy_heat_solar_thermal
   share_group:
@@ -11006,6 +18498,16 @@
   slide_id: 277
   position: 2
   dependent_on:
+  description:
+    content_en: Solar thermal collectors generate heat from the sun and use this to
+      heat water. This heat production is especially high in the summer. Heat demand,
+      on the other hand, peaks in the winter. Use seasonal heat storage for effective
+      deployment.
+    content_nl: Bij zonthermie wordt de warmte van de zon omgezet in warm water. Deze
+      warmteproductie is vooral groot in de zomer, terwijl de vraag naar warmte hoog
+      is in de winter. Maak gebruik van seizoensopslag voor een effectieve inzet.
+    short_content_en:
+    short_content_nl:
 - id: 980
   key: capacity_of_energy_chp_local_engine_biogas
   share_group: ''
@@ -11029,6 +18531,13 @@
   slide_id: 279
   position: 2
   dependent_on: ''
+  description:
+    content_en: "A CHP produces both heat and electricity. Here you can set the capacity
+      of biogas CHPs that supply heat for district heating.\r\n</br>"
+    content_nl: "Een WKK produceert zowel warmte als elektriciteit. Stel hier het
+      vermogen aan biogas-WKKs in dat warmte levert aan warmtenetten.\r\n</br>"
+    short_content_en:
+    short_content_nl:
 - id: 981
   key: capacity_of_energy_heat_heatpump_water_water_electricity
   share_group:
@@ -11052,6 +18561,14 @@
   slide_id: 277
   position: 6
   dependent_on:
+  description:
+    content_en: A heat pump produces heat with electricity and ambient heat. Specify
+      here the capacity of collective heat pumps that supplies heat for district heating
+    content_nl: Een warmtepomp produceert warmte uit elektriciteit en omgevingswarmte.
+      Stel hier het vermogen aan collectieve warmtepompen in dat warmte levert aan
+      warmtenetten.
+    short_content_en:
+    short_content_nl:
 - id: 982
   key: capacity_of_energy_heat_burner_network_gas
   share_group:
@@ -11075,6 +18592,13 @@
   slide_id: 277
   position: 7
   dependent_on:
+  description:
+    content_en: A burner produces heat. Specify here the capacity of gas heaters that
+      supplies heat for district heating.
+    content_nl: Een ketel produceert warmte. Stel hier het vermogen aan gasketels
+      in dat warmte levert aan warmtenetten.
+    short_content_en:
+    short_content_nl:
 - id: 983
   key: capacity_of_energy_heat_burner_hydrogen
   share_group:
@@ -11098,6 +18622,13 @@
   slide_id: 277
   position: 8
   dependent_on:
+  description:
+    content_en: A burner produces heat. Specify here the capacity of hydrogen heaters
+      that supplies heat for district heating.
+    content_nl: Een ketel produceert warmte. Stel hier het vermogen aan waterstofketels
+      in dat warmte levert aan warmtenetten.
+    short_content_en:
+    short_content_nl:
 - id: 984
   key: capacity_of_energy_heat_burner_wood_pellets
   share_group:
@@ -11121,6 +18652,13 @@
   slide_id: 277
   position: 9
   dependent_on:
+  description:
+    content_en: A burner produces heat. Specify here the capacity of biomass heaters
+      that supplies heat for district heating.
+    content_nl: Een ketel produceert warmte. Stel hier het vermogen aan biomassaketels
+      in dat warmte levert aan warmtenetten.
+    short_content_en:
+    short_content_nl:
 - id: 985
   key: capacity_of_energy_heat_burner_waste_mix
   share_group:
@@ -11144,6 +18682,13 @@
   slide_id: 277
   position: 10
   dependent_on:
+  description:
+    content_en: A burner produces heat. Specify here the capacity of waste heaters
+      that supplies heat for district heating.
+    content_nl: Een ketel produceert warmte. Stel hier het vermogen aan afvalverbranders
+      in dat warmte levert aan warmtenetten.
+    short_content_en:
+    short_content_nl:
 - id: 986
   key: capacity_of_energy_heat_burner_coal
   share_group: ''
@@ -11167,6 +18712,13 @@
   slide_id: 278
   position: 11
   dependent_on: has_coal_oil_for_heating_built_environment
+  description:
+    content_en: A burner produces heat. Specify here the capacity of coal heaters
+      that supplies heat for district heating.
+    content_nl: Een ketel produceert warmte. Stel hier het vermogen aan kolenketels
+      in dat warmte levert aan warmtenetten.
+    short_content_en:
+    short_content_nl:
 - id: 987
   key: capacity_of_energy_heat_burner_crude_oil
   share_group: ''
@@ -11190,6 +18742,13 @@
   slide_id: 277
   position: 12
   dependent_on: has_coal_oil_for_heating_built_environment
+  description:
+    content_en: A boiler produces heat. Specify here the capacity of oil heaters that
+      supplies heat for district heating.
+    content_nl: Een ketel produceert warmte. Stel hier het vermogen aan olieketels
+      in dat warmte levert aan warmtenetten.
+    short_content_en:
+    short_content_nl:
 - id: 988
   key: heat_storage_enabled
   share_group:
@@ -11236,6 +18795,31 @@
   slide_id: 263
   position: 10
   dependent_on: ''
+  description:
+    content_en: "Scenarios with large amounts of \"must-run\" heat production will
+      often have considerable excesses of heat. Storage allows you to preserve this
+      heat for later use. Seasonal storage can be switched on/off <a href=\"scenario/supply/heat/seasonal-storage-of-heat\"
+      >here</a>.\r\n</br></br>\r\nThe start value (20 €/MWh) is based on the potential
+      costs of large-scale HT ATES (High Temperature Aquifer Thermal Energy Storage).
+      HT ATES is the underground storage of warm water (60-90 degrees Celsius) in
+      aquifers. The costs strongly depend on the size of the aquifer and the depth.
+      In Denmark, PTES (Pit Thermal Energy Storage) is often used: large insulated
+      water basins. However, this is more difficult to apply in the Netherlands due
+      to the higher groundwater level."
+    content_nl: "Scenario's met een grote hoeveelheid 'must run' en volatiele warmteproductie
+      zoals zonthermie, geothermie of restwarmte, hebben vaak een aanzienlijke warmteproductie
+      in uren met geen of weinig vraag. (Seizoens)opslag stelt je in staat om deze
+      warmte op te slaan en op een later moment in te zetten. Seizoensopslag kan <a
+      href=\"scenario/supply/heat/seasonal-storage-of-heat\" >hier</a> aan/uit worden
+      gezet.\r\n</br></br>\r\nDe startwaarde (20 €/MWh) is gebaseerd op de potentiële
+      kosten van grootschalige HT ATES (High Temperature Aquifer Thermal Energy Storage).
+      HT ATES is het ondergronds opslaan van warm water (60-90 graden Celsius) in
+      aquifers. De kosten zijn sterk afhankelijk van de grootte van de aquifer en
+      de diepte. In Denemarken wordt vaak PTES (Pit Thermal Energy Storage) toegepast:
+      grote geïsoleerde water bassins. Echter is dit in Nederland lastiger toe te
+      passen door het hogere grondwaterpeil."
+    short_content_en:
+    short_content_nl:
 - id: 990
   key: capacity_of_energy_chp_local_wood_pellets
   share_group: ''
@@ -11259,6 +18843,13 @@
   slide_id: 279
   position: 1
   dependent_on: ''
+  description:
+    content_en: "A CHP produces both heat and electricity. Here you can set the capacity
+      of biomass CHPs that supply heat for district heating.\r\n</br>"
+    content_nl: "Een WKK produceert zowel warmte als elektriciteit. Stel hier het
+      vermogen aan biomassa-WKKs in dat warmte levert aan warmtenetten.\r\n</br>"
+    short_content_en:
+    short_content_nl:
 - id: 991
   key: capacity_of_energy_chp_local_engine_network_gas
   share_group: ''
@@ -11282,6 +18873,13 @@
   slide_id: 46
   position: 6
   dependent_on: ''
+  description:
+    content_en: "A CHP produces both heat and electricity. Here you can set the capacity
+      of gas CHPs that supply heat for district heating.\r\n</br>"
+    content_nl: "Een WKK produceert zowel warmte als elektriciteit. Stel hier het
+      vermogen aan gas WKKs in dat warmte levert aan warmtenetten.\r\n</br>"
+    short_content_en:
+    short_content_nl:
 - id: 992
   key: energy_heat_distribution_loss_share
   share_group: ''
@@ -11305,6 +18903,21 @@
   slide_id: 280
   position: 18
   dependent_on: ''
+  description:
+    content_en: The default value for the distribution losses slider is typically
+      low or even zero for many regions modelled in the ETM. This is mainly due to
+      a lack of reliable data for the present year. Please make sure to change this
+      slider to a more realistic value if district heating plays a role in your scenario.
+      A 15% loss value is a sensible default for new district heating systems. For
+      older systems, this is closer to 25-30%.
+    content_nl: De standaardwaarde van de verliesschuif is erg laag of zelfs nul voor
+      veel landen en regio's in het ETM. Dit komt omdat er vaak geen betrouwbare data
+      over warmteverliezen beschikbaar is. Zorg ervoor dat de schuif hieronder op
+      een realistisch getal gezet wordt als warmtenetten een rol spelen in jouw scenario.
+      Voor moderne warmtenetten is 15% een veelgebruikte aanname, voor oudere/bestaande
+      systemen ligt dit dichter bij 25-30%.
+    short_content_en:
+    short_content_nl:
 - id: 993
   key: om_costs_solar_thermal
   share_group: ''
@@ -11328,6 +18941,14 @@
   slide_id: 281
   position: 2
   dependent_on: ''
+  description:
+    content_en: This slider sets the future change in operational and maintenance
+      costs for solar thermal energy. Costs are compared to current costs.
+    content_nl: Met deze schuif stel je de toe-of afname in die je verwacht voor de
+      onderhouds- en beheerkosten van zonthermie. De kosten worden vergeleken met
+      de kosten van vandaag de dag.
+    short_content_en:
+    short_content_nl:
 - id: 994
   key: investment_costs_solar_thermal
   share_group: ''
@@ -11351,6 +18972,14 @@
   slide_id: 281
   position: 1
   dependent_on: ''
+  description:
+    content_en: This slider sets the change in future investment costs for solar thermal
+      energy. Costs are compared to current costs.
+    content_nl: Met deze schuif stel je de toe-of afname in die je verwacht voor de
+      investeringskosten van zonthermie. De kosten worden vergeleken met de kosten
+      van vandaag de dag.
+    short_content_en:
+    short_content_nl:
 - id: 995
   key: energy_heat_network_storage_loss_share
   share_group: ''
@@ -11374,6 +19003,21 @@
   slide_id: 278
   position: 5
   dependent_on: ''
+  description:
+    content_en: 'The start value (15%) is based on the yearly losses of an ''Ecovat''
+      system (link: https://www.ecovat.eu/): a large underground buffer tank filled
+      with water. Storage losses are highly dependent on the type of system. For larger
+      storage systems, for example, the percentage of losses decrease. On the other
+      hand, the losses increase when an open system is used (eg WKO) instead of a
+      closed system such as Ecovat.'
+    content_nl: 'De startwaarde (15%) is gebaseerd op de jaarlijkse verliezen van
+      een Evocat systeem (link: https://www.ecovat.eu/): een groot ondergronds buffervat
+      gevuld met water. Opslagverliezen zijn afhankelijk van het type systeem. Bij
+      grotere opslagsystemen verminderen bijvoorbeeld het verliespercentage. Daarentegen
+      nemen de verliezen juist toe wanneer een open systeem wordt gebruikt (bijv.
+      WKO) in plaats van een gesloten systeem zoals Ecovat.'
+    short_content_en:
+    short_content_nl:
 - id: 996
   key: merit_order_subtype_of_energy_power_nuclear_uranium_oxide
   share_group: ''
@@ -11397,6 +19041,11 @@
   slide_id: 48
   position: 10
   dependent_on: ''
+  description:
+    content_en: ''
+    content_nl: ''
+    short_content_en:
+    short_content_nl:
 - id: 997
   key: share_of_industry_chemicals_other_reused_residual_heat
   share_group: ''
@@ -11406,12 +19055,28 @@
   unit: "%"
   fixed: false
   comments: ''
-  interface_group: 'residual_heat'
+  interface_group: residual_heat
   command_type: ''
   related_converter: ''
   slide_id: 277
   position: 3
   dependent_on: ''
+  description:
+    content_en: "What percentage of the available residual heat from the chemical
+      industry do you want to use in heat networks? How the residual heat potential
+      is determined can be read in our <a href=\"https://github.com/quintel/documentation/blob/master/general/residual_heat_industry.md\"
+      target=\"_blank\">documentation</a>. Often no more than 10-20% of the available
+      heat is used due to short-term restrictions and strategic considerations. The
+      costs of using residual heat can be adjusted <a href=\"/scenario/costs/costs_heat/residual-heat\">here</a>.\r\n</br>"
+    content_nl: "Hoeveel procent van de beschikbare restwarmte uit de chemische industrie
+      wil je uitkoppelen? Hoe de restwarmte potentie is bepaald, is te lezen in onze
+      <a href=\"https://github.com/quintel/documentation/blob/master/general/residual_heat_industry.md\"
+      target=\"_blank\">documentatie</a>. Vaak wordt er niet meer dan 10-20% van de
+      beschikbare warmte uitgekoppeld in verband met korte termijn restricties en
+      strategische overwegingen. De kosten voor het uitkoppelen van restwarmte kunnen
+      <a href=\"/scenario/costs/costs_heat/residual-heat\">hier</a> aangepast worden.\r\n</br>"
+    short_content_en:
+    short_content_nl:
 - id: 998
   key: share_of_industry_chemicals_fertilizers_reused_residual_heat
   share_group: ''
@@ -11421,12 +19086,28 @@
   unit: "%"
   fixed: false
   comments: ''
-  interface_group: 'residual_heat'
+  interface_group: residual_heat
   command_type: ''
   related_converter: ''
   slide_id: 277
   position: 3
   dependent_on: ''
+  description:
+    content_en: "What percentage of the available residual heat from the fertilizer
+      industry do you want to use in heat networks? How the residual heat potential
+      is determined can be read in our <a href=\"https://github.com/quintel/documentation/blob/master/general/residual_heat_industry.md\"
+      target=\"_blank\">documentation</a>. Often no more than 10-20% of the available
+      heat is used due to short-term restrictions and strategic considerations. The
+      costs of using residual heat can be adjusted <a href=\"/scenario/costs/costs_heat/residual-heat\">here</a>.\r\n</br>"
+    content_nl: "Hoeveel procent van de beschikbare restwarmte uit de kunstmestindustrie
+      wil je uitkoppelen? Hoe de restwarmte potentie is bepaald, is te lezen in onze
+      <a href=\"https://github.com/quintel/documentation/blob/master/general/residual_heat_industry.md\"
+      target=\"_blank\">documentatie</a>. Vaak wordt er niet meer dan 10-20% van de
+      beschikbare warmte uitgekoppeld in verband met korte termijn restricties en
+      strategische overwegingen. De kosten voor het uitkoppelen van restwarmte kunnen
+      <a href=\"/scenario/costs/costs_heat/residual-heat\">hier</a> aangepast worden.\r\n</br>"
+    short_content_en:
+    short_content_nl:
 - id: 999
   key: share_of_industry_chemicals_refineries_reused_residual_heat
   share_group: ''
@@ -11436,12 +19117,28 @@
   unit: "%"
   fixed: false
   comments: ''
-  interface_group: 'residual_heat'
+  interface_group: residual_heat
   command_type: ''
   related_converter: ''
   slide_id: 277
   position: 3
   dependent_on: ''
+  description:
+    content_en: "What percentage of the available residual heat from refineries do
+      you want to use in heat networks? How the residual heat potential is determined
+      can be read in our <a href=\"https://github.com/quintel/documentation/blob/master/general/residual_heat_industry.md\"
+      target=\"_blank\">documentation</a>. Often no more than 10-20% of the available
+      heat is used due to short-term restrictions and strategic considerations. The
+      costs of using residual heat can be adjusted <a href=\"/scenario/costs/costs_heat/residual-heat\">here</a>.\r\n</br>"
+    content_nl: "Hoeveel procent van de beschikbare restwarmte uit raffinaderijen
+      wil je uitkoppelen? Hoe de restwarmte potentie is bepaald, is te lezen in onze
+      <a href=\"https://github.com/quintel/documentation/blob/master/general/residual_heat_industry.md\"
+      target=\"_blank\">documentatie</a>. Vaak wordt er niet meer dan 10-20% van de
+      beschikbare warmte uitgekoppeld in verband met korte termijn restricties en
+      strategische overwegingen. De kosten voor het uitkoppelen van restwarmte kunnen
+      <a href=\"/scenario/costs/costs_heat/residual-heat\">hier</a> aangepast worden.\r\n</br>"
+    short_content_en:
+    short_content_nl:
 - id: 1000
   key: share_of_industry_other_ict_reused_residual_heat
   share_group: ''
@@ -11451,9 +19148,27 @@
   unit: "%"
   fixed: false
   comments: ''
-  interface_group: 'residual_heat'
+  interface_group: residual_heat
   command_type: ''
   related_converter: ''
   slide_id: 277
   position: 3
   dependent_on: ''
+  description:
+    content_en: "What percentage of the available residual heat from datacenters do
+      you want to use in heat networks? How the residual heat potential is determined
+      can be read in our <a href=\"https://github.com/quintel/documentation/blob/master/general/residual_heat_industry.md\"
+      target=\"_blank\">documentation</a>. Often no more than 10-20% of the available
+      heat is used due to short-term restrictions, strategic considerations and alternatives
+      that are already better for companies. The costs of using residual heat can
+      be adjusted <a href=\"/scenario/costs/costs_heat/residual-heat\">here</a>.\r\n</br>"
+    content_nl: "Hoeveel procent van de beschikbare restwarmte uit datacenters wil
+      je uitkoppelen? Hoe de restwarmte potentie is bepaald, is te lezen in onze <a
+      href=\"https://github.com/quintel/documentation/blob/master/general/residual_heat_industry.md\"
+      target=\"_blank\">documentatie</a>. Vaak wordt er niet meer dan 10-20% van de
+      beschikbare warmte uitgekoppeld in verband met korte termijn restricties, strategische
+      overwegingen en alternatieven die nu al beter voor bedrijven zijn. De kosten
+      voor het uitkoppelen van restwarmte kunnen <a href=\"/scenario/costs/costs_heat/residual-heat\">hier</a>
+      aangepast worden.\r\n</br>"
+    short_content_en:
+    short_content_nl:

--- a/config/ymodel/slides.yml
+++ b/config/ymodel/slides.yml
@@ -19,6 +19,15 @@
   output_element_id: 58
   alt_output_element_id: 58
   dependent_on: ''
+  description:
+    content_en: 'The demand for heating depends on the level of insulation. Below
+      you can set for each housing type you the heat demand reduction compared to
+      a house with energy label G. '
+    content_nl: De vraag naar warmte is afhankelijk van de mate van isolatie. Hieronder
+      kan je de warmtevraag-reductie per huistype instellen vergeleken met een huis
+      met energielabel G.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 2
   image: house_lighting.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -38,6 +47,12 @@
   output_element_id: 2
   alt_output_element_id: 2
   dependent_on: ''
+  description:
+    content_en: Lighting is a small but obvious part of a household's need for energy.
+    content_nl: Verlichting is een klein maar zichtbaar deel van het energiegebruik
+      van een huishouden.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 3
   image: house_appliances.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -57,6 +72,13 @@
   output_element_id: 2
   alt_output_element_id: 2
   dependent_on: ''
+  description:
+    content_en: 'There is ample room for improvement of household appliances. How
+      much more energy efficient do you think they will become? '
+    content_nl: 'Er kan nog veel verbeterd worden aan huishoudelijke apparaten. Hoeveel
+      efficiënter denk jij dat ze zullen worden? '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 4
   image: house_heating.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -76,6 +98,11 @@
   output_element_id: 56
   alt_output_element_id: 56
   dependent_on: ''
+  description:
+    content_en: "How will households be heated and generate hot water? \r\n"
+    content_nl: "Hoe zullen huishoudens verwarmd worden en hun warm water maken? \r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 5
   image: house_solarpanels.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -95,6 +122,13 @@
   output_element_id: 5
   alt_output_element_id: 5
   dependent_on: ''
+  description:
+    content_en: Generating electricity locally saves energy and maybe also money in
+      the future.
+    content_nl: Het lokaal opwekken van stroom bespaart energie en in de toekomst
+      mogelijk ook geld.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 6
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -114,6 +148,14 @@
   output_element_id: 32
   alt_output_element_id: 32
   dependent_on: ''
+  description:
+    content_en: Nobody can predict future fuel prices. This makes electricity costs
+      hard to predict. What do you think these fuels will cost in the future?
+    content_nl: Niemand kan voorspellen hoeveel brandstoffen in de toekomst zullen
+      kosten. Dat maakt het moeilijk om elektriciteitskosten te voorspellen. Wat gaan
+      brandstoffen volgens jou kosten in de toekomst?
+    short_content_en: test
+    short_content_nl: ''
 - id: 7
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -125,14 +167,23 @@
     zone: *1
     time: 2012-06-28 15:55:16.000000000 Z
   general_sub_header: change
-  group_sub_header:
-  subheader_image:
+  group_sub_header: 
+  subheader_image: 
   key: costs_combustion_investment
   position: 2
   sidebar_item_id: 12
   output_element_id: 32
   alt_output_element_id: 32
-  dependent_on:
+  dependent_on: 
+  description:
+    content_en: 'How will the investment costs of these plants change in the future?
+      Many factors are influential: steel prices, environmental laws, technological
+      breakthroughs, etc. '
+    content_nl: 'Hoe zullen de investeringskosten voor het bouwen van dit soort centrales
+      veranderen? Veel dingen spelen mee: staalprijzen, milieuwetgeving, technologische
+      doorbraken, enz.'
+    short_content_en: ''
+    short_content_nl: ''
 - id: 8
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -144,14 +195,21 @@
     zone: *1
     time: 2012-06-28 15:55:16.000000000 Z
   general_sub_header: change
-  group_sub_header:
-  subheader_image:
+  group_sub_header: 
+  subheader_image: 
   key: costs_combustion_operational_and_maintenance
   position: 3
   sidebar_item_id: 12
   output_element_id: 32
   alt_output_element_id: 32
-  dependent_on:
+  dependent_on: 
+  description:
+    content_en: The costs to run power plants may be different in the future. How
+      do you think these could change?
+    content_nl: De kosten om centrales te laten draaien veranderen met de tijd. Hoe
+      hoog denk je dat ze in de toekomst zullen zijn?
+    short_content_en: ''
+    short_content_nl: ''
 - id: 9
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -163,14 +221,23 @@
     zone: *1
     time: 2012-06-28 15:55:16.000000000 Z
   general_sub_header: change
-  group_sub_header:
-  subheader_image:
+  group_sub_header: 
+  subheader_image: 
   key: costs_wind_investment
   position: 1
   sidebar_item_id: 14
   output_element_id: 32
   alt_output_element_id: 32
-  dependent_on:
+  dependent_on: 
+  description:
+    content_en: 'How will the investment costs of wind turbines change in the future?
+      Many factors are influential: steel prices, environmental laws, technological
+      breakthroughs, etc. '
+    content_nl: 'Hoe zullen de investeringskosten voor het bouwen van windturbines
+      in de toekomst veranderen? Veel dingen spelen mee: staalprijzen, milieuwetgeving,
+      technologische doorbraken, enz.'
+    short_content_en: ''
+    short_content_nl: ''
 - id: 10
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -182,14 +249,21 @@
     zone: *1
     time: 2012-06-28 15:55:16.000000000 Z
   general_sub_header: change
-  group_sub_header:
-  subheader_image:
+  group_sub_header: 
+  subheader_image: 
   key: costs_wind_operational_and_maintenance
   position: 2
   sidebar_item_id: 14
   output_element_id: 32
   alt_output_element_id: 32
-  dependent_on:
+  dependent_on: 
+  description:
+    content_en: The costs to run wind power may change in the future, as the technology
+      develops. How do you think these could change?
+    content_nl: De kosten om windmolens te laten draaien zullen veranderen met de
+      tijd. Hoe hoog denk je dat ze in de toekomst zullen zijn?
+    short_content_en: ''
+    short_content_nl: ''
 - id: 11
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -201,14 +275,23 @@
     zone: *1
     time: 2012-06-28 15:55:16.000000000 Z
   general_sub_header: change
-  group_sub_header:
-  subheader_image:
+  group_sub_header: 
+  subheader_image: 
   key: costs_water_investment
   position: 1
   sidebar_item_id: 15
   output_element_id: 32
   alt_output_element_id: 32
-  dependent_on:
+  dependent_on: 
+  description:
+    content_en: How will the investment costs of water power change in the future?
+      Will there be room for big dams in the world? Will environmental laws allow
+      for them?
+    content_nl: Hoe zullen de investeringskosten voor het bouwen van waterkracht veranderen?
+      Is er in de wereld genoeg ruimte voor grote dammen? Zullen ze toegestaan zijn
+      door strengere milieuwetten?
+    short_content_en: ''
+    short_content_nl: ''
 - id: 12
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -220,14 +303,21 @@
     zone: *1
     time: 2012-06-28 15:55:16.000000000 Z
   general_sub_header: change
-  group_sub_header:
-  subheader_image:
+  group_sub_header: 
+  subheader_image: 
   key: costs_water_operational_and_maintenance
   position: 2
   sidebar_item_id: 15
   output_element_id: 32
   alt_output_element_id: 32
-  dependent_on:
+  dependent_on: 
+  description:
+    content_en: 'The costs to run hydro-electric dams are a minor part of the total.
+      How do you think these could change? '
+    content_nl: De kosten om waterkrachtcentrales te laten draaien zijn maar een klein
+      deel van het totaal. Hoe denk je dat deze zullen veranderen?
+    short_content_en: ''
+    short_content_nl: ''
 - id: 13
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -247,6 +337,14 @@
   output_element_id: 48
   alt_output_element_id: 32
   dependent_on: ''
+  description:
+    content_en: Geothermal energy is getting quite a bit of attention these days.
+      How will the investment costs and operation costs change for this technology
+      in the future?
+    content_nl: Er is veel aandacht voor aardwarmte tegenwoordig. Hoe veranderen de
+      investeringskosten en onderhoudskosten van deze technologie in de toekomst?
+    short_content_en: ''
+    short_content_nl: ''
 - id: 16
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -258,14 +356,23 @@
     zone: *1
     time: 2012-06-28 15:55:16.000000000 Z
   general_sub_header: change
-  group_sub_header:
-  subheader_image:
+  group_sub_header: 
+  subheader_image: 
   key: costs_earth_operational_and_maintenance
   position: 2
   sidebar_item_id: 17
   output_element_id: 32
   alt_output_element_id: 32
-  dependent_on:
+  dependent_on: 
+  description:
+    content_en: 'Geothermal power is getting quite a bit of attention these days.
+      Operational and maintenance costs are a minor part of geothermal electricity
+      costs. What do you think they will be in the future? '
+    content_nl: 'Er is tegenwoordig veel aandacht voor stroom uit aardwarmte. De onderhouds-
+      en beheerkosten zijn maar een klein deel van het geheel. Hoe denk jij dat ze
+      in de toekomst zullen veranderen? '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 17
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -285,6 +392,15 @@
   output_element_id: 32
   alt_output_element_id: 32
   dependent_on: ''
+  description:
+    content_en: How will investment costs for realizing solar power in your own country
+      change in the future? Costs are declining rapidly, while the efficiency of solar
+      panels is improving.
+    content_nl: Hoe zullen de investeringen die zijn nodig voor zonnestroom veranderen
+      in de toekomst? De kosten namen de afgelopen jaren zeer snel af, terwijl de
+      efficiëntie toenam.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 19
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -296,14 +412,23 @@
     zone: *1
     time: 2012-06-28 15:55:16.000000000 Z
   general_sub_header: change
-  group_sub_header:
-  subheader_image:
+  group_sub_header: 
+  subheader_image: 
   key: costs_nuclear_investment
   position: 2
   sidebar_item_id: 13
   output_element_id: 32
   alt_output_element_id: 32
-  dependent_on:
+  dependent_on: 
+  description:
+    content_en: 'How will the investment costs for nuclear plants change in the future?
+      Many factors are influential: steel prices, environmental laws, technological
+      breakthroughs, etc. '
+    content_nl: 'Hoe zullen de investeringskosten voor het bouwen van nucleaire centrales
+      in de toekomst veranderen? Veel dingen spelen een rol: staalprijzen, milieuwetgeving,
+      technologische doorbraken, voldoende technisch geschoolde mensen, enz.'
+    short_content_en: ''
+    short_content_nl: ''
 - id: 20
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -315,14 +440,22 @@
     zone: *1
     time: 2012-06-28 15:55:16.000000000 Z
   general_sub_header: change
-  group_sub_header:
-  subheader_image:
+  group_sub_header: 
+  subheader_image: 
   key: costs_nuclear_operational_and_maintenance
   position: 3
   sidebar_item_id: 13
   output_element_id: 32
   alt_output_element_id: 32
-  dependent_on:
+  dependent_on: 
+  description:
+    content_en: The costs to run nuclear plants may be different in the future. How
+      do you think these could change?
+    content_nl: De kosten om kerncentrales te laten draaien zullen in de toekomst
+      anders zijn, maar zijn slechts een klein onderdeel van de totale kosten. Hoe
+      hoog denk jij dat ze zullen zijn?
+    short_content_en: ''
+    short_content_nl: ''
 - id: 21
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -342,6 +475,14 @@
   output_element_id: 32
   alt_output_element_id: 32
   dependent_on: ''
+  description:
+    content_en: How much will nuclear fuel cost compared to today's prices? On the
+      right you can see that nuclear power is not so sensitive to uranium prices.
+    content_nl: Hoeveel kost kernbrandstof in de toekomst in vergelijking met de prijzen
+      van vandaag? In de kostengrafiek zie je dat kernenergie niet zo gevoelig is
+      voor de prijzen van uranium.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 22
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -361,6 +502,15 @@
   output_element_id: 32
   alt_output_element_id: 32
   dependent_on: ''
+  description:
+    content_en: Emitting CO<sub>2</sub> is no longer free for European power producers.
+      How much cheaper or more expensive compared to todays prices will it be in the
+      future?
+    content_nl: De uitstoot van CO<sub>2</sub> is niet gratis meer voor Europese stroomproducenten.
+      Hoeveel goedkoper of duurder vergeleken met de prijs van vandaag zal CO<sub>2</sub>
+      in de toekomst zijn?
+    short_content_en: ''
+    short_content_nl: ''
 - id: 23
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -380,6 +530,13 @@
   output_element_id: 32
   alt_output_element_id: 32
   dependent_on: ''
+  description:
+    content_en: Will CO<sub>2</sub> capture and storage really become cheaper than
+      it is today? Do you know how much?
+    content_nl: Zal het afvangen en ondergronds opslaan van CO<sub>2</sub> echt goedkoper
+      worden? Weet jij ook hoeveel?
+    short_content_en: ''
+    short_content_nl: ''
 - id: 24
   image: car.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -397,8 +554,31 @@
   position: 1
   sidebar_item_id: 51
   output_element_id: 202
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "Our mobility has grown as a result of a growing economy. Will this
+      trend continue in the future? The growth rate that you indicate here determines
+      the future demand for 'passenger kilometres', the total number of kilometres
+      people travel per year. This number includes all passenger transport applications
+      (car, bus, bike, etc.) and is not influenced by the population size. \r\n<br
+      /> <br />\r\nBesides the growth rate, you can choose the division of transport
+      applications here. What percentage of the kilometres we travel is covered by
+      cars, busses, bikes, etc.?\r\n\r\n<br /> <br />\r\nPlease note that international
+      aviation is part of the <a href=\"/scenario/demand/transport_international_transport/international-transport\">international
+      transport section</a>."
+    content_nl: "Onze mobiliteit is gegroeid als gevolg van een groeiende economie.
+      Zet deze trend zich voort in de toekomst? De groeifactor die je hier invoert,
+      bepaalt onze toekomstige vraag naar 'passagierskilometers', het totaal aantal
+      kilometers dat we afleggen in een jaar. Dit getal omvat alle passagiersvervoersmiddelen
+      (auto, bus, fiets, etc.) en wordt niet beïnvloed door (de groei van) het aantal
+      inwoners. \r\n<br /> <br />\r\nNaast de groeifactor kun je hier de verdeling
+      van vervoermiddelen bepalen. Hoeveel procent van de kilometers die we reizen,
+      leggen we af met de auto, bus, fiets, etc.?\r\n<br /> <br />\r\nLet op: internationaal
+      vliegverkeer valt onder de <a href=\"/scenario/demand/transport_international_transport/international-transport\">sectie
+      'internationaal transport'</a>."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 25
   image: engine.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -416,8 +596,24 @@
   position: 2
   sidebar_item_id: 51
   output_element_id: 203
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: Will there be a shift away from cars that run on fossil fuels? How
+      will a massive roll-out of electric cars affect energy use? Please indicate
+      what cars we drive in the future. In the <a href="/scenario/supply/transport_fuels/road-transport"
+      >road fuels section</a> you can determine which fuel blends cars will use and
+      in the <a href="/scenario/flexibility/flexibility_demand/demand-response-electric-vehicles"
+      >demand response ev section</a> you can determine where electric cars will charge.
+    content_nl: Gaan we massaal over op auto's die geen fossiele brandstoffen gebruiken?
+      Wat gebeurt er als we allemaal overstappen op elektrische auto's? Hier kun je
+      aangeven in wat voor auto's we in de toekomst rijden. In de <a href="/scenario/supply/transport_fuels/road-transport"
+      >sectie brandstoffen wegverkeer </a> kun je bepalen op welke brandstofmix auto's
+      zullen rijden en in de <a href="/scenario/flexibility/flexibility_demand/demand-response-electric-vehicles"
+      >sectie vraagsturing - elektrische auto's</a> kun je aangeven waar auto's zullen
+      opladen.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 26
   image: engine.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -435,8 +631,18 @@
   position: 12
   sidebar_item_id: 52
   output_element_id: 207
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: Will there be a shift away from trucks that run on fossil fuels? How
+      does this affect energy use? In the <a href="/scenario/supply/transport_fuels/road-transport"
+      >road fuels section</a> you can determine which fuels trucks will use.
+    content_nl: Komen er meer trucks die geen fossiele brandstoffen gebruiken? Wat
+      gebeurt er dan met het energiegebruik? In de <a href="/scenario/supply/transport_fuels/road-transport"
+      >brandstoffensectie van wegverkeer</a> kun je bepalen op welke brandstoffen
+      vrachtwagens zullen rijden.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 27
   image: industry.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -456,6 +662,17 @@
   output_element_id: 153
   alt_output_element_id: 153
   dependent_on: ''
+  description:
+    content_en: 'The growth you indicate here is due to economic and population growth
+      and concerns all sectors other than chemical and metal industry. This growth
+      is <strong>excluding</strong> efficiencies and technological changes you can
+      indicate in the subsections below.  '
+    content_nl: De groei die je hier aangeeft is het gevolg van economische en bevolkingsgroei
+      en gaat over alle industriesectoren behalve de metaal- en chemiesectoren. Dit
+      is dus <strong>exclusief</strong> efficiëntieverbeteringen en andere technologieën
+      die je in de gedeeltes hieronder kunt aangeven.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 28
   image: industry.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -475,6 +692,19 @@
   output_element_id: 154
   alt_output_element_id: 154
   dependent_on: ''
+  description:
+    content_en: How will industry meet heat demand? A different mix of technologies
+      for heat can strongly affect energy efficiency, sustainability and CO<sub>2</sub>
+      emissions. The number and kind of CHPs you want in order to meet this demand
+      can be set in the  <a href="/scenario/demand/industry/combined-heat-power">
+      Combined heat & power</a> section.
+    content_nl: Hoe maakt de industrie haar warmte? Door op andere manieren warmte
+      te maken, kan de efficiëntie sterk verbeteren, maar ook de CO<sub>2</sub>-uitstoot
+      en hoe hernieuwbaar het energiegebruik is. De aantallen en soorten WKK's die
+      je wilt gebruiken kun je instellen in het <a href="/scenario/demand/industry/combined-heat-power">
+      Warmte-kracht koppeling</a> gedeelte.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 29
   image: industry.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -494,6 +724,14 @@
   output_element_id: 153
   alt_output_element_id: 153
   dependent_on: ''
+  description:
+    content_en: Of all sectors in the economy, industry has the strongest track record
+      in energy efficiency improvements. Saving energy, means reducing costs.
+    content_nl: Van alle economische sectoren, heeft de industrie de beste reputatie
+      als het op efficiëntieverbeteringen aankomt. Energie besparen betekent nu eenmaal
+      geld besparen.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 30
   image: tractor_and_greenhouse.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -512,7 +750,16 @@
   sidebar_item_id: 5
   output_element_id: 29
   alt_output_element_id: 29
-  dependent_on:
+  dependent_on: 
+  description:
+    content_en: 'The growth you indicate here is due to economic and population growth.
+      This growth is <strong>including</strong> efficiency improvements, but <strong>excluding</strong>
+      technological changes you can indicate in the subsections below.  '
+    content_nl: De groei die je hier aangeeft is het gevolg van economische en bevolkingsgroei.
+      Dit is <strong>inclusief</strong> efficiëntieverbeteringen, maar <strong>exclusief</strong>
+      andere technologieën die je in de gedeeltes hieronder kunt aangeven.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 31
   image: tractor_and_greenhouse.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -532,6 +779,15 @@
   output_element_id: 30
   alt_output_element_id: 30
   dependent_on: ''
+  description:
+    content_en: How is heat produced in agriculture? A different mix of heat generating
+      technologies can strongly affect energy efficiency, sustainability and CO<sub>2</sub>
+      emissions.
+    content_nl: Hoe wordt de warmte die gebruikt wordt in de landbouw geproduceerd?
+      Een andere mix van warmtetechnologieën heeft impact op energie-efficiëntie,
+      duurzaamheid en CO<sub>2</sub>-uitstoot in de landbouw.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 32
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -543,14 +799,21 @@
     zone: *1
     time: 2012-06-28 15:55:16.000000000 Z
   general_sub_header: "%/year"
-  group_sub_header:
-  subheader_image:
+  group_sub_header: 
+  subheader_image: 
   key: demand_other_demand_growth
   position: 1
   sidebar_item_id: 6
   output_element_id: 31
   alt_output_element_id: 31
-  dependent_on:
+  dependent_on: 
+  description:
+    content_en: 'The growth you indicate here is due to economic and population growth.
+      This growth is <strong>excluding</strong> efficiencies and technological changes. '
+    content_nl: De groei die je hier aangeeft is het gevolg van economische en bevolkingsgroei.
+      Dit is dus <strong>exclusief</strong> efficiëntieverbeteringen en andere technologieën.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 34
   image: car_engine.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -568,8 +831,17 @@
   position: 2
   sidebar_item_id: 3
   output_element_id: 201
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: Transport vehicles tend to become more energy efficient over time,
+      but by how much? The sliders below allow you to indicate the efficiency improvement
+      per vehicle type in percentage per year.
+    content_nl: Vervoersmiddelen worden met de jaren efficiënter, maar hoeveel eigenlijk?
+      Met de onderstaande sliders kan je de efficiëntieverbetering per type vervoersmiddel
+      in procenten per jaar bepalen.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 35
   image: windmills.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -588,7 +860,14 @@
   sidebar_item_id: 29
   output_element_id: 134
   alt_output_element_id: 52
-  dependent_on:
+  dependent_on: 
+  description:
+    content_en: "'Not in my backyard' is most people's attitude to wind turbines.
+      How much land and sea will governments allocate to wind power?"
+    content_nl: "'Not in my backyard' is hoe de meeste mensen over grote windmolens
+      denken. Hoeveel land en zeeoppervlak stelt de overheid beschikbaar voor windstroom?"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 36
   image: house_solarpanels.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -604,10 +883,18 @@
   subheader_image: ''
   key: policy_area_solar_power
   position: 2
-  sidebar_item_id:
+  sidebar_item_id: 
   output_element_id: 36
   alt_output_element_id: 36
-  dependent_on:
+  dependent_on: 
+  description:
+    content_en: Governments may set aside land for solar power or make solar panels
+      on roofs mandatory. How much do you want to allocate?
+    content_nl: Misschien reserveert de overheid wel land voor zonnecentrales, of
+      worden zonnepanelen op daken verplicht. Hoeveel oppervlak wil jij beschikbaar
+      stellen?
+    short_content_en: ''
+    short_content_nl: ''
 - id: 37
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -622,11 +909,19 @@
   group_sub_header: ''
   subheader_image: ''
   key: policy_area_biomass
-  position:
-  sidebar_item_id:
-  output_element_id:
-  alt_output_element_id:
-  dependent_on:
+  position: 
+  sidebar_item_id: 
+  output_element_id: 
+  alt_output_element_id: 
+  dependent_on: 
+  description:
+    content_en: 'Biomass can be imported or ''home-grown''. The latter partly competes
+      with food production. How much land should be designated for energy crops? '
+    content_nl: Biomassa kun je importeren of in eigen land verbouwen. Dat laatste
+      gaat dan deels ten koste van voedselproductie. Hoeveel land moet beschikbaar
+      gesteld worden voor energieteelt?
+    short_content_en: ''
+    short_content_nl: ''
 - id: 38
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -646,6 +941,13 @@
   output_element_id: 127
   alt_output_element_id: 46
   dependent_on: ''
+  description:
+    content_en: Governments set CO<sub>2</sub> reduction targets. By how much do you
+      think emissions should change?
+    content_nl: Overheden maken CO<sub>2</sub> reductiedoelstellingen. Wat denk jij
+      dat de doelstelling moet zijn?
+    short_content_en: ''
+    short_content_nl: ''
 - id: 39
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -664,7 +966,14 @@
   sidebar_item_id: 19
   output_element_id: 127
   alt_output_element_id: 34
-  dependent_on:
+  dependent_on: 
+  description:
+    content_en: 'Governments set targets for how much of the energy used should be
+      renewable. What do you think the percentages should be? '
+    content_nl: Overheden maken doelstellingen voor hoeveel energiegebruik hernieuwbaar
+      moet zijn. Wat moet dat percentage zijn volgens jou?
+    short_content_en: ''
+    short_content_nl: ''
 - id: 40
   image: dependence_chart.png
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -684,6 +993,27 @@
   output_element_id: 132
   alt_output_element_id: 76
   dependent_on: ''
+  description:
+    content_en: "Import and export contribute positively to the economic activity
+      of a country. Mutual dependence strengthens trade relations and creates stability
+      between countries. Security of supply is an important aspect for energy trade,
+      because economic activity is not possible without energy supply. That is why
+      a balanced view on this topic is important; not all energy carriers ‘travel
+      easily’, and not all energy flows are that ‘secure’ in the long term. To what
+      extent do you want your country to import foreign energy?\r\n<div class='nl-only'>\r\n
+      \ <br/><br/>\r\n  <a href=\"/scenario/supply/fuel_production/\">Take me to the
+      fuel production section.</a>\r\n</div>"
+    content_nl: "Import en export leveren een positieve bijdrage aan de economische
+      activiteit van een land. Wederzijdse afhankelijkheid versterkt de handelsrelaties
+      en creëert stabiliteit tussen landen. Voor energiehandel geldt dat leveringszekerheid
+      van groot belang is, omdat economische activiteit niet mogelijk is zonder energie.
+      Daarom moeten we ons een genuanceerd beeld vormen over de import en export van
+      energie. Want niet alle energie ‘reist makkelijk’, en niet alle energiestromen
+      zijn op de lange termijn even ‘zeker’. In welke mate vind je dat jouw land buitenlandse
+      energie mag importeren?\r\n<DE><br/><br/><a href=\"/scenario/supply/fuel_production/\">Open
+      de brandstofproductie sectie.</a></DE>"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 41
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -702,7 +1032,12 @@
   sidebar_item_id: 21
   output_element_id: 133
   alt_output_element_id: 39
-  dependent_on:
+  dependent_on: 
+  description:
+    content_en: By how much are energy costs allowed to change in the future?
+    content_nl: Hoeveel mogen de kosten voor energie veranderen in de toekomst?
+    short_content_en: ''
+    short_content_nl: ''
 - id: 42
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -714,14 +1049,21 @@
     zone: *1
     time: 2011-03-10 07:04:33.000000000 Z
   general_sub_header: 'NULL'
-  group_sub_header:
-  subheader_image:
+  group_sub_header: 
+  subheader_image: 
   key: policy_grid_grid_and_interconnectivity
-  position:
-  sidebar_item_id:
-  output_element_id:
-  alt_output_element_id:
-  dependent_on:
+  position: 
+  sidebar_item_id: 
+  output_element_id: 
+  alt_output_element_id: 
+  dependent_on: 
+  description:
+    content_en: 'How much power can come from intermittent sources? How much baseload
+      power production capacity is allowed and how much power may be imported? '
+    content_nl: Hoeveel stroom mag afkomstig zijn van fluctuerende bronnen? Wat is
+      het maximum percentage basislast vermogen en import van elektriciteit?
+    short_content_en: ''
+    short_content_nl: ''
 - id: 43
   image: house.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -741,6 +1083,18 @@
   output_element_id: 213
   alt_output_element_id: 213
   dependent_on: ''
+  description:
+    content_en: Changes in personal prosperity influence the household energy demand.
+      Some of these changes scale with population, whereas others scale with the number
+      of residences. These changes do <strong>not</strong> include efficiency improvements
+      and technological changes. These you can indicate in the slides below.
+    content_nl: Veranderingen in persoonlijke welvaart beïnvloeden het energiegebruik
+      van een huishouden. Sommige van deze veranderingen schalen met de bevolking,
+      terwijl anderen met het aantal huishoudens schalen. Dit is <strong>exclusief</strong>
+      efficiëntieverbeteringen en andere technologieën die je in de gedeeltes hieronder
+      kunt aangeven.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 44
   image: industry_solarpanels.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -760,6 +1114,19 @@
   output_element_id: 251
   alt_output_element_id: 28
   dependent_on: ''
+  description:
+    content_en: 'Below you can set the number of local combined heat and power (CHP)
+      units that will supply heat for the industrial heat network. When the heat produced
+      by local CHPs is lower than the heating demand from industry, then heat can
+      be delivered by <a href="/scenario/supply/heat/large-scale-heat-and-residual-heat">large-scale
+      heat and residual heat sources</a>. '
+    content_nl: 'Hieronder kun je het aantal warmte-krachtkoppelingsinstallaties (WKKs)
+      bepalen dat warmte levert voor het warmtenet in de industrie. Als de geproduceerde
+      warmte van lokale WKKs lager is dan de warmtevraag van de industrie, kunnen
+      <a href="/scenario/supply/heat/large-scale-heat-and-residual-heat">grootschalige
+      warmte en restwarmte bronnen</a> bijspringen. '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 45
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -779,6 +1146,15 @@
   output_element_id: 99
   alt_output_element_id: 99
   dependent_on: ''
+  description:
+    content_en: Coal-fired power plants tend to be running as much as possible. They
+      produce roughly twice as much CO<sub>2</sub> as gas-fired ones. They are not
+      flexible in their output.
+    content_nl: Kolencentrales draaien als het even kan meer dan 80% van de tijd op
+      vol vermogen. Ze zijn dus niet zo flexibel qua productie. Kolencentrales produceren
+      grofweg twee keer zoveel CO<sub>2</sub> als gascentrales.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 46
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -798,6 +1174,15 @@
   output_element_id: 99
   alt_output_element_id: 99
   dependent_on: ''
+  description:
+    content_en: Gas-fired power plants produce roughly half as much CO<sub>2</sub>
+      as coal-fired ones. They are quite flexible in their output and therefore used
+      to fill in peaks in demand.
+    content_nl: Gascentrales produceren grofweg de helft van de CO<sub>2</sub> van
+      een kolencentrale. Ze zijn erg flexibel qua productie en worden daarom vaak
+      gebruikt om de pieken in de vraag op te vangen.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 47
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -817,6 +1202,17 @@
   output_element_id: 99
   alt_output_element_id: 99
   dependent_on: ''
+  description:
+    content_en: "Oil-fired power plants are not common in Europe. These plants produce
+      less CO<sub>2</sub> than coal-fired plants, but more than gas-fired ones. \r\n<br/>\r\nDiesel
+      engines are used in places without connection to the power grid, as emergency
+      power-supply, as well as for stabilizing the power grid."
+    content_nl: "Oliecentrales komen weinig voor in Europa. Deze centrales produceren
+      veel CO<sub>2</sub>, maar minder dan kolencentrales. \r\n<br/>\r\nDieselmotoren
+      worden vaak gebruik op plaatsen zonder stroomaansluiting, als noodaggregaten
+      of stabilisatie van het stroomnet."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 48
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -836,6 +1232,23 @@
   output_element_id: 99
   alt_output_element_id: 99
   dependent_on: ''
+  description:
+    content_en: Here you can set the capacity for conventional and 3rd generation
+      nuclear plants. The ETM does not include any CO<sub>2</sub> emissions for nuclear
+      power plants. By default nuclear power plants are modeled as dispatchable plants.
+      The toggle below the sliders allows you to make them 'must-run' plants (independent
+      of electricity demand) with a flat production profile. This functionality was
+      added, because nuclear plants tend to run as much as possible. This is because
+      of their low operating costs and high capital costs.
+    content_nl: Hier kan je het geïnstalleerd vermogen van conventionele en 3e generatie
+      kerncentrales instellen. Het ETM neemt voor kerncentrales geen CO<sub>2</sub>
+      uitstoot mee. Standaard worden kerncentrales als regelbare centrales gemodelleerd.
+      Met de knop onder de schuifjes kan je dit aanpassen naar een niet-regelbare
+      centrale (onafhankelijk van de elektriciteitsvraag) met een vlak profiel. Deze
+      functionaliteit is toegevoegd, omdat kerncentrales zoveel mogelijk op vol vermogen
+      draaien. Ze hebben namelijk lage draaikosten en hoge kapitaalkosten.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 49
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -855,6 +1268,17 @@
   output_element_id: 77
   alt_output_element_id: 77
   dependent_on: ''
+  description:
+    content_en: 'Natural gas in the gas network can be mixed with green gas to make
+      the supply of gas more sustainable. In addition, Liquefied Natural Gas (LNG),
+      a fuel that is only used in liquid form in the transport sector, can also be
+      converted back to gases and fed into the national gas network. '
+    content_nl: 'Aardgas in het gasnetwerk kan worden bijgemengd met groengas om het
+      gasverbruik te verduurzamen. Daarnaast kan vloeibaar aardgas (LNG), een brandstof
+      die enkel in de transport sector in vloeibare vorm gebruikt wordt, ook weer
+      omgezet worden naar gas en in het gasnetwerk ingevoerd worden. '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 51
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -874,6 +1298,16 @@
   output_element_id: 99
   alt_output_element_id: 99
   dependent_on: ''
+  description:
+    content_en: "How much wind power to you want to install? Full load hours for wind
+      and sun can be adjusted in the <a href=\"/scenario/flexibility/flexibility_weather/extreme-weather-conditions\">weather
+      section</a>.\r\n"
+    content_nl: "<p>\r\nGebruik de PICO kaartlaag voor windenergie om de potentie
+      voor windmolens op land en aan de kust te verkennen. <a href=\"/embeds/pico\"
+      data-remote=\"true\">Verken de potentie van wind op land en aan de kust.</a>\r\n</p>\r\n<p>\r\nDe
+      vollasturen voor wind en zon kunnen worden ingesteld in bij <a href=\"/scenario/flexibility/flexibility_weather/extreme-weather-conditions\">'Weersomstandigheden'</a>.\r\n</p>"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 52
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -893,6 +1327,14 @@
   output_element_id: 99
   alt_output_element_id: 99
   dependent_on: ''
+  description:
+    content_en: Hydro-electricity is considered renewable, but large dams are often
+      built at tremendous cost to the environment. How much do you want to produce?
+    content_nl: Waterkracht is officieel hernieuwbaar, maar het bouwen van grote stuwdammen
+      brengt vaak enorme milieuschade met zich mee. Hoeveel waterkracht wil je inzetten?
+      Wat is het potentieel?
+    short_content_en: ''
+    short_content_nl: ''
 - id: 53
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -912,6 +1354,13 @@
   output_element_id: 99
   alt_output_element_id: 99
   dependent_on: ''
+  description:
+    content_en: 'The potential of geothermal power is not very well known in many
+      countries. How much do you think could be produced? '
+    content_nl: Het potentieel van stroom uit aardwarmte is nog niet voor alle landen
+      bekend. Hoeveel denk jij dat er gemaakt zou kunnen worden?
+    short_content_en: ''
+    short_content_nl: ''
 - id: 54
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -931,6 +1380,24 @@
   output_element_id: 99
   alt_output_element_id: 99
   dependent_on: ''
+  description:
+    content_en: "Is solar power the future? How much do you want to produce? \r\n<br><br>\r\nThe
+      choices you made in the \"Demand\" section determine the number of de-central
+      solar panels on roofs of houses and buildings. You can build solar PV panels
+      in the <a href=\"/scenario/demand/households/solar-panels\">'solar panels' section
+      of households</a> and the <a href=\"/scenario/demand/buildings/solar-panels\">'solar
+      panels' section of buildings</a>.\r\n<br><br>\r\nHere, you can build central
+      solar power plants, on landfills and terrain unfit for other purposes."
+    content_nl: "Is zonnestroom de energie van de toekomst? Hoeveel wil jij produceren?\r\n<br><br>\r\nDe
+      keuzes die je bij \"Vraag\" hebt gemaakt bepalen de hoeveelheid de-centrale
+      zonnestroom die er op daken van woningen en gebouwen komt te liggen. Je kunt
+      zonnepanelen bouwen in de <a href=\"/scenario/demand/households/solar-panels\">'zonnepanelen'
+      sectie van huishoudens</a> en de <a href=\"/scenario/demand/buildings/solar-panels\">'zonnepanelen'
+      sectie van gebouwen</a>.\r\n<br><br>\r\nHier kun je centrale zonneparken bouwen,
+      bijvoorbeeld op vuilnisbelten en terreinen die niet gebruikt hoeven te worden
+      voor andere doeleinden."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 55
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -950,6 +1417,14 @@
   output_element_id: 99
   alt_output_element_id: 99
   dependent_on: ''
+  description:
+    content_en: Burning waste to produce electricity competes with other uses for
+      waste. How much power can be produced?
+    content_nl: Het verbranden van afval om elektriciteit op te wekken gaat ten koste
+      van andere toepassingen van afval. Hoeveel stroom kan er gemaakt worden met
+      afval?
+    short_content_en: ''
+    short_content_nl: ''
 - id: 61
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -964,13 +1439,22 @@
   group_sub_header: ''
   subheader_image: ''
   key: supply_transport_diesel
-  position:
-  sidebar_item_id:
-  output_element_id:
-  alt_output_element_id:
-  dependent_on:
+  position: 
+  sidebar_item_id: 
+  output_element_id: 
+  alt_output_element_id: 
+  dependent_on: 
+  description:
+    content_en: How much of the diesel used in road transport will come from renewable
+      sources? Do consider the impact on land (and sea) use for growing the required
+      crops.
+    content_nl: Hoeveel van de gebruikte diesel voor wegtransport komt van hernieuwbare
+      bronnen? Houd rekening met de impact op landgebruik (of zeegebruik) als hiervoor
+      gewassen geteeld moeten worden.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 62
-  image:
+  image: 
   created_at: !ruby/object:ActiveSupport::TimeWithZone
     utc: 2012-08-07 13:13:57.000000000 Z
     zone: *1
@@ -980,14 +1464,22 @@
     zone: *1
     time: 2011-03-10 07:04:33.000000000 Z
   general_sub_header: share
-  group_sub_header:
-  subheader_image:
+  group_sub_header: 
+  subheader_image: 
   key: supply_transport_gasoline
-  position:
-  sidebar_item_id:
-  output_element_id:
-  alt_output_element_id:
-  dependent_on:
+  position: 
+  sidebar_item_id: 
+  output_element_id: 
+  alt_output_element_id: 
+  dependent_on: 
+  description:
+    content_en: How much of the gasoline used will come from renewable sources? Do
+      not forget that currently, growing the required crops competes with food production
+      for arable land.
+    content_nl: 'Hoeveel van de gebruikte benzine komt van hernieuwbare bronnen? Vergeet
+      niet dat het telen van gewassen hiervoor deels ten koste gaat van voedselproductie. '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 63
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1000,13 +1492,21 @@
     time: 2011-03-10 07:04:33.000000000 Z
   general_sub_header: share
   group_sub_header: ''
-  subheader_image:
+  subheader_image: 
   key: supply_transport_compressed_gas
-  position:
-  sidebar_item_id:
-  output_element_id:
-  alt_output_element_id:
-  dependent_on:
+  position: 
+  sidebar_item_id: 
+  output_element_id: 
+  alt_output_element_id: 
+  dependent_on: 
+  description:
+    content_en: How much of the compressed gas (CNG) used in transport will come from
+      renewable sources? Does your country have enough bio-resources?
+    content_nl: Hoeveel van het hogedruk gas (CNG) dat als transportbrandstof gebruikt
+      wordt, komt van hernieuwbare bronnen? Heeft jouw land wel genoeg biologische
+      bronnen?
+    short_content_en: ''
+    short_content_nl: ''
 - id: 99
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1025,7 +1525,12 @@
   sidebar_item_id: 21
   output_element_id: 133
   alt_output_element_id: 40
-  dependent_on:
+  dependent_on: 
+  description:
+    content_en: By how much are electricity costs allowed to change in the future?
+    content_nl: 'Hoeveel mogen de kosten voor elektriciteit veranderen in de toekomst? '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 102
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1041,10 +1546,19 @@
   subheader_image: ''
   key: demand_other_combined_heat_power
   position: 2
-  sidebar_item_id:
+  sidebar_item_id: 
   output_element_id: 63
   alt_output_element_id: 63
   dependent_on: ''
+  description:
+    content_en: 'How many combined heat and power (CHP) units will be used in the
+      service and government sectors? These generate heat and electricity locally,
+      which saves energy. '
+    content_nl: Hoeveel warmte-kracht koppelingen (WKK's) worden door de dienstensector
+      en overheid gebruikt? Deze maken warmte en elektriciteit op locatie en besparen
+      zo energie.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 103
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1063,7 +1577,37 @@
   sidebar_item_id: 28
   output_element_id: 61
   alt_output_element_id: 61
-  dependent_on:
+  dependent_on: 
+  description:
+    content_en: "The high voltage (HV) network is used for the long distance transport
+      of electricity, both within the country and for import and export. Large power
+      plants and large industrial users are connected to the HV network.\r\n\r\n<br/><br/>\r\n\r\nBuilding
+      new power plants requires investing in network capacity. These costs cannot
+      be avoided. The costs for the HV network are directly proportional to the generation
+      capacity built.\r\n\r\n<br/><br/>\r\n\r\nThere is no distinction between the
+      required investments for the different types of power plants, as this depends
+      on generation capacity. The only exception is offshore wind turbines for which
+      extra offshore cables are required.\r\n\r\n<br/><br/>\r\n\r\nFurthermore, significant
+      changes to the amount of electricity imported or exported will also incur network
+      investments since extra interconnectors are required.\r\n\r\n<br/><br/>\r\n\r\nIn
+      the chart you see the required network investments as a result of your choices
+      in the section ‘Supply’.\r\n"
+    content_nl: "Het hoogspanningsnet (HS-net) wordt gebruik om elektriciteit over
+      lange afstanden te transporteren, zowel binnen Nederland als voor import en
+      export. Grote centrales en grote industriële gebruikers zijn aangesloten op
+      het HS-net.\r\n\r\n<br/><br/>\r\n\r\nBij het bouwen van nieuwe centrales zijn
+      ook investeringen in het elektriciteitsnetwerk nodig. Deze kosten zijn onvermijdelijk
+      en zijn afhankelijk van de productiecapaciteit die je bouwt.\r\n\r\n<br/><br/>\r\n\r\nEr
+      is geen verschil tussen de nodige investering voor verschillende soorten centrales,
+      omdat deze enkel van de productiecapaciteit afhangen. De enige uitzondering
+      zijn windturbines op zee.  Daarvoor zijn extra investeringen nodig voor het
+      ‘stopcontact op zee.’\r\n\r\n<br/><br/>\r\n\r\nBij grote hoeveelheden import
+      of export brengt het ETM ook investeringen in rekening voor extra interconnectie
+      met het buitenland.\r\n\r\n<br/><br/>\r\n\r\nIn de grafiek zie je de benodigde
+      meerinvestering in de elektriciteitsinfrastructuur als gevolg van jouw keuzes
+      bij ‘Aanbod’."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 104
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1082,7 +1626,38 @@
   sidebar_item_id: 28
   output_element_id: 61
   alt_output_element_id: 61
-  dependent_on:
+  dependent_on: 
+  description:
+    content_en: "Households, buildings, agricultural users, and small industrial users,
+      are attached to the low voltage (LV) and medium voltage (MV) networks. \r\n\r\n
+      <br/><br/>\r\n\r\nThese electricity networks consist of cables (to distribute
+      electricity to the various users) and transformers (to transform the voltage
+      from high to low). Both cables and transformers can only handle a limited amount
+      of capacity.\r\n\r\n<br/><br/>\r\n\r\nThe required capacity in the networks
+      is determined by the number of users and the appliances used by those users.
+      Technologies such as electric vehicles and electric heaters or heat pumps in
+      particular significantly increase the required capacity. \r\n\r\n<br/><br/>\r\n\r\nIf
+      the required network capacity exceeds the available capacity network infrastructure
+      investments  will be required to add new cables and transformers. It is in particular
+      desirable to avoid investments in the LV network since these incur the largest
+      costs due to the necessity to open up streets to place new cables.\r\n\r\n<br/><br/>\r\n\r\nIn
+      the chart you see the required network investments as a result of your choices
+      in the section ‘Demand’."
+    content_nl: "Huishoudens, gebouwen, tuinbouw, en kleine industriële gebruikers
+      zijn aangesloten op het laag- en middenspanningsnetwerk (LS en MS).\r\n\r\n<br/><br/>\r\n\r\nDeze
+      elektriciteitsnetwerken bestaan uit kabels (om elektriciteit te distribueren
+      over de gebruikers) en transformatoren (om van hoog- naar laagspanning te gaan).
+      Zowel de kabels als de transformatoren hebben een beperkte capaciteit.\r\n\r\n<br/><br/>\r\n\r\nDe
+      nodige netwerkcapaciteit wordt bepaald door het aantal aangesloten gebruikers
+      en de aangesloten apparaten. Technologieën als elektrische voertuigen, elektrische
+      kachels, en warmtepompen in het bijzonder hebben veel capaciteit nodig.\r\n\r\n<br/><br/>\r\n\r\nAls
+      de nodige capaciteit hoger uitkomt dan de beschikbare capaciteit, zijn investeringen
+      nodig. Het is wenselijk om investeringen in het LS netwerk te vermijden omdat
+      deze het duurst zijn. Hiervoor moeten namelijk de straten worden opengebroken.\r\n\r\n<br/><br/>\r\n\r\nIn
+      de grafiek zie je de benodigde meerinvestering in de elektriciteitsinfrastructuur
+      als gevolg van jouw keuzes bij ‘Vraag’. "
+    short_content_en: ''
+    short_content_nl: ''
 - id: 105
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1094,14 +1669,22 @@
     zone: *1
     time: 2011-03-10 07:04:33.000000000 Z
   general_sub_header: change
-  group_sub_header:
-  subheader_image:
+  group_sub_header: 
+  subheader_image: 
   key: hidden_infrastructure_gas_network
-  position:
-  sidebar_item_id:
-  output_element_id:
-  alt_output_element_id:
-  dependent_on:
+  position: 
+  sidebar_item_id: 
+  output_element_id: 
+  alt_output_element_id: 
+  dependent_on: 
+  description:
+    content_en: The model does not yet take costs for extra gas infrastrucure into
+      account. Such costs could result from plans to use lots of green gas.
+    content_nl: Het model neemt nog geen extra kosten mee voor het gasnetwerk die
+      het gevolg zouden kunnen zijn van de keuze om op grote schaal groengas in te
+      zetten, bijvoorbeeld.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 108
   image: house_heating.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1121,6 +1704,13 @@
   output_element_id: 66
   alt_output_element_id: 66
   dependent_on: ''
+  description:
+    content_en: 'How will households be cooled? Some of the same technologies as listed
+      under ''Space Heating'' can be used here. '
+    content_nl: Hoe worden woningen gekoeld? Hiervoor kunnen voor een deel dezelfde
+      apparaten worden gebruikt als voor verwarming.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 109
   image: house_heating.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1140,6 +1730,11 @@
   output_element_id: 67
   alt_output_element_id: 67
   dependent_on: ''
+  description:
+    content_en: 'Will energy use change much if households change the way they cook? '
+    content_nl: Zal de energievraag veel veranderen als huishoudens anders gaan koken?
+    short_content_en: ''
+    short_content_nl: ''
 - id: 110
   image: house_heating.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1159,6 +1754,13 @@
   output_element_id: 213
   alt_output_element_id: 213
   dependent_on: ''
+  description:
+    content_en: Will changing our behavior make a big difference for household energy
+      consumption?
+    content_nl: 'Hoeveel verandert de huishoudelijke energievraag als we ons gedrag
+      aanpassen?  '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 113
   image: building_uncapped.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1178,6 +1780,15 @@
   output_element_id: 68
   alt_output_element_id: 68
   dependent_on: ''
+  description:
+    content_en: 'The changes in energy use per building you indicate here are due
+      to changes in prosperity. This is <strong>excluding</strong> efficiencies and
+      technological changes you can indicate in the subsections below.  '
+    content_nl: De veranderingen in energiegebruik per gebouw die je hier aangeeft
+      zijn het gevolg van welvaartsgroei. Dit is dus <strong>exclusief</strong> efficiëntieverbeteringen
+      en andere technologieën die je in de gedeeltes hieronder kunt aangeven.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 114
   image: building_insulation.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1197,6 +1808,15 @@
   output_element_id: 68
   alt_output_element_id: 69
   dependent_on: ''
+  description:
+    content_en: The insulation of buildings such as offices, schools, shops, hospitals,
+      and hotels tends to be quite different. What is the average heat demand reduction
+      for these buildings in the future?
+    content_nl: De isolatie van gebouwen zoals kantoren, scholen, winkels, ziekenhuizen
+      en horeca verschilt sterk. Wat is de gemiddelde warmtevraag-reductie voor deze
+      gebouwen in de toekomst?
+    short_content_en: ''
+    short_content_nl: ''
 - id: 115
   image: building_heating_uncapped.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1208,14 +1828,22 @@
     zone: *1
     time: 2012-06-28 15:55:16.000000000 Z
   general_sub_header: share
-  group_sub_header:
-  subheader_image:
+  group_sub_header: 
+  subheader_image: 
   key: demand_buildings_heating
   position: 3
   sidebar_item_id: 2
   output_element_id: 70
   alt_output_element_id: 70
-  dependent_on:
+  dependent_on: 
+  description:
+    content_en: How will offices and other buildings be heated? European countries
+      can save a lot of energy by being smarter about how buildings are heated.
+    content_nl: Hoe zullen kantoren en overige gebouwen verwarmd worden? In de meeste
+      Europese landen kan veel energie bespaard worden door gebouwen op een slimmere
+      manier te verwarmen.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 116
   image: building_cooling_uncapped.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1234,7 +1862,12 @@
   sidebar_item_id: 2
   output_element_id: 71
   alt_output_element_id: 71
-  dependent_on:
+  dependent_on: 
+  description:
+    content_en: How will offices and other buildings be cooled in the future?
+    content_nl: 'Hoe worden kantoren en andere gebouwen in de toekomst gekoeld? '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 117
   image: building_ventilation_uncapped.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1250,10 +1883,17 @@
   subheader_image: ''
   key: demand_buildings_ventilation
   position: 6
-  sidebar_item_id:
+  sidebar_item_id: 
   output_element_id: 68
   alt_output_element_id: 68
   dependent_on: ''
+  description:
+    content_en: Ventilation of well-insulated spaces is essential to people's health.
+      It also causes a loss of precious heat.
+    content_nl: Ventilatie van goed geïsoleerde ruimtes is nodig voor ieders gezondheid.
+      Ventilatie zorgt alleen ook voor warmteverlies.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 118
   image: building_appliances_uncapped.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1272,7 +1912,14 @@
   sidebar_item_id: 2
   output_element_id: 72
   alt_output_element_id: 72
-  dependent_on:
+  dependent_on: 
+  description:
+    content_en: There is ample room for improvement of appliances. Computers, monitors
+      and the like are becoming more efficient. Do you know by how much?
+    content_nl: Er kan nog veel verbeterd worden aan apparaten in kantoren. Computers,
+      monitoren en dergelijke worden steeds zuiniger. Weet jij hoeveel?
+    short_content_en: ''
+    short_content_nl: ''
 - id: 119
   image: building_lighting_uncapped.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1291,7 +1938,15 @@
   sidebar_item_id: 2
   output_element_id: 72
   alt_output_element_id: 72
-  dependent_on:
+  dependent_on: 
+  description:
+    content_en: 'Whereas lighting is a small part of household energy consumption,
+      in offices and other buildings it is quite significant. '
+    content_nl: Hoewel maar een klein deel van het energiegebruik van huishoudens
+      naar verlichting gaat, is het een flink deel van het gebruik in kantoren en
+      overige gebouwen.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 121
   image: building_decentral_uncapped.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1310,7 +1965,14 @@
   sidebar_item_id: 2
   output_element_id: 74
   alt_output_element_id: 74
-  dependent_on:
+  dependent_on: 
+  description:
+    content_en: Generating electricity locally saves energy and maybe also money in
+      the future.
+    content_nl: Het lokaal opwekken van stroom bespaart energie en in de toekomst
+      mogelijk ook geld.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 122
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1330,6 +1992,19 @@
   output_element_id: 42
   alt_output_element_id: 42
   dependent_on: ''
+  description:
+    content_en: Solar water heaters are a relatively cheap and reliable source of
+      heat. The amount of solar heat in your scenario depends on the choices you make
+      in the <a href="/scenario/demand/households/solar-panels">'solar panels' section
+      in households</a> ('solar thermal collectors') and the <a href="/scenario/demand/buildings/space-heating">'space
+      heating' section in buildings</a>.
+    content_nl: Zonneboilers zijn een relatief goedkope en betrouwbare bron van warmte.
+      De hoeveelheid zonnewarmte in jouw scenario hangt af van je keuzes in de <a
+      href="/scenario/demand/households/solar-panels">zonnepanelensectie van huishoudens</a>
+      ('zonthermische collectoren') en de <a href="/scenario/demand/buildings/space-heating">ruimteverwarmingssectie
+      van gebouwen</a>.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 123
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1347,8 +2022,17 @@
   position: 9
   sidebar_item_id: 51
   output_element_id: 205
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: How much of the aviation fuel used will come from renewable sources?
+      Do not forget that currently, growing the required crops competes with food
+      production for arable land.
+    content_nl: 'Hoeveel van het gebruikte vliegtuigbrandstof komt van hernieuwbare
+      bronnen? Vergeet niet dat het telen van gewassen hiervoor deels ten koste gaat
+      van voedselproductie. '
+    short_content_en: ''
+    short_content_nl: ''
 - id: 124
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1368,6 +2052,20 @@
   output_element_id: 43
   alt_output_element_id: 43
   dependent_on: ''
+  description:
+    content_en: Which fuels will power your ships? Keep in mind that ships with diesel
+      / dual fuel engines can run on a variety of fuels, and that your choice here
+      is the average fuel mix of a ship with that engine. In the <a href="/scenario/demand/transport_freight_transport/domestic-navigation-technology"
+      >domestic navigation section</a> you can select the engines your inland vessels
+      will be equiped with.
+    content_nl: Welke brandstoffen zullen jouw binnenvaartschepen gebruiken? Vergeet
+      niet dat schepen met diesel / dual fuel motoren op verschillende brandstoffen
+      kunnen varen, en dat jouw keuze hier de gemiddelde brandstofmix voor een schip
+      met deze motor weerspiegelt. In de <a href="/scenario/demand/transport_freight_transport/domestic-navigation-technology"
+      >binnenvaartsectie</a> kun je kiezen met welke motoren jouw binnenvaartschepen
+      uitgerust zijn.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 125
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1385,8 +2083,20 @@
   position: 3
   sidebar_item_id: 51
   output_element_id: 206
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: Which train technologies will be mostly used? Electric trains are
+      cleaner and more efficient than diesel or coal-powered ones, but require more
+      infrastructure to run. In the <a href="/scenario/supply/transport_fuels/rail-transport"
+      >train fuels section</a> you can determine which fuels diesel trains will use.
+    content_nl: Welke trein-technologiën zullen voornamelijk gebruikt worden? Elektrische
+      treinen zijn schoner en efficiënter dan kolen- of dieseltreinen, maar hebben
+      wel meer infrastructuur nodig om te kunnen rijden. In de <a href="/scenario/supply/transport_fuels/rail-transport"
+      > brandstoffensectie van treinen</a> kun je aangeven welke brandstoffen dieseltreinen
+      zullen gebruiken.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 131
   image: car.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1398,14 +2108,14 @@
     zone: *1
     time: 2011-03-10 07:04:34.000000000 Z
   general_sub_header: number
-  group_sub_header:
-  subheader_image:
+  group_sub_header: 
+  subheader_image: 
   key: supply_transport_public_transport_technologies
-  position:
-  sidebar_item_id:
-  output_element_id:
-  alt_output_element_id:
-  dependent_on:
+  position: 
+  sidebar_item_id: 
+  output_element_id: 
+  alt_output_element_id: 
+  dependent_on: 
 - id: 140
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1425,6 +2135,24 @@
   output_element_id: 242
   alt_output_element_id: 99
   dependent_on: ''
+  description:
+    content_en: "The fuel mix of your coal plants can be made greener by using biomass
+      alternatives. Here, you can choose the relative share of coal and biocoal. Currently,
+      only the pulverized coal plant and the coal plant for district heat can use
+      wood pellets. You can build co-firing versions of these plants in the <a href=\"/scenario/supply/electricity/coal-plants\"
+      >coal plant section</a>.\r\n<br><br>\r\nAdditionally, the fuel mix for industrial
+      gas-fired CHPs (mainly in the refinery sector) can be made greener by co-firing
+      bio-oil."
+    content_nl: "De brandstofmix van kolencentrales kan groener door biomassa in te
+      zetten.\r\nHier kun je de verhouding van kolen en biokolen kiezen. Vooralsnog
+      kunnen alleen de poederkolen centrale en de kolencentrale met warmtelevering
+      houtpellets gebruiken. In de \r\n<a href=\"/scenario/supply/electricity/coal-plants\"
+      >kolencentrale sectie</a> van het model kun je meestook varianten van deze centrales
+      inzetten.\r\n<br><br>  \r\nDaarbij kan de brandstofmix van industriële gasgestookte
+      WKK's (m.n. bij raffinaderijen) groener gemaakt worden door bio-olie bij te
+      stoken."
+    short_content_en: ''
+    short_content_nl: ''
 - id: 143
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1444,6 +2172,22 @@
   output_element_id: 100
   alt_output_element_id: 100
   dependent_on: ''
+  description:
+    content_en: "Coal is used worldwide as a fuel. It is readily available and therefore
+      a secure and cheap source of energy for generations to come. However, it does
+      produce more CO<sub>2</sub> than other fuels, and without proper management
+      its production and utilization brings additional negative environmental and
+      health impacts not associated with other fossil fuels. \r\n\r\n<a href=\"/texts/fce_coal\"
+      class=\"fancybox\">read more</a>"
+    content_nl: Kolen worden overal in de wereld gebruikt en zijn ruim voorradig.
+      Ze zijn dus een veilige en goedkope bron van energie voor de komende generaties.
+      Er komt wel meer CO<sub>2</sub> vrij bij het verbranden van kolen dan bij  alle
+      andere brandstoffen. Daarnaast is er bij kolen, bij gebrek aan zorgvuldig beleid
+      voor productie en gebruik, een risico op verdere negatieve gevolgen voor het
+      milieu en de volksgezondheid, wat bij andere fossiele brandstoffen niet speelt.
+      <a href="/texts/fce_coal" class="fancybox">lees verder</a>
+    short_content_en: ''
+    short_content_nl: ''
 - id: 144
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1463,6 +2207,29 @@
   output_element_id: 100
   alt_output_element_id: 100
   dependent_on: ''
+  description:
+    content_en: "Natural gas is a burning fossil fuel, of which global reserves are
+      increasing. A relatively low carbon content and efficiency in power production
+      result in CO<sub>2</sub> emissions per kWhe that are half as large as for coal-based
+      power production. Pre-treatment of raw natural gas comes on the opposite with
+      negative impact on the local environment in some producing countries. Natural
+      gas mostly consists of methane, which is a powerful greenhouse gas in itself.
+      Natural gas can be exported through pipelines as a gas, or by ships when liquefied.
+      Keep in mind that liquefaction changes the composition and therefore the attributes
+      of natural gas, because some components are removed. <a href=\"/texts/fce_naturalgas\"
+      class=\"fancybox\">read more</a>\r\n<br/>"
+    content_nl: "Aardgas is een fossiele brandstof waarvan steeds meer reserves beschikbaar
+      komen. Doordat aardgas relatief weinig koolstof bevat en de productie efficiënt
+      is, stoten gascentrales half zoveel CO<sub>2</sub> uit per kWhe als kolencentrales.
+      Bij het zuiveren van ruw aardgas treedt lokaal wel milieuvervuiling op in enkele
+      producerende landen. Aardgas bestaat voornamelijk uit methaan, wat zelf een
+      sterk broeikasgas is. Na extractie kan aardgas getransporteerd worden via pijpleidingen
+      of door schepen, in het laatste geval in vloeibare vorm. Merk op dat tijdens
+      het vloeibaar maken van aardgas de samenstelling ervan verandert en daardoor
+      de eigenschappen, omdat sommige componenten verwijderd worden. <a href=\"/texts/fce_naturalgas\"
+      class=\"fancybox\">lees verder</a>\r\n<br/> \r\n\r\n"
+    short_content_en: ''
+    short_content_nl: ''
 - id: 145
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1482,6 +2249,23 @@
   output_element_id: 100
   alt_output_element_id: 100
   dependent_on: ''
+  description:
+    content_en: "Mineral oil is the source of many energy carriers, chemicals, plastics,
+      fertilizer, etc. The numbers shown here are for crude oil itself. Emissions
+      for refining or processing to obtain chemicals have not been included. <br/>\r\nThe
+      oil market is more dynamic than that for natural gas, for example. The mix of
+      origins is therefore not as clearly determined as for gas and can vary faster.
+      For this reason, we have not included any sliders here. <a href=\"/texts/fce_oil\"
+      class=\"fancybox\">read more</a>"
+    content_nl: "Aardolie is de bron van veel verschillende energiedragers, chemicaliën,
+      plastics, kunstmest, etc. De getallen die hier zijn opgenomen gaan over het
+      gebruik van aardolie zelf. Uitstoot door raffinage of verwerking tot chemicaliën
+      is niet meegenomen. <br/>\r\nDe oliemarkt is dynamischer dan bijvoorbeeld de
+      gasmarkt. De herkomst ligt daardoor over minder lange periodes vast dan voor
+      aardgas en kan meer variëren. Daarom zijn hier geen schuifjes opgenomen. <a
+      href=\"/texts/fce_oil\" class=\"fancybox\">lees verder</a>"
+    short_content_en: 
+    short_content_nl: 
 - id: 146
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1501,6 +2285,21 @@
   output_element_id: 105
   alt_output_element_id: 105
   dependent_on: ''
+  description:
+    content_en: 'Nuclear energy is a low-carbon technology: nuclear power plants do
+      not emit CO<sub>2</sub>, but uranium mining, processing and transportation is
+      associated with some CO<sub>2</sub> emissions. This low-carbon technology comes
+      at a price though: there is a small risk of severe nuclear accidents and no
+      long-term solution has yet been found for the high-level radioactive waste.
+      <a href="/texts/fce_uranium" class="fancybox">read more</a>'
+    content_nl: 'Kernenergie levert weinig CO<sub>2</sub> uitstoot op. Bij het winnen,
+      verwerken en transporteren van uranium wordt wel wat CO<sub>2</sub> uitgestoten.
+      Er wordt wel een prijs betaald voor deze lage uitstoot: de kans op ernstige
+      ongelukken - ook al is die klein - en het ontbreken van een langetermijnoplossing
+      voor het hoogradioactieve afval. <a href="/texts/fce_uranium" class="fancybox">lees
+      verder</a>'
+    short_content_en: ''
+    short_content_nl: ''
 - id: 147
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1520,6 +2319,23 @@
   output_element_id: 107
   alt_output_element_id: 107
   dependent_on: ''
+  description:
+    content_en: Wood pellets can be co-fired in coal-fired power plants. Although
+      no fossil CO<sub>2</sub> is emitted when wood is converted into electricity,
+      greenhouse gases are emitted in earlier steps in the fuel chain, especially
+      in the production and transport of wood. It is important to note that pellet
+      production should not cause deforestation or other types of degradation of natural
+      areas in order to have a positive impact on the climate at all. <a href="/texts/fce_biomass"
+      class="fancybox">read more</a>
+    content_nl: Houtpellets kunnen worden bijgestookt in kolencentrales.  Hoewel er
+      bij de omzetting naar elektriciteit geen fossiele CO<sub>2</sub> vrijkomt, worden
+      er in eerdere stappen in de brandstofketen wel broeikasgassen uitgestoten, vooral
+      bij de teelt en het transport van hout. Merk op dat het gebruik van houtpellets
+      niet moet leiden tot ontbossing of degradatie van natuurlijke gebieden, wil
+      bijstook überhaupt een positieve impact op het klimaat hebben. <a href="/texts/fce_biomass"
+      class="fancybox">lees verder</a>
+    short_content_en: ''
+    short_content_nl: ''
 - id: 148
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1539,6 +2355,24 @@
   output_element_id: 107
   alt_output_element_id: 107
   dependent_on: ''
+  description:
+    content_en: Green gas is treated biogas, which is produced from biomass. The biogas
+      has been purified and enriched to have the same properties as natural gas, so
+      it can be added to the gas grid. For the ETM, green gas production from co-digestion
+      of maize silage and manure is assumed. Green gas has far lower chain emissions
+      than fossil fuels, but is not completely climate neutral. Greenhouse gas emissions
+      occur during maize cultivation and during biogas production and treatment. <a
+      href="/texts/fce_greengas" class="fancybox">read more</a>
+    content_nl: Groengas is behandeld biogas, wat wordt geproduceerd uit biomassa.
+      Het biogas is gezuiverd en verrijkt om dezelfde kwaliteiten als aardgas te hebben.
+      Het kan dan toegevoegd worden aan het gasnetwerk. Voor het ETM wordt uitgegaan
+      van groengasproductie op basis van co-vergisting van snijmaïs en mest. Groengas
+      heeft veel lagere ketenemissies dan fossiele brandstoffen, maar is niet compleet
+      klimaatneutraal. Broeikasgasemissies vinden plaats bij het telen van snijmaïs
+      en tijdens het produceren en behandelen van biogas. <a href="/texts/fce_greengas"
+      class="fancybox">lees verder</a>
+    short_content_en: ''
+    short_content_nl: ''
 - id: 151
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1554,10 +2388,47 @@
   subheader_image: ''
   key: supply_electricity_backup_backup_options
   position: 2
-  sidebar_item_id:
+  sidebar_item_id: 
   output_element_id: 115
   alt_output_element_id: 115
   dependent_on: ''
+  description:
+    content_en: "Electricity production from wind and solar is not always available
+      and therefore some form of electricity backup is required to ensure security
+      of supply. \r\n<br/><br/>\r\nThe chart at the right shows the costs and emissions
+      associated with backup of volatile power production. These costs are incurred
+      <i>on top of</i> the power production costs of volatile technologies. For example:
+      A 3 MW wind turbine will produce 6 - 10 GWh of electricity per year at a certain
+      cost. On top of this about 0.6 - 1.5 MW backup capacity is required. This is
+      not free of charge. During times of low wind, CO<sub>2</sub> emitting backup
+      capacity will come online to produce electricity at a certain cost. \r\n<br/><br/>\r\nBackup
+      options need to deal with short term fluctuations in wind and solar output.
+      This means they operate at a less than optimal efficiency. This contributes
+      to small increases in emissions and electricity production costs when compared
+      to operating at maximum efficiency. Increasing the share of volatile electricity
+      increases the fluctuations and in turn the backup requirements.\r\n<br/><br/>\r\nPicking
+      a clean and cheap backup option to work together with the wind turbines and
+      solar panels in your scenario is desirable.\r\n<br/><br/>\r\nMore information
+      can be found in our <a href=\"https://github.com/quintel/documentation/blob/master/general/electricity_backup.md\"
+      target =\"_blank\">documentation</a>."
+    content_nl: "Je kunt niet altijd rekenen op stroom van windmolens of zonnepanelen
+      en daarom is backup vermogen nodig om de leveringszekerheid te garanderen. \r\n<br/><br/>\r\nDe
+      grafiek rechts toont de kosten en uitstoot van backupopties voor volatiele stroomopwek.
+      Deze kosten komen <i>bovenop</i> de productiekosten van deze technologieën.
+      Bijvoorbeeld: Een 3 MW windmolen produceert per jaar 6 - 10 GWh aan stroom tegen
+      bepaalde kosten. Daarbij is 0,6 - 1,5 GW aan backupvermogen nodig die niet gratis
+      is. Als er weinig wind is, gaat deze backup optie draaien met bijbehorende CO<sub>2</sub>
+      uitstoot en kosten.\r\n<br/><br/>\r\nDe backup centrales moeten omgaan met korte
+      termijn fluctuaties in de productie van wind en zon. Daardoor zijn ze minder
+      efficiënt. Dat betekent weer dat de kosten en uitstoot ook iets hoger zijn dan
+      bij optimale efficiëntie. Door meer volatiele technieken in te zetten, nemen
+      de fluctuaties toe en dus ook de vraag naar backup.\r\n<br/><br/> \r\nHet is
+      aan te raden om een schone en goedkope backup optie te bouwen naast het zon-
+      en windvermogen in jouw scenario.\r\n<br/><br/> \r\nMeer informatie kunt u:
+      <a href=\"https://github.com/quintel/documentation/blob/master/general/electricity_backup.md\"
+      target =\"_blank\">hier</a> vinden.\r\n"
+    short_content_en: 
+    short_content_nl: 
 - id: 152
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1577,6 +2448,49 @@
   output_element_id: 172
   alt_output_element_id: 125
   dependent_on: ''
+  description:
+    content_en: "Will there be sufficient power supply in the future to meet demand
+      at any moment? For example, is your scenario robust for extended periods of
+      low wind and solar generation combined with demand peaks? Renewable power production
+      presents challenges for the security of supply.\r\n<br /><br />\r\nThe chart
+      to the right shows how reliable power supply is for every hour per year in your
+      scenario. In the dashboard below you can see the number of (expected) blackout
+      hours due to a lack of power supply.\r\n<br /><br />\r\nProduction technologies
+      vary in their ability to supply electricity during demand peaks. Batteries and
+      other forms of storage have fast reaction times but require charging and are
+      less suited to bridge long gaps in solar and wind production. Dispatchable power
+      plants can supply power at any time but some of them require many operating
+      hours per year to cover their costs or are too expensive to turn on and off
+      repeatedly.\r\n<br /><br />\r\n(Renewable) gas turbines and engines using green
+      gas or hydrogen are promising technologies to provide back-up capacity for a
+      future energy system relying on wind and solar power. This is due to their fast
+      ramping speeds and relatively low investment costs.\r\n<br /><br />\r\n<strong>Tip:</strong>
+      Take a look at the <a href=\"/scenario/flexibility/flexibility_weather/extreme-weather-conditions\">Weather
+      conditions</a> section to explore how variations in outdoor temperature, wind
+      speeds and solar radiation impact your scenario. Is your scenario able to cope
+      with extreme weather conditions? Will people be left in the dark during periods
+      of very low wind and solar generation?"
+    content_nl: "Is er in de toekomst op ieder moment voldoende elektriciteit om aan
+      de vraag te voldoen? Hoe zit het met momenten waarop de vraag piekt en er weinig
+      productie uit zon en wind is? Elektriciteitsproductie zonder CO<sub>2</sub>-uitstoot
+      levert uitdagingen op voor de voorzieningszekerheid.\r\n<br /><br />\r\nIn de
+      grafiek zie je hoe betrouwbaar de stroomproductie is in jouw scenario. In het
+      dashboard rechtsonderaan zie je hoeveel uur stroomuitval er te verwachten is
+      door een tekort aan productievermogen.\r\n<br /><br />\r\nNiet alle leveringsopties
+      zijn even goed geschikt om de piekvraag in te vullen. Batterijen en andere vormen
+      van opslag kunnen snel reageren, maar moeten wel volgeladen zijn en kunnen geen
+      lange periodes zonder zon en wind overbruggen. Schakelbare elektriciteitscentrales
+      kunnen ieder moment leveren, maar sommigen moeten veel vollasturen draaien om
+      winstgevend te zijn of maken te hoge kosten als ze vaak aan- of uitschakelen.\r\n<br
+      /><br />\r\nVooral gasturbines en gasmotoren voor de productie van stroom (en
+      eventueel ook warmte) op groengas of waterstof zijn een voor de hand liggende
+      duurzame optie als back-up voor wind- en zonnestroom.\r\n<br /><br />\r\n<strong>Tip:</strong>
+      Op de pagina\r\n<a href=\"/scenario/flexibility/flexibility_weather/extreme-weather-conditions\">Weersomstandigheden</a>
+      kun je verschillende weerjaren inladen, om te zien hoe je scenario verandert.
+      Is jouw scenario bestand tegen extreme weersomstandigheden? Gaat het licht uit
+      als het een paar weken niet waait?"
+    short_content_en: 
+    short_content_nl: 
 - id: 153
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1596,6 +2510,45 @@
   output_element_id: 172
   alt_output_element_id: 172
   dependent_on: ''
+  description:
+    content_en: "Generally speaking, electricity generation follows electricity demand.
+      The order in which power plants are dispatched is determined by the merit order.
+      The merit order ranks power plants according to their marginal costs. Those
+      with the lowest marginal costs are dispatched first to meet demand; those with
+      higher costs only when demand is high enough. Power plants with low operating
+      costs therefore have a high number of operating hours while expensive ones may
+      operate as little as a few hundred hours per year. This can play a large role
+      in the total CO<sub>2</sub> emissions of your scenario.\r\n<br/><br/>\r\nBy
+      default the ETM calculates which power plants have to be dispatched for each
+      hour in the year. This calculation is performed every time you make changes
+      to your scenario. You can choose to switch the merit order calculation off;
+      when switched off, all power plants will have the same full load hours in the
+      future as in the present year of your scenario and these will not respond to
+      your assumptions on fuel or other costs. \r\n<br/><br/>\r\nThe merit order calculation
+      in the ETM is simplified as it does not distinguish or rank individual plants,
+      but only <strong>types</strong> of plants. For more information about the merit
+      order calculation <a href=\"https://github.com/quintel/documentation/blob/master/general/merit_order.md\"
+      target =\"_blank\">consult our documentation</a>."
+    content_nl: "Over het algemeen volgt de elektriciteitsproductie de vraag naar
+      elektriciteit. De volgorde waarin elektriciteitscentrales worden ingeschakeld
+      wordt bepaald door de 'merit order'. De merit order rangschikt de elektriciteitscentrales
+      naar draaikosten (ook wel 'marginale kosten'). De centrales met de laagste draaikosten
+      zet men het eerste in om de vraag in te vullen; de centrales met hogere kosten
+      pas als de vraag hoog genoeg is. Centrales met relatief lage draaikosten maken
+      dan ook veel draaiuren, terwijl duurdere centrales misschien maar een paar honderd
+      uur aan staan. Dit kan veel verschil maken voor de CO<sub>2</sub> uitstoot in
+      jouw scenario. \r\n<br/><br/>\r\nStandaard rekent het ETM op uurbasis uit welke
+      elektriciteitscentrales moeten worden ingeschakeld. De berekening wordt elke
+      keer dat je je scenario aanpast opnieuw uitgevoerd. Je kunt er voor kiezen om
+      de merit order berekening uit te zetten. Als je de berekening hebt uitgezet,
+      zullen alle elektriciteitscentrales dezelfde draaiuren hebben als in het startjaar
+      van je scenario en niet reageren op jouw aannames over brandstof- of andere
+      kosten.\r\n<br/><br/>\r\nHet ETM voert een versimpelde merit order berekening
+      uit, aangezien deze geen individuele centrales onderscheidt, maar alleen <strong>soorten</strong>
+      centrales.\r\n<br/><br/>\r\nBekijk voor meer informatie <a href=\"https://github.com/quintel/documentation/blob/master/general/merit_order.md\"
+      target =\"_blank\">onze documentatie</a>."
+    short_content_en: 
+    short_content_nl: 
 - id: 154
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1615,6 +2568,14 @@
   output_element_id: 118
   alt_output_element_id: 118
   dependent_on: _always_hidden
+  description:
+    content_en: "The ETM calculates impact on employment for technologies used to
+      supply heat and electricity. To do this, the ETM makes assumptions about the
+      production of these technologies. You can change these assumptions here.\r\n\r\n"
+    content_nl: "Het ETM berekent werkgelegenheidseffecten voor de technologieën waarmee
+      warmte en elektriciteit worden gemaakt.\r\n"
+    short_content_en: 
+    short_content_nl: 
 - id: 155
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1634,6 +2595,19 @@
   output_element_id: 43
   alt_output_element_id: 43
   dependent_on: ''
+  description:
+    content_en: How much of the fuel used by diesel trains will come from renewable
+      sources? Do not forget that the arable land used for growing the required crops
+      for biodiesel competes with food production. In the <a href="/scenario/demand/transport_passenger_transport/train-technology"
+      >passenger train section</a> and <a href="/scenario/demand/transport_freight_transport/train-technology"
+      >freight train section</a> you can specify your train technology.
+    content_nl: Hoeveel van de gebruikte brandstof voor dieseltreinen komt van hernieuwbare
+      bronnen? Vergeet niet dat het telen van gewassen hiervoor deels ten koste gaat
+      van voedselproductie. In de <a href="/scenario/demand/transport_passenger_transport/train-technology"
+      >technologie passagierstreinen</a> and <a href="/scenario/demand/transport_freight_transport/train-technology"
+      >technologie goederentreinen</a> kun je de treintechnologie specificeren.
+    short_content_en: ''
+    short_content_nl: ''
 - id: 156
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1653,6 +2627,22 @@
   output_element_id: 43
   alt_output_element_id: 43
   dependent_on: ''
+  description:
+    content_en: How much of the fuels used in road transport will come from renewable
+      sources? Do consider the impact on land (and sea) use for growing the required
+      crops. In the <a href="/scenario/demand/transport_passenger_transport/car-technology"
+      >car technology</a> and the <a href="/scenario/demand/transport_freight_transport/truck-technology"
+      >truck technology</a> section you can select the engine type of your cars and
+      trucks. Keep in mind that LNG is used by trucks, but not by cars.
+    content_nl: 'Hoeveel van de gebruikte brandstof voor het wegverkeer komt van hernieuwbare
+      bronnen? Houd rekening met de impact op landgebruik (of zeegebruik) als hiervoor
+      gewassen geteeld moeten worden. In de <a href="/scenario/demand/transport_passenger_transport/car-technology"
+      >autotechnologie-</a> en de <a href="/scenario/demand/transport_freight_transport/truck-technology"
+      >vrachtwagentechnologiesectie</a> kun je bepalen welk type motor auto''s en
+      vrachtwagens hebben. N.B.: vloeibaar aardgas wordt door vrachtwagens gebruikt,
+      maar niet door auto''s.'
+    short_content_en: ''
+    short_content_nl: ''
 - id: 157
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1672,6 +2662,14 @@
   output_element_id: 113
   alt_output_element_id: 113
   dependent_on: ''
+  description:
+    content_en: Below you can change the investment costs of heat pumps (both collective
+      and individual systems) and the costs for heat buffers in individual households.
+    content_nl: Hieronder kun je de investeringskosten aanpassen voor warmtepompen
+      (zowel individuele als collectieve systemen) en de kosten voor warmtebuffers
+      in individuele huishoudens.
+    short_content_en: 
+    short_content_nl: 
 - id: 158
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1691,6 +2689,29 @@
   output_element_id: 100
   alt_output_element_id: 100
   dependent_on: ''
+  description:
+    content_en: "<p>Greenhouse gasses are emitted when fuels are used, but also when
+      they are extracted, treated and transported to their final destination. In this
+      section,  you can choose to include these fuel chain emissions in the CO<sub>2</sub>
+      calculations.</p>\r\n<p>For each type of fuel you can choose where it comes
+      from. You will see that fuel chain emissions can vary strongly between regions
+      of origin. Even direct CO<sub>2</sub> emissions from combustion vary between
+      regions of origin, because coal from Eastern Europe is not the same as coal
+      from North America, for example. Your mix of origins will change CO<sub>2</sub>
+      emissions, regardless of whether 'FCE' is 'ON' or 'OFF'.</p>\r\n\r\n<div class=\"fce-toggle\"></div>"
+    content_nl: "<p>Broeikasgassen worden uitgestoten bij het gebruik van brandstoffen,
+      maar ook bij de extractie, bewerking en transport ervan. Deze ketenemissies
+      gebeuren vaak buiten de grenzen van het land dat de brandstoffen gebruikt. In
+      dit gedeelte van het model kun je kiezen of je wilt dat het model in de CO<sub>2</sub>
+      berekeningen ook de ketenemissies meeneemt.</p>\r\n<p>Hieronder kun je per brandstofsoort
+      de herkomstmix kiezen. Je zult zien dat de ketenemissies per herkomstregio sterk
+      kunnen veranderen. Ook de CO<sub>2</sub> emissies door directe verbranding veranderen
+      als je de mix aanpast, omdat bijvoorbeeld kolen uit Oost Europa een andere samenstelling
+      hebben dan die uit Noord-Amerika. De herkomstmix heeft dus invloed op de CO<sub>2</sub>
+      uitstoot, ongeacht of de ketenemissies 'AAN' of 'UIT' staan.</p>\r\n\r\n<div
+      class=\"fce-toggle\"></div>"
+    short_content_en: 
+    short_content_nl: 
 - id: 159
   image: industry.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1710,6 +2731,17 @@
   output_element_id: 136
   alt_output_element_id: 136
   dependent_on: ''
+  description:
+    content_en: Here you can indicate how you think industrial production volumes
+      might change. These are often the result of economic changes. These <strong>
+      do not include</strong> efficiency improvements</strong> or newer technologies
+      chosen in the sections below.
+    content_nl: "Hier kun je de verandering in het industrieel productievolume kiezen.
+      Dat is bijvoorbeeld het gevolg van economische veranderingen. Dit is dus <strong>exclusief</strong>
+      efficiëntieverbeteringen en nieuwere technologieën die je in de gedeeltes hieronder
+      kunt kiezen.\r\n"
+    short_content_en: 
+    short_content_nl: 
 - id: 160
   image: industry.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1729,6 +2761,17 @@
   output_element_id: 130
   alt_output_element_id: 130
   dependent_on: has_metal
+  description:
+    content_en: After steel production, aluminium production is the most energy intensive.
+      You can choose from three measures to reduce energy consumption. Note that the
+      smelt oven only recycles used aluminium. Here you can indicate what you think
+      will happen.
+    content_nl: "Aluminiumproductie is de meeste energie-intensieve metaalsector na
+      staal. Je kunt kiezen uit drie maatregelen om dit verbruik terug te dringen.
+      Let op: bij smeltoven komt er geen nieuw aluminium bij, dit is recycling van
+      bestaand aluminium. Geef aan hoe jij denkt dat de verdeling gaat worden.\r\n"
+    short_content_en: 
+    short_content_nl: 
 - id: 161
   image: industry.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1748,6 +2791,15 @@
   output_element_id: 131
   alt_output_element_id: 131
   dependent_on: ''
+  description:
+    content_en: This sector includes the production of lead, zinc, copper, silver
+      or gold and post-processing of produced steel and aluminium. You can indicate
+      efficiency changes for electric and heat processes in this sector.
+    content_nl: In deze sector valt de productie van lood, zink, koper, zilver of
+      goud en de nabewerking van geproduceerd staal en aluminium. Hier kun je de efficiëntieverbeteringen
+      aangeven van elektrische en van warmteprocessen voor deze sector.
+    short_content_en: 
+    short_content_nl: 
 - id: 162
   image: industry.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1767,6 +2819,19 @@
   output_element_id: 135
   alt_output_element_id: 135
   dependent_on: has_metal
+  description:
+    content_en: 'Steel processing requires energy-intensive furnaces. Several alternatives
+      are possible. The percentage of recycled steel that can be used as input varies
+      per technology: blast furnaces and cyclone furnaces use up to 20% recycled steel
+      and electric ovens are used for recycling only. The cyclone furnaces are unique
+      in the sense that they can run on 100% bio-fuel.'
+    content_nl: "Voor staalverwerking zijn energie-intensieve ovens nodig. Hiervoor
+      zijn verschillende alternatieven mogelijk. Het percentage gerecycled staal dat
+      als input kan dienen, verschilt per technologie: bij hoogovens en cycloonovens
+      kan tot 20% hergebruikt worden en de elektrische oven dient alleen voor recycling.
+      Alleen de cycloonoven kan volledig op biogrondstof overschakelen.\r\n"
+    short_content_en: 
+    short_content_nl: 
 - id: 163
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1786,6 +2851,37 @@
   output_element_id: 137
   alt_output_element_id: 57
   dependent_on: ''
+  description:
+    content_en: "Outdoor temperature and technical developments of wind and solar
+      technologies and have an effect on (hourly) demand and supply. Here you can
+      set the average temperature and full load hours of wind turbines and solar pv.\r\n<p>\r\nFurthermore,
+      the Netherlands have experienced extreme cold periods in the past, as well as
+      periods with little wind and sun. This may happen again in the future, and low
+      temperatures may negatively affect the ability for air and hybrid heat pumps
+      to satisfy demand. Besides that, a lack of wind and sun may negatively affect
+      the electricity production from wind and solar power. To explore these effects
+      for a scenario for (a region within) the Netherlands a year with extreme weather
+      conditions can be selected.\r\n</p>\r\nFor more information about weather conditions
+      consult our <a href=\"https://github.com/quintel/documentation/blob/master/general/weather_conditions.md\"
+      target =\"_blank\">documentation</a>.\r\n</p>\r\nDemand and production curves
+      can be downloaded in the <a href=\"/scenario/data/data_export/merit-order-prices\">results
+      section</a>."
+    content_nl: "Buitentemperatuur en technische ontwikkelingen van zon en wind technologie
+      hebben effect op (uurlijkse) vraag en aanbod. Stel hier gemiddelde temperatuur
+      en vollasturen van windturbines en zonnepanelen in.\r\n<p>\r\nDaarnaast zijn
+      er in het verleden uitzonderlijk koude periodes of periodes met uitzonderlijk
+      weinig wind en zon voorgekomen. Zulke periodes met extreme weersomstandigheden
+      kunnen in de toekomst weer voorkomen. De vraag is of de opgestelde warmte- en
+      elektriciteitstechnologieën dan voldoende vermogen zullen hebben om in de warmte-
+      en elektriciteitsvraag te voorzien. Om dat te verkennen kan voor een scenario
+      voor (een regio binnen) Nederland een jaar met extreme weersomstandigheden worden
+      geselecteerd.\r\n</p>\r\nKijk voor meer informatie over weeromstandigheden in
+      onze <a href=\"https://github.com/quintel/documentation/blob/master/general/weather_conditions.md\"
+      target =\"_blank\">documentatie</a>.\r\n</p>\r\nProductiecurves kunnen worden
+      gedownload in de <a href=\"/scenario/data/data_export/merit-order-prices\">resultaten
+      sectie</a>.\r\n\r\n\r\n"
+    short_content_en: 
+    short_content_nl: 
 - id: 164
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1805,6 +2901,25 @@
   output_element_id: 138
   alt_output_element_id: 138
   dependent_on: ''
+  description:
+    content_en: "The EU mandates a minimum percentage of liquid biofuels for road
+      transport. Such fuels are often produced more efficiently in tropical countries.
+      Is the entire fuel chain also more efficient in terms of greenhouse gas emissions?
+      The biomass from which the liquid biofuels are produced can be chosen under
+      <a href=\"/scenario/supply/biomass/supply_biomass_biofuels_production\">'Biomass'</a>
+      and influences the fuel chain emissions. How much biofuel is used can be chosen
+      under 'Transport fuels'\r\n\r\n<a href=\"/texts/fce_liquid_biofuels\" class=\"fancybox\">read
+      more</a>"
+    content_nl: "De EU heeft bepaald dat een minimum percentage vloeibare biobrandstoffen
+      worden bijgemengd in de brandstoffen voor wegtransport. Zulke brandstoffen kunnen
+      vaak efficiënter gemaakt worden in tropische landen. Is de hele keten ook efficiënter
+      vanuit het oogpunt van broeikasgasemissies? Onder het kopje <a href=\"/scenario/supply/biomass/supply_biomass_biofuels_production\">'Biomassa'</a>
+      kun je kiezen van welke biomassa de biobrandstoffen gemaakt worden en dit heeft
+      invloed op de ketenemissies. Hoeveel biobrandstoffen worden ingezet kies je
+      onder 'Transport brandstoffen'\r\n\r\n<a href=\"/texts/fce_liquid_biofuels\"
+      class=\"fancybox\">lees verder</a>"
+    short_content_en: 
+    short_content_nl: 
 - id: 165
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1824,6 +2939,39 @@
   output_element_id: 143
   alt_output_element_id: 143
   dependent_on: _always_hidden
+  description:
+    content_en: "This page is about excess electricity and what to do with it. Wind
+      turbines and solar panels are subject to volatile natural patterns. Their electricity
+      supply does not match  demand and large amounts of volatile production capacity
+      will therefore lead to excess electricity. \r\n<br/><br/>\r\nThe ETM exports
+      this excess, but this may not be an option, since our neighbors will likely
+      face similar weather conditions and simultaneously peaking supply from wind
+      and solar. Today, the only practical option for dealing with large amounts of
+      excess is to shut down or 'curtail' production from wind and solar facilities.
+      This effectively increases their production costs. It may therefore be economically
+      attractive to store or convert the excess electricity into a useful form of
+      energy. \r\n<br/><br/>\r\nThe chart gives an indication of how the increase
+      of production costs due to curtailment compares to storage or conversion technologies.\r\nMore
+      detailed information can be found in our <a href=\"https://github.com/quintel/documentation/blob/master/general/storage.md\"
+      target =\"_blank\">documentation</a>. "
+    content_nl: "Deze pagina gaat over de mogelijke maatregelen voor het omgaan met
+      een elektriciteitsoverschot. Elektriciteitsproductie van windturbines en zonnepanelen
+      is onderhevig aan natuurlijke fluctuaties. Aanbod en vraag van elektriciteit
+      komen niet met elkaar overeen en grote hoeveelheden volatiele productiecapaciteit
+      kunnen daarom leiden tot elektriciteitsoverschotten.\r\n<br/><br/>\r\nIn het
+      ETM wordt een overschot aan elektriciteit geëxporteerd. Dit kan echter onmogelijk
+      zijn als buurlanden geconfronteerd worden met vergelijkbare en gelijktijdige
+      pieken in het elektriciteitsaanbod. Vandaag de dag is het afsluiten of beperken
+      van wind- en zonvermogen de enige optie voor het omgaan met grote hoeveelheden
+      overtollig aanbod. Dit verhoogt echter de effectieve productiekosten waardoor
+      het economisch aantrekkelijker kan zijn om de overtollige elektriciteit op te
+      slaan of om te zetten in een andere, bruikbare energiesoort.\r\n<br/><br/>\r\nDe
+      grafiek rechts geeft een indicatie hoe de stijging van productiekosten als gevolg
+      van het beperken van capaciteit zich verhoudt tot de kosten van opslag- en conversietechnologieën.\r\nMeer
+      informatie kunt u vinden in onze <a href=\"https://github.com/quintel/documentation/blob/master/general/storage.md\"
+      documentatie =\"_blank\">documentatie</a>. "
+    short_content_en: 
+    short_content_nl: 
 - id: 166
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1843,6 +2991,15 @@
   output_element_id: 163
   alt_output_element_id: 143
   dependent_on: ''
+  description:
+    content_en: Using the sliders below you can set the electricity storage options
+      for the different network levels. Excess electricity is stored and supplied
+      to the grid later, once the "excess event" has passed.
+    content_nl: Met de volgende sliders kun je aangeven welke elektriciteitsopslag
+      technologieën je inzet in de verschillende netvlakken. Elektriciteitsoverschotten
+      worden opgeslagen en ingezet zodra er geen overproductie meer is.
+    short_content_en: 
+    short_content_nl: 
 - id: 168
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1862,6 +3019,19 @@
   output_element_id: 163
   alt_output_element_id: 163
   dependent_on: ''
+  description:
+    content_en: Excess electricity can be used to produce hydrogen in an electrolysis
+      process. In the ETM, the hydrogen produced by using excess power will be fed
+      into the central hydrogen network. In addition to this hydrogen producing technology,
+      you can choose to produce hydrogen through other processes in <a href="/scenario/supply/hydrogen/hydrogen-production"
+      >hydrogen production slide</a>. Any excess hydrogen will be exported.
+    content_nl: Overtollige elektriciteit kan worden gebruikt om waterstof te produceren
+      door elektrolyse. Deze waterstof wordt in het ETM gevoed in het centrale waterstofnetwerk.
+      Andere waterstofproducerende technologieën kunnen ingesteld worden in de <a
+      href="/scenario/supply/hydrogen/hydrogen-production">waterstofproductieslide</a>.
+      Overtollige waterstof wordt geëxporteerd.
+    short_content_en: 
+    short_content_nl: 
 - id: 169
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1881,6 +3051,34 @@
   output_element_id: 143
   alt_output_element_id: 143
   dependent_on: _always_hidden
+  description:
+    content_en: "Why should wind power production costs increase from a certain level
+      of penetration? \r\n<br/><br/>\r\nIf we assume wind power that exceeds demand
+      cannot be exported, stored or converted into something economically useful,
+      the remaining option is to curtail electricity production. If the installed
+      capacity increases, the share of the electricity production that needs to be
+      curtailed increases. As the share of curtailment increases, the total cost per
+      unit of energy produced (€/MWh) will also increase. The same logic applies to
+      solar PV.\r\n<br/><br/>\r\nThe chart on the right indicates how the total production
+      cost of wind turbines may increase due to curtailment. These costs can help
+      in evaluating storage and conversion technologies. Instead of building more
+      wind turbines, it might become economically interesting to introduce storage
+      and conversion technologies in order to have more useful power available."
+    content_nl: "Waarom stijgen de productiekosten van windenergie als gevolg van
+      een bepaald marktaandeel?\r\n<br/><br/>\r\nWanneer we aannemen dat het overschot
+      aan geproduceerde windenergie niet kan worden geëxporteerd, opgeslagen of omgezet
+      in iets economisch nuttigs, dan is de resterende optie om de elektriciteitsproductie
+      te beperken. Als de geïnstalleerde capaciteit toeneemt, zal een groter aandeel
+      van de energieproductie beperkt moeten worden. Naarmate het aandeel ongebruikte
+      capaciteit toeneemt, zullen de totale productiekosten van elektriciteit (€/MWh)
+      ook toenemen. Hetzelfde geldt voor zon-PV.\r\n<br/><br/>\r\nDe grafiek rechts
+      geeft een indicatie hoe de totale productiekosten van elektriciteit van windturbines
+      kan toenemen als gevolg van beperking van productie. Deze kostenindicatie kan
+      helpen bij het evalueren van opslag- en conversietechnologieën. In plaats van
+      het bouwen van meer windturbines, kan het economisch interessant worden om opslag-
+      en conversietechnologieën te introduceren om bruikbaar vermogen te vergroten."
+    short_content_en: 
+    short_content_nl: 
 - id: 170
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1900,6 +3098,29 @@
   output_element_id: 223
   alt_output_element_id: 216
   dependent_on: ''
+  description:
+    content_en: "The energy transition affects the electricity network. In the table
+      on the right you can see the peak load and usable capacity for the different
+      grid levels. When you click on the 'Annual'-toggle in the top bar, you will
+      be directed to the hourly chart that shows the net load on all electricity levels
+      over time. Are you interested in the hourly peak load curves and demand curves
+      for each grid level? These can be found in the list with all charts (click on
+      'see more charts' and go to 'Network')\r\n</br></br> \r\nThe total investment
+      needed when the electricity network should be reinforced is depended on the
+      investments costs per grid level. These can be set in the <a href=\"/scenario/costs/infrastructure/electricity-infrastructure-costs\"
+      >Costs</a> section."
+    content_nl: "De energietransitie heeft gevolgen voor het elektriciteitsnet. In
+      de tabel rechts kan je de piekbelasting en bruikbare capaciteit zien op de verschillende
+      netniveau's. Als je klikt op het 'Jaarlijkse'-schuifje krijg je de grafiek te
+      zien die de nettobelasting op het elektriciteitsnetwerk per uur laat zien. Wanneer
+      je geïnteresseerd bent in uurlijkse piekbelasting-curves of vraagcurves per
+      netniveau, kan je deze vinden in de lijst met alle grafieken (klik op  'Meer
+      grafieken bekijken' en ga naar 'Netwerk').\r\n</br></br>\r\nDe totale investering
+      die nodig is wanneer het elektriciteitsnetwerk moet worden uitgebreid is afhankelijk
+      van de investeringskosten per netniveau. Deze kunnen onder het <a href=\"/scenario/costs/infrastructure/electricity-infrastructure-costs\"
+      >Kosten</a> kopje worden ingesteld."
+    short_content_en: 
+    short_content_nl: 
 - id: 171
   image: house.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1919,6 +3140,13 @@
   output_element_id: 213
   alt_output_element_id: 145
   dependent_on: ''
+  description:
+    content_en: 'The energy demand for all residences combined depends on the size
+      of the population and the number of residences, which both can be set here. '
+    content_nl: De energievraag voor alle huishoudens samen is afhankelijk van het
+      aantal inwoners en het aantal huizen, welke je beide hier kunt instellen.
+    short_content_en: 
+    short_content_nl: 
 - id: 172
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1936,8 +3164,36 @@
   position: 2
   sidebar_item_id: 40
   output_element_id: 156
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: _always_hidden
+  description:
+    content_en: "The electricity market is one of the last markets in the EU facing
+      cross-border integration. Most industries are already competing in the EU Single
+      Market. The proposal of the European Commission to create a common European
+      energy policy was an important step towards harmonising national markets into
+      working regional markets and finally a pan-European market.<br/><br/>\r\n\r\nIn
+      order to achieve this, both physical interconnection capacity and administrative
+      market coupling are being realized. \r\n \r\nThe thinking is that markets are
+      the most efficient means to assure demand is met by supply at the lowest costs.
+      Overall expected benefits are: <br/><br/>\r\n\r\n\t• Lower electricity costs
+      <br/>\r\n\t• More equal electricity prices between countries<br/><br/>\r\n\r\nIn
+      practice, market distortions by (the mismatch of) individual member states'
+      policies may result in less than perfect market coupling."
+    content_nl: "De elektriciteitsmarkt is één van de laatste markten in de EU die
+      nog niet geïntegreerd is. De meeste bedrijven in de EU concurreren al met elkaar
+      op de gemeenschappelijke Europese markt. De Europese Commissie heeft voorgesteld
+      om een  gemeenschappelijk Europees energiebeleid op te stellen. Dit was een
+      belangrijke stap  om nationale markten te harmoniseren naar regionale markten
+      en uiteindelijk één gemeenschappelijke markt.  \r\n<br/><br/>\r\nHiervoor wordt
+      zowel fysieke interconnectiecapaciteit als een administratieve marktkoppeling
+      gerealiseerd. Dit hinkt op de gedachte dat markten de meest efficiënte manier
+      zijn om te zorgen dat tegen de laagste kosten aan de vraag naar stroom wordt
+      voldaan. De verwachte voordelen zijn:<br/><br/>\r\n\t• Lagere stroomkosten <br/>\r\n\t•
+      Meer prijsconvergentie tussen landen<br/><br/>\r\n\r\nIn de praktijk kan het
+      zo zijn dat de marktwerking verstoord wordt door (een mismatch van) het energiebeleid
+      van verschillende lidstaten.  \r\n\r\n \r\n"
+    short_content_en: 
+    short_content_nl: 
 - id: 173
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1957,6 +3213,25 @@
   output_element_id: 149
   alt_output_element_id: 149
   dependent_on: _always_hidden
+  description:
+    content_en: "The so-called <strong>merit order</strong> (also see <a href=\"/scenario/costs/merit_order/merit-order\"
+      >Merit Order</a>) determines the order in which producers of electricity meet
+      demand. Producers with the lowest marginal costs have priority.\r\n<br/><br/>\r\nThis
+      means that, in general, countries with cheaper electricity production will export
+      to countries with more expensive production. They will do this until prices
+      in both countries converge or the interconnectors work at maximum capacity.\r\n<br/><br/>\r\nIn
+      order to achieve the coupling of electricity markets on a physical level, interconnections
+      between countries are being increased and their utilization optimized. "
+    content_nl: "De <strong>merit order</strong>  bepaalt de volgorde waarin elektriciteitsproducenten
+      aan de vraag voldoen (zie ook <a href=\"/scenario/costs/merit_order/merit-order\"
+      >Merit Order</a>). De producenten met de laagste marginale kosten hebben voorrang.
+      \r\n<br/><br/>\r\nDit betekent dat landen met goedkopere stroomproductie exporteren
+      naar landen met duurdere opwek, totdat de prijzen in beide landen gelijk zijn
+      of de interconnectoren 'vol zitten'. \r\n<br/><br/>\r\nOm fysieke marktkoppeling
+      te bevorderen, wordt de interconnectiecapaciteit tussen landen uitgebreid en
+      het gebruik ervan geoptimaliseerd."
+    short_content_en: 
+    short_content_nl: 
 - id: 174
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1976,6 +3251,43 @@
   output_element_id: 99
   alt_output_element_id: 147
   dependent_on: _always_hidden
+  description:
+    content_en: "Countries in the EU are planning to invest in increasing interconnection
+      capacity (see <a href=\"http://refman.et-model.com/publications/1829\" target=\"_blank\">10-Year
+      Network Development Plan (ENTSO-E)</a>). In the chart on the right, we qualitatively
+      show how the electricity prices of two countries change if the interconnection
+      capacity between them is doubled. \r\n<br/><br/>\r\nThe blue lines show the
+      hourly electricity prices for countries A and B in the reference year (2010).
+      When the blue lines meet (e.g. hours 1-5) the price of electricity is the same
+      for the two countries (convergence). This happens because they both use electricity
+      from the cheapest producer available (electricity is being exported from the
+      country with cheapest production to the other country).\r\n<br/><br/>\r\nAt
+      all other times the blue lines do not match. This happens because, even if one
+      of the countries has cheap production capacity available, the interconnector
+      is already working at maximum capacity (is congested). The country that cannot
+      import the cheap electricity will have to get it from a more expensive local
+      producer. \r\n<br/><br/>\r\nThe red lines show the prices of electricity when
+      the interconnection capacity is doubled. Because the capacity is higher, the
+      interconnector is congested less often and the price of electricity converges
+      more frequently."
+    content_nl: "De lidstaten van de EU zijn van plan om meer interconnectiecapaciteit
+      te realiseren (zie <a href=\"http://refman.et-model.com/publications/1829\"
+      target=\"_blank\">10-Year Network Development Plan (ENTSO-E)</a>). In de figuur
+      rechts kun je zien hoe de stroomprijzen in twee fictieve landen veranderen als
+      de interconnectiecapaceit verdubbelt. \r\n<br/><br/>\r\nDe blauwe lijnen zijn
+      de stroomprijzen per uur voor de landen A en B in het referentiejaar (2010).
+      Als de lijnen bij elkaar komen (bijv. uur 1-5) hebben beide landen dezelfde
+      stroomprijs (convergentie). Dit komt doordat ze beide stroom geleverd krijgen
+      door de goedkoopste producent (het goedkoopste land exporteert naar het andere
+      land). \r\n<br/><br/>\r\nVaak komen de lijnen niet samen. Dat komt doordat de
+      interconnector maximaal benut is (congestie), ook al heeft één van de landen
+      nog goedkope productiecapaciteit over. Het land dat de stroom niet kan importeren
+      zal deze van een duurdere locale producent moeten afnemen.\r\n<br/><br/>\r\nDe
+      rode en oranje lijnen zijn de stroomprijzen als de interconnectiecapaciteit
+      verdubbeld wordt. Doordat deze hoger is, komt het minder vaak voor dat de interconnector
+      maximaal benut is en convergeren de prijzen vaker.  "
+    short_content_en: 
+    short_content_nl: 
 - id: 175
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -1993,8 +3305,41 @@
   position: 5
   sidebar_item_id: 40
   output_element_id: 148
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: _always_hidden
+  description:
+    content_en: "The EU has the goal to increase the available capacity of renewable
+      energy sources (RES) for 2020 (<a href=\"http://refman.et-model.com/publications/1830\"
+      target=\"_blank\">Scenario Outlook and System Adequacy Forecast 2011-2025 (ENTSO-E)</a>).
+      The future situation that we consider here features installed capacities of
+      wind and solar up to 2020 targets. <br/><br/>\r\nIn the chart on the right,
+      we can (qualitatively) see what the effect on the  <em>marginal electricity
+      production costs</em> would be compared to the present situation.\r\n<br/><br/>\r\nThe
+      blue line shows the hourly costs of producing electricity in the present and
+      the orange line when increasing the capacity of RES. The decrease in the costs
+      results from the larger share of RES capacity, which has zero marginal electricity
+      production costs (see <a href=\"/scenario/costs/merit_order/merit-order\" >Merit
+      Order</a>). The average costs of producing electricity are therefore lower.
+      \r\n<br/><br/>\r\nNote that the costs for investments and installation of renewable
+      generating capacity have not been included here. These are typically much higher
+      than for non-renewable capacity. The <em>integral production costs</em> are
+      therefore likely to increase with more renewable capacity."
+    content_nl: "De EU heeft als doel om meer hernieuwbaar productievermogen te realiseren
+      in 2020 (zie <a href=\"http://refman.et-model.com/publications/1830\" target=\"_blank\">Scenario
+      Outlook and System Adequacy Forecast 2011-2025 (ENTSO-E)</a>). De toekomstsituatie
+      die we in het figuur hiernaast tonen, gaat uit van zon- en windvermogens volgens
+      de 2020 doelen. <br/><br/>\r\nWe zien het kwalitatieve effect op de marginale
+      stroomproductiekosten vergeleken met de huidige situatie.<br/><br/>\r\nDe blauwe
+      lijn toont de huidige kosten van stroomproductie op uurbasis en de oranje lijn
+      die bij toenemend hernieuwbaar vermogen. De kostenafname is het gevolg van een
+      groter aandeel van stroomproductie met nul marginale kosten (see <a href=\"/scenario/costs/merit_order/merit-order\"
+      >Merit Order</a>). De gemiddelde kosten dalen daardoor.\r\n<br/><br/>\r\nDe
+      investerings- en installatiekosten van hernieuwbaar vermogen is hierbij niet
+      meegenomen. Deze zijn typisch veel hoger dan voor niet duurzame stroomproductie.
+      De <em>integrale productiekosten</em> zullen daardoor waarschijnlijk eerder
+      stijgen dan dalen bij toenemende hernieuwbare productie."
+    short_content_en: 
+    short_content_nl: 
 - id: 176
   image: industry.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2014,6 +3359,15 @@
   output_element_id: 152
   alt_output_element_id: 152
   dependent_on: ''
+  description:
+    content_en: 'The growth you indicate here is due to economic and population growth.
+      This growth is <strong>excluding</strong> efficiencies and technological changes
+      you can indicate in the subsections below.  '
+    content_nl: De groei die je hier aangeeft is het gevolg van economische groei
+      en bevolkingsgroei. Dit is dus <strong>exclusief</strong> efficiëntieverbeteringen
+      en andere technologieën die je in de gedeeltes hieronder kunt aangeven.
+    short_content_en: 
+    short_content_nl: 
 - id: 177
   image: industry.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2033,6 +3387,14 @@
   output_element_id: 152
   alt_output_element_id: 152
   dependent_on: ''
+  description:
+    content_en: Of all sectors in the economy, industry has the strongest track record
+      in energy efficiency improvements. Saving energy, means reducing costs.
+    content_nl: Van alle economische sectoren, heeft de industrie de beste reputatie
+      als het op efficiëntieverbeteringen aankomt. Energie besparen betekent nu eenmaal
+      geld besparen.
+    short_content_en: 
+    short_content_nl: 
 - id: 178
   image: industry.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2052,6 +3414,19 @@
   output_element_id: 151
   alt_output_element_id: 151
   dependent_on: ''
+  description:
+    content_en: How will the chemical industry meet its heat demand? A different mix
+      of technologies for heat can strongly affect energy efficiency, sustainability
+      and CO<sub>2</sub> emissions. The number and kind of CHPs you want in order
+      to meet this demand can be set in the  <a href="/scenario/demand/industry/combined-heat-power">
+      Combined heat & power</a> section.
+    content_nl: Hoe maakt de chemische industrie haar warmte? Door op andere manieren
+      warmte te maken, kan de efficiëntie, maar ook de CO<sub>2</sub>-uitstoot en
+      hoe hernieuwbaar het energiegebruik is, sterk verbeteren. De aantallen en soorten
+      WKK's die je wilt gebruiken kun je instellen in het <a href="/scenario/demand/industry/combined-heat-power">
+      Warmte-kracht koppeling</a> gedeelte.
+    short_content_en: 
+    short_content_nl: 
 - id: 179
   image: industry.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2071,6 +3446,32 @@
   output_element_id: 178
   alt_output_element_id: 176
   dependent_on: ''
+  description:
+    content_en: "In most countries industry is responsible for the largest part of
+      the energy use. Because this industry is very diverse, we split it up in different
+      sectors. We follow the division of the industry into subsectors as used by the
+      International Energy Agency (IEA) as much as possible. The chart on the right
+      shows the energy use of each of these sectors. In the slides below you can set
+      the growth and efficiency improvements of each sector. A number of smaller sectors
+      have been grouped in <a href=\"/scenario/demand/industry/other\" > Other industry</a>.\r\n<br/><br/>\r\nSome
+      sectors have been modelled in more detail. This makes it possible to explore
+      potential structural changes to these sectors as a result of the energy transition.
+      You can draw inspiration for this from the report <a href=\"http://refman.energytransitionmodel.com/publications/2037\"
+      target =\"_blank\">Industrie in transitie (in Dutch)</a>."
+    content_nl: "In de meeste landen is de industrie verantwoordelijk voor het grootste
+      deel van het energiegebruik. Omdat de industrie heel divers is, hebben we deze
+      onderverdeeld in verschillende subsectoren. Hierbij wordt zoveel mogelijk de
+      indeling uit de energiestatistiek van het Internationaal Energieagentschap (IEA)
+      gevolgd. De grafiek hiernaast laat het energiegebruik voor elk van deze sectoren
+      zien. In de slides hieronder kun je de omvang en efficiëntieverbeteringen van
+      elke sector instellen. Een aantal kleine sectoren zijn gegroepeerd onder <a
+      href=\"/scenario/demand/industry/other\" > Overige industrie</a>.\r\n<br/><br/>\r\nEnkele
+      van de grootste sectoren zijn in meer detail gemodelleerd. Hierdoor is het mogelijk
+      of eventuele structuurveranderingen in deze sectoren als gevolg van de energietransitie
+      te verkennen. Zie voor inspiratie het rapport <a href=\"http://refman.energytransitionmodel.com/publications/2037\"
+      target =\"_blank\">Industrie in transitie</a>."
+    short_content_en: 
+    short_content_nl: 
 - id: 180
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2088,8 +3489,30 @@
   position: 3
   sidebar_item_id: 43
   output_element_id: 158
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "The chart on the right shows our <strong>estimates</strong> of annual
+      extraction of mineral oil. This curve cannot be adjusted by the user and it
+      does not respond to changing market conditions (for example how competitive
+      domestic production of oil will be).\r\n<br/>\r\nPlease note that the quantities
+      of oil shown will be produced regardless of whether their is a use for oil in
+      the future. In the absence of domestic demand, any extracted oil will automatically
+      be exported.\r\n<br/><br/>\r\nMore information on the environmental impact of
+      oil extraction can be found  \r\n<a href=\"/texts/fce_oil\" class=\"fancybox\">in
+      this text</a> from the <a href=\"/scenario/supply/fce/mineral-oil\">fuel chain
+      emissions section.</a>\r\n"
+    content_nl: "In de grafiek hiernaast is de <strong>geschatte</strong> binnenlandse
+      productie van aardolie per jaar weergegeven. De gebruiker kan deze curve momenteel
+      nog niet aanpassen en deze reageert niet op marktomstandigheden (bijvoorbeeld
+      hoe concurrerend de productie van olie is). \r\n<br/>\r\nLet op dat deze hoeveelheden
+      geproduceerd worden, ongeacht of ze ook worden gebruikt in het model. Als er
+      geen binnenlandse toepassing voor is in de toekomst leidt dit automatisch tot
+      export van de gewonnen olie. \r\n<br/><br/>\r\nMeer informatie over de milieueffecten
+      van oliewinning is te vinden in  \r\n<a href=\"/texts/fce_oil\" class=\"fancybox\">in
+      this text</a> uit het gedeelte over <a href=\"/scenario/supply/fce/mineral-oil\">ketenemissies.</a>"
+    short_content_en: 
+    short_content_nl: 
 - id: 181
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2107,8 +3530,30 @@
   position: 2
   sidebar_item_id: 43
   output_element_id: 157
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "The chart on the right shows our <strong>estimates</strong> of annual
+      extraction of coal and lignite. This curve cannot be adjusted by the user and
+      it does not respond to changing market conditions (for example how competitive
+      domestic production of coal will be).\r\n<br/>\r\nPlease note that the quantities
+      of coal shown will be produced regardless of whether their is a use for coal
+      in the future. In the absence of domestic demand, any mined coal will automatically
+      be exported.\r\n<br/><br/>\r\nMore information on the environmental impact of
+      coal mining can be found  \r\n<a href=\"/texts/fce_coal\" class=\"fancybox\">in
+      this text</a> from the <a href=\"/scenario/supply/fce/coal\">fuel chain emissions
+      section.</a>\r\n"
+    content_nl: "In de grafiek hiernaast is de <strong>geschatte</strong> binnenlandse
+      productie van kolen en kolenproducten per jaar weergegeven. De gebruiker kan
+      deze curve momenteel nog niet aanpassen en deze reageert niet op marktomstandigheden
+      (bijvoorbeeld hoe concurrerend de winning van kolen is). \r\n<br/>\r\nLet op
+      dat deze hoeveelheden geproduceerd worden, ongeacht of ze ook worden gebruikt
+      in het model. Als er geen binnenlandse toepassing voor is in de toekomst leidt
+      dit automatisch tot export van gewonnen kolen. \r\n<br/><br/>\r\nMeer informatie
+      over de milieueffecten van kolenmijnen is te vinden in  \r\n<a href=\"/texts/fce_coal\"
+      class=\"fancybox\">deze tekst</a> uit het gedeelte over <a href=\"/scenario/supply/fce/coal\">ketenemissies.</a>"
+    short_content_en: 
+    short_content_nl: 
 - id: 182
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2126,8 +3571,30 @@
   position: 4
   sidebar_item_id: 43
   output_element_id: 159
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "The chart on the right shows our <strong>estimates</strong> of annual
+      extraction of natural gas. This curve cannot be adjusted by the user and it
+      does not respond to changing market conditions (for example how competitive
+      domestic production of natural gas will be).\r\n<br/>\r\nPlease note that the
+      quantities of natural gas shown will be produced regardless of whether their
+      is a use for natural gas in the future. In the absence of domestic demand, any
+      extracted natural gas will automatically be exported.\r\n<br/><br/>\r\nMore
+      information on the environmental impact of natural gas extraction can be found
+      \ \r\n<a href=\"/texts/fce_naturalgas\" class=\"fancybox\">in this text</a>
+      from the <a href=\"/scenario/supply/fce/natural-gas\">fuel chain emissions section.</a>\r\n"
+    content_nl: "In de grafiek hiernaast is de <strong>geschatte</strong> binnenlandse
+      productie van aardgas per jaar weergegeven. De gebruiker kan deze curve momenteel
+      nog niet aanpassen en deze reageert niet op marktomstandigheden (bijvoorbeeld
+      hoe concurrerend de winning van aardgas is). \r\n<br/>\r\nLet op dat deze hoeveelheden
+      geproduceerd worden, ongeacht of ze ook worden gebruikt in het model. Als er
+      geen binnenlandse toepassing voor is in de toekomst leidt dit automatisch tot
+      export van gewonnen aardgas. \r\n<br/><br/>\r\nMeer informatie over de milieueffecten
+      van aardgaswinning is te vinden in  \r\n<a href=\"/texts/fce_naturalgas\" class=\"fancybox\">deze
+      tekst</a> uit het gedeelte over <a href=\"/scenario/supply/fce/natural-gas\">ketenemissies.</a>"
+    short_content_en: 
+    short_content_nl: 
 - id: 184
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2145,8 +3612,30 @@
   position: 6
   sidebar_item_id: 43
   output_element_id: 161
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "The chart on the right shows our <strong>estimates</strong> of annual
+      extraction of uranium oxide. This curve cannot be adjusted by the user and it
+      does not respond to changing market conditions (for example how competitive
+      domestic production of uranium oxide will be).\r\n<br/>\r\nPlease note that
+      the quantities of uranium shown will be produced regardless of whether their
+      is a use for it in the future. In the absence of domestic demand, any uranium
+      oxide produced will automatically be exported.\r\n<br/><br/>\r\nMore information
+      on the environmental impact of uranium mining can be found  \r\n<a href=\"/texts/fce_uranium\"
+      class=\"fancybox\">in this text</a> from the <a href=\"/scenario/supply/fce/uranium\">fuel
+      chain emissions section.</a>\r\n"
+    content_nl: "In de grafiek hiernaast is de <strong>geschatte</strong> binnenlandse
+      productie van uraniumoxide per jaar weergegeven. De gebruiker kan deze curve
+      momenteel nog niet aanpassen en deze reageert niet op marktomstandigheden (bijvoorbeeld
+      hoe concurrerend de winning van uranium is). \r\n<br/>\r\nLet op dat deze hoeveelheden
+      geproduceerd worden, ongeacht of ze ook worden gebruikt in het model. Als er
+      geen binnenlandse toepassing voor is in de toekomst leidt dit automatisch tot
+      export van gewonnen uranium. \r\n<br/><br/>\r\nMeer informatie over de milieueffecten
+      van uraniumproductie is te vinden in  \r\n<a href=\"/texts/fce_uranium\" class=\"fancybox\">deze
+      tekst</a> uit het gedeelte over <a href=\"/scenario/supply/fce/uranium\">ketenemissies.</a>"
+    short_content_en: 
+    short_content_nl: 
 - id: 185
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2164,8 +3653,39 @@
   position: 1
   sidebar_item_id: 43
   output_element_id: 76
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "The energy we use every day comes in the form of energy carriers
+      like electricity, coal or natural gas. Some of these carriers are extracted
+      from mines or wells. Such carriers are called primary carriers. They are often
+      converted to more useful carriers like electricity, heat or gasoline, for example.
+      \  \r\n<br/><br/>\r\nIn the ETM, the extraction of primary energy carriers is
+      not (yet) the result of domestic or foreign demand. instead, domestic production
+      is determined by annual production curves. \r\n <br/><br/>\r\nAlthough this
+      is far from the ideal way of modeling the production of such carriers, it does
+      spare the user rather complicated considerations like:\r\n<ul>\r\n<li>What are
+      domestic resources and how (quickly) are they depleted in the intervening years
+      between the present and future year modeled?</li>\r\n<li>What is maximum annual
+      production capacity?</li>\r\n<li>How does annual production respond to different
+      circumstances in the market?</li>\r\n</ul>\r\nSuch questions are not easily
+      answered and would require quite a nit of extra input (sliders). "
+    content_nl: "De energie die we dagelijks gebruiken komt altijd in de vorm van
+      een energiedrager zoals stroom, kolen of gas. Sommige energiedragers kunnen
+      direct worden gewonnen (denk aan olie, kolen en gas). Die noemen we primaire
+      energiedragers. Ze worden vaak omgezet in andere, meer bruikbare energievormen
+      zoals stroom, warmte of benzine.\r\n<br/><br/>\r\nIn het ETM is de winning van
+      primaire energiedragers (nog) niet het gevolg van binnen- of buitenlandse vraag
+      ernaar. In plaats daarvan wordt de binnenlandse productie bepaald door curves
+      met geschatte jaarlijkse productiecijfers.\r\n<br/><br/>\r\nDit is niet ideaal
+      natuurlijk, maar bespaart de gebruiker de nodige hoofdbrekens. Vragen zoals:\r\n<ul>\r\n<li>Wat
+      zijn de binnenlandse voorraden en hoe (snel) worden die opgemaakt tussen nu
+      en het toekomstjaar?</li>\r\n<li>Wat is de maximale jaarlijkse productiecapaciteit?</li>\r\n<li>Hoe
+      reageert de jaarlijkse productie op de verschillende marktomstandigheden?</li>\r\n</ul>\r\nDit
+      zijn lastig te beantwoorden vragen voor de meeste gebruikers en zouden veel
+      extra input (schuifjes) vergen."
+    short_content_en: 
+    short_content_nl: 
 - id: 186
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2183,8 +3703,29 @@
   position: 2
   sidebar_item_id: 53
   output_element_id: 163
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: _always_hidden
+  description:
+    content_en: "Electric vehicles could provide a cost-effective way of storing electricity
+      as they contain a relatively large battery. Some of the charge in the battery
+      is, however, needed in order to fuel your next ride. With the slider below,
+      you can set which percentage of the electric vehicles' battery is reserved for
+      flexibility purposes. You can set the percentage of electric vehicles in the
+      <a href=\"/scenario/demand/transport_passenger_transport/car-technology\">car
+      technology section of transport</a>.\r\n<br/><br/>\r\nElectricity is stored
+      in the battery of the electric vehicles at times of excess electricity production
+      by volatile sources and is supplied to the grid once the 'excess event' has
+      passed."
+    content_nl: "Elektrische auto's zijn een kosteneffectieve manier om elektriciteit
+      op te slaan omdat ze een relatief grote batterij bevatten. Een deel van de lading
+      in de batterij is echter wel nodig om met de auto te kunnen rijden. Met de volgende
+      slider kun je daarom aangeven welk percentage van de batterij in alle elektrische
+      auto's kan worden gebruikt voor flexibiliteitsdoeleinden. Je kunt het percentage
+      elektrische auto's instellen in <a href=\"/scenario/demand/transport_passenger_transport/car-technology\">autotechnologie
+      slide</a>.\r\n<br/><br/>\r\nElektriciteitsoverschotten worden opgeslagen in
+      de batterij en ingezet zodra er geen overproductie meer is."
+    short_content_en: 
+    short_content_nl: 
 - id: 187
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2204,6 +3745,27 @@
   output_element_id: 164
   alt_output_element_id: 164
   dependent_on: ''
+  description:
+    content_en: The difference between the hourly electricity supply and demand can
+      be imported or exported. The interconnector capacity between countries is, however,
+      limited, restricting the amount of electricity that can be imported or exported
+      at any time. Below you can set the technical capacity of all interconnectors
+      combined. It might be that not all of this capacity is available for export,
+      e.g. because you expect that neighbouring countries will have excess electricity
+      at the same time as your country does. You can set which percentage of the physical
+      interconnector capacity is available for export using the sliders below. Read
+      more about import/export <a href="https://github.com/quintel/documentation/blob/master/general/import_export.md">here</a>.
+    content_nl: Het verschil tussen de vraag en het aanbod van elektriciteit op uurbasis
+      kan worden geïmporteerd of geëxporteerd. De interconnectiecapaciteit tussen
+      landen is echter beperkt; het is hierdoor maar beperkt mogelijk om elektriciteit
+      te exporteren. Hieronder kun je de totale capaciteit van alle interconnectoren
+      instellen. Het is echter mogelijk dat niet al deze capaciteit beschikbaar is
+      voor export, bijvoorbeeld omdat de omringende landen op hetzelfde moment met
+      elektriciteitsoverschotten kampen. Het is daarom mogelijk om het percentage
+      van de interconnectiecapaciteit dat beschikbaar is voor export te beperken.
+      Lees meer over import/export <a href="https://github.com/quintel/documentation/blob/master/general/import_export.md">hier</a>.
+    short_content_en: 
+    short_content_nl: 
 - id: 191
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2221,8 +3783,19 @@
   position: 14
   sidebar_item_id: 52
   output_element_id: 207
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "Will ships owners hold on to conventional diesel engine ships, or
+      will they make a transition to Liquefied Natural Gas (LNG) engine ships? In
+      the <a href=\"/scenario/supply/transport_fuels/domestic-navigation\" >domestic
+      navigation fuels section</a> you can set the fuel mix these engines run on.\r\n"
+    content_nl: Blijft de binnenvaart conventionele dieselmotoren gebruiken, of maakt
+      men de overstap naar schepen met LNG-motoren? In de <a href="/scenario/supply/transport_fuels/domestic-navigation"
+      >brandstoffensectie van binnenvaartschepen</a> kun je instellen door welke brandstofmix
+      deze motoren aangedreven worden.
+    short_content_en: 
+    short_content_nl: 
 - id: 192
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2242,6 +3815,24 @@
   output_element_id: 100
   alt_output_element_id: 100
   dependent_on: _always_hidden
+  description:
+    content_en: 'When natural gas is cooled down to - 162 degrees celsius (under atmospheric
+      pressure), it becomes liquid and its energetic density is higher by a factor
+      of about 600. Then it is transported from the Middle East (main producer) and
+      within Europe from Norway to import terminals around the world. Upon arrival,
+      most of it is regasified and fed into the national natural gas grid. This pathway  has
+      smaller energy losses than pipeline transport, depending on distance and other
+      factors. LNG is also used in transport, most notably by trucks and ships. '
+    content_nl: Wanneer aardgas op een temperatuur van -162 graden Celsius gebracht
+      wordt (onder atmosferische druk), wordt het vloeibaar en neemt de energetische
+      dichtheid toe met een factor 600. Daarna wordt het getransporteerd vanuit met
+      name het Midden Oosten (en in Europa vanuit Noorwegen) naar een import terminal,
+      waar het grotendeels weer hervergast wordt en ingevoerd wordt in het aardgasnetwerk.
+      Deze route leidt in sommige gevallen tot minder energieverlies dan transport
+      per pijpleiding. Daarnaast wordt LNG  (vloeibaar aardgas) ook gebruikt voor
+      transport, met name door vrachtwagens en schepen.
+    short_content_en: 
+    short_content_nl: 
 - id: 193
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2261,6 +3852,35 @@
   output_element_id: 214
   alt_output_element_id: 225
   dependent_on: ''
+  description:
+    content_en: "Below you can specify how hydrogen will be produced in the future.
+      The ETM offers the following options: electrolysis of wind and solar power from
+      wind/solar farms dedicated to hydrogen production; steam methane reforming (with
+      and without CCS); gasification of biomass; import from abroad.\r\n<br /><br
+      />\r\nIn addition, it is possible to convert excess electricity into hydrogen
+      using 'power-to-gas' (see the <a href=\"/scenario/flexibility/flexibility_conversion/conversion-to-hydrogen\"
+      >power-to-gas slide</a>). You can do this if your scenario has moments where
+      electricity production exceeds demand. Hydrogen for the fertilizer industry
+      can also be produced on-site since this industry already has large hydrogen
+      production plants built (see the <a href=\"/scenario/demand/industry/fertilizers\"
+      >fertilizer industry slide</a>).\r\n<br><br />\r\nFor more information see our
+      <a href=\"https://github.com/quintel/documentation/blob/master/general/Hydrogen.md\"
+      >documentation</a>."
+    content_nl: "In dit gedeelte kun je selecteren hoe de waterstof geproduceerd wordt
+      in de toekomst. Het ETM biedt de volgende opties: elektrolyse van wind- en zonnestroom
+      van wind/zonneparken ; stoomreforming van aardgas (met of zonder CCS); vergassing
+      van biomassa; import uit het buitenland.\r\n<br /><br />\r\nJe kunt er ook voor
+      kiezen om overschotten elektriciteit om te zetten in waterstof (zie de sectie
+      <a href=\"/scenario/flexibility/flexibility_conversion/conversion-to-hydrogen\"
+      >power-to-gas</a>). Dit kan alleen als er in jouw scenario momenten in het jaar
+      zijn waarop de elektriciteitsproductie hoger is dan de vraag. Daarnaast is het
+      in de kunstmestindustrie mogelijk om lokaal waterstof te produceren. Deze industrie
+      beschikt op dit moment al over waterstoffabrieken (zie <a href=\"/scenario/demand/industry/fertilizers\"
+      >kunstmestindustrie</a>).\r\n<br> <br/>\r\nMeer informatie is te vinden in de
+      <a href=\"https://github.com/quintel/documentation/blob/master/general/Hydrogen.md\"
+      >documentatie</a>."
+    short_content_en: 
+    short_content_nl: 
 - id: 194
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2280,6 +3900,36 @@
   output_element_id: 173
   alt_output_element_id: 164
   dependent_on: ''
+  description:
+    content_en: "Wind turbines and solar panels are subject to volatile natural patterns.
+      The electricity that they produce might therefore not always be used to match
+      demand directly and consequently lead to excess electricity. To prevent curtailment
+      of excess electricity production, the ETM contains several flexibility technologies
+      that can either store or convert the excess electricity. You can include these
+      technologies in the <a href=\"/scenario/flexibility/flexibility_storage/storage-in-household-batteries\">'Storage'</a>
+      and <a href=\"/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-households\">'Conversion'</a>
+      tab. \r\n<br/><br/>\r\nUsing the list below, you can decide on the order in
+      which the flexibility technologies have to be applied. The ETM will send excess
+      electricity to the first technology on your list until its maximum capacity
+      is reached; the remaining excess electricity is send to the second technology
+      on your list and so on. Finally, any remaining excess electricity is curtailed.
+      You can drag and drop the technologies in the desired order."
+    content_nl: "Windmolens en zonnepanelen hebben van nature een grillig productiepatroon.
+      De elektriciteit die ze produceren kan daarom niet altijd worden gebruikt om
+      elektriciteitsvraag in te vullen. Dit kan leiden tot overproductie van elektriciteit.
+      Om te voorkomen dat deze elektriciteitsproductie moet worden beperkt, kent het
+      ETM een aantal flexibiliteitstechnologieën die de overschotten kunnen opslaan
+      of omzetten in andere energiedragers. Je kan die technologieën inzetten in de
+      <a href=\"/scenario/flexibility/flexibility_storage/storage-in-household-batteries\">'Opslag'</a>
+      en <a href=\"/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-households\">'Conversie'</a>
+      tabs.\r\n<br/><br/>\r\nDoor middel van de lijst hieronder kun je de volgorde
+      bepalen waarin de technologieën worden ingezet. Het ETM stuurt elektriciteitsoverschotten
+      naar de technologie die als eerste op de lijst staat zolang de capaciteit dit
+      toelaat; verdere overschotten worden naar de tweede technologie op de lijst
+      gestuurd en zo verder. Enige overgebleven elektriciteit wordt gecurtailed. Je
+      kunt de technologieën in de gewenste volgorde verslepen."
+    short_content_en: 
+    short_content_nl: 
 - id: 195
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2299,6 +3949,15 @@
   output_element_id: 170
   alt_output_element_id: 170
   dependent_on: ''
+  description:
+    content_en: Here you can specify how much higher the average initial investment
+      costs of electric cars (excl. taxes) will be than those of conventional combustion
+      engine cars. Keep in mind that hydrogen-powered cars are electric too!
+    content_nl: Hier kun je aangeven hoeveel hoger de gemiddelde aanschafkosten van
+      elektrische auto's (excl. belastingen) zullen liggen dan die van auto's met
+      verbrandingsmotoren. Vergeet niet dat waterstofauto's ook elektrisch zijn!
+    short_content_en: 
+    short_content_nl: 
 - id: 196
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2318,6 +3977,49 @@
   output_element_id: 125
   alt_output_element_id: 116
   dependent_on: ''
+  description:
+    content_en: "The merit order ranks power plants according to their marginal costs.
+      Not all electricity production technologies participate in the merit order.
+      Renewable power from wind and solar has priority, for example, and so increasing
+      the share of such technologies in your scenario will decrease the operating
+      hours of the remaining plants. Since the merit order is determined solely by
+      marginal costs, it is possible that more efficient technologies are 'pushed'
+      out of the electricity generation mix this way.\r\n<br/><br/>\r\nFurthermore,
+      certain technologies are considered 'must-run'. These are mainly CHPs that satisfy
+      a certain heat demand and do not primarily run to sell power. These must-run
+      plants are therefore not included in the merit order. They do influence the
+      operating hours of other plants of course.\r\n<br/><br/>\r\nThe ETM calculates
+      which power plants are dispatched at each hour in the year. The results are
+      updated every time you make changes to your scenario and communicated through
+      various charts. You can download the resulting hourly load curves for each type
+      of power plant as well as the power price curve for your scenario using the
+      download buttons below.\r\n<ul class=\"data-download merit-data-downloads\">\r\n
+      \ <li><a href=\"%{etengine_url}/api/v3/scenarios/%{scenario_id}/merit/loads.csv\"><span
+      class=\"fa fa-download\"></span> Load curves <span class=\"filetype\">(3.8MB
+      CSV)</span></a></li>\r\n  <li><a href=\"%{etengine_url}/api/v3/scenarios/%{scenario_id}/merit/price.csv\"><span
+      class=\"fa fa-download\"></span> Price curve <span class=\"filetype\">(158KB
+      CSV)</span></a></li>\r\n</ul>"
+    content_nl: "De merit order rangschikt de elektriciteitscentrales naar marginale
+      kosten. Niet alle soorten stroomopwek doen mee in de merit order. Hernieuwbare
+      stroom van wind en zon heeft marginale kosten van 0 EUR/MWh en krijgt voorrang
+      op het net, dus als je hier meer van bouwt, zakt het aantal draaiuren van fossiele
+      centrales. Aangezien alleen op draaikosten gerangschikt wordt, kan dit betekenen
+      dat efficiënte maar dure fossiele centrales uit de mix worden geduwd. \r\n<br/><br/>\r\nOok
+      'must run' technologieën doen niet mee in de merit order. Dit zijn bijvoorbeeld
+      WKK's die warmte leveren en niet primair draaien vanwege de stroom die ze maken.
+      Toch hebben ze invloed op de draaiuren van andere centrales.\r\n<br/><br/>\r\nHet
+      ETM berekent op uurbasis welke centrales zijn ingeschakeld. De berekening wordt
+      elke keer dat je je scenario aanpast opnieuw uitgevoerd en de resultaten worden
+      weergegeven in diverse grafieken. Je kunt ook de draaiprofielen van de verschillende
+      soorten centrales en de resulterende stroomprijscurve voor jouw scenario downloaden
+      via onderstaande knoppen.\r\n<ul class=\"data-download merit-data-downloads\">\r\n
+      \ <li><a href=\"%{etengine_url}/api/v3/scenarios/%{scenario_id}/merit/loads.csv\"><span
+      class=\"fa fa-download\"></span> Draaiprofielen <span class=\"filetype\">(3.8MB
+      CSV)</span></a></li>\r\n  <li><a href=\"%{etengine_url}/api/v3/scenarios/%{scenario_id}/merit/price.csv\"><span
+      class=\"fa fa-download\"></span> Prijscurve <span class=\"filetype\">(158KB
+      CSV)</span></a></li>\r\n</ul>"
+    short_content_en: 
+    short_content_nl: 
 - id: 197
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2337,6 +4039,68 @@
   output_element_id: 171
   alt_output_element_id: 171
   dependent_on: ''
+  description:
+    content_en: |
+      The merit order ranks power plants according to their marginal costs.
+      Based on the hourly demand, the ETM calculates which power plants are
+      dispatched each hour. Combined with the marginal costs of these
+      plants, the ETM calculates the hourly electricity price. The ETM
+      assumes that this price is equal to the marginal costs of the most
+      expensive plant running.
+
+      <br/><br/>
+
+      The price curve for your scenario, as well as the load curves for all power plants, can be downloaded following the links below.
+
+      <ul class="data-download merit-data-downloads">
+        <li><a href="%{etengine_url}/api/v3/scenarios/%{scenario_id}/curves/merit_order.csv"><span class="fa fa-download"></span> Load curves <span class="filetype">(7MB CSV)</span></a></li>
+        <li><a href="%{etengine_url}/api/v3/scenarios/%{scenario_id}/curves/electricity_price.csv"><span class="fa fa-download"></span> Price curve <span class="filetype">(300KB CSV)</span></a></li>
+      </ul>
+
+      <div class="data-deprecation">
+        <span class="fa fa-info-circle"></span>
+        The format of the load and price curves has recently changed. You can
+        download copies of this data in the old format below, but note that
+        these will be discontinued in April 2020.
+
+        <ul class="data-download merit-data-downloads">
+          <li><a href="%{etengine_url}/api/v3/scenarios/%{scenario_id}/merit/loads.csv"><span class="fa fa-download"></span> Load curves (old format) <span class="filetype">(11MB CSV)</span></a></li>
+          <li><a href="%{etengine_url}/api/v3/scenarios/%{scenario_id}/merit/price.csv"><span class="fa fa-download"></span> Price curve (old format) <span class="filetype">(158KB CSV)</span></a></li>
+        </ul>
+      </div>
+    content_nl: |
+      De merit order rangschikt de elektriciteitscentrales naar marginale
+      kosten. In combinatie met de elektriciteitsvraag op uurbasis, berekent
+      het ETM welke centrales zijn ingeschakeld. In combinatie met de
+      draaikosten van deze centrales kan het ETM de prijs op uurbasis
+      uitrekenen. Het ETM neemt aan dat deze prijs gelijk is aan de kosten
+      van de duurste centrale die op dat moment is ingeschakeld.
+
+      <br/><br/>
+
+      De prijscurve voor jouw scenario en de draaiprofielen voor de
+      verschillende soorten centrales zijn te downloaden via de links
+      hieronder.
+
+      <ul class="data-download merit-data-downloads">
+        <li><a href="%{etengine_url}/api/v3/scenarios/%{scenario_id}/curves/merit_order.csv"><span class="fa fa-download"></span> Draaiprofielen <span class="filetype">(7MB CSV)</span></a></li>
+        <li><a href="%{etengine_url}/api/v3/scenarios/%{scenario_id}/curves/electricity_price.csv"><span class="fa fa-download"></span> Prijscurve <span class="filetype">(300KB CSV)</span></a></li>
+      </ul>
+
+
+      <div class="data-deprecation">
+        <span class="fa fa-info-circle"></span>
+        De bestandsindeling van de draaiprofielen en prijscurves is recent veranderd.
+        Hieronder kun je de data in het oude format downloaden.
+        Let op: De oude bestanden blijven beschikbaar tot april 2020.
+
+        <ul class="data-download merit-data-downloads">
+          <li><a href="%{etengine_url}/api/v3/scenarios/%{scenario_id}/merit/loads.csv"><span class="fa fa-download"></span> Draaiprofielen (oud format) <span class="filetype">(11MB CSV)</span></a></li>
+          <li><a href="%{etengine_url}/api/v3/scenarios/%{scenario_id}/merit/price.csv"><span class="fa fa-download"></span> Prijscurve (oud format) <span class="filetype">(158KB CSV)</span></a></li>
+        </ul>
+      </div>
+    short_content_en: 
+    short_content_nl: 
 - id: 198
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2352,10 +4116,28 @@
   subheader_image: ''
   key: flexibility_flexibility_excess_electricity
   position: 1
-  sidebar_item_id:
+  sidebar_item_id: 
   output_element_id: 175
   alt_output_element_id: 175
   dependent_on: ''
+  description:
+    content_en: "Wind turbines and solar panels are subject to volatile natural patterns.
+      The electricity that they produce might therefore not always be used to match
+      demand directly. This mismatch will lead to excess electricity, in particular
+      in scenarios with large amounts of volatile production capacity. The ETM keeps
+      track of the number of hours with excess electricity and the duration of these
+      excess events.\r\n<br/><br/>\r\nTo prevent curtailment of this excess electricity
+      production, the ETM contains several flexibility technologies that can make
+      good use of it."
+    content_nl: "Windmolens en zonnepanelen hebben van nature een grillig productiepatroon.
+      De elektriciteit die ze produceren kan daarom niet noodzakelijk altijd worden
+      gebruikt om elektriciteitsvraag in te vullen. Dit kan leiden tot overproductie
+      van elektriciteit. Het ETM houdt bij op welke uren er een overschot van elektriciteit
+      is en hoe lang deze elektriciteitsoverschotten duren.\r\n<br/><br/>\r\nOm te
+      voorkomen dat deze elektriciteitsproductie moet worden beperkt, kent het ETM
+      een aantal flexibiliteitstechnologieën die goed kunnen omgaan met deze elektriciteitsoverschotten."
+    short_content_en: 
+    short_content_nl: 
 - id: 199
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2375,6 +4157,33 @@
   output_element_id: 190
   alt_output_element_id: 180
   dependent_on: ''
+  description:
+    content_en: "Refineries turn crude oil into oil products. These oil products are
+      used as fuel in the transport sector or feedstock in the chemical industry.
+      Refineries make most of their money by selling transport fuels. The demand for
+      these fuels will most probably change as transport technologies change. You
+      can set these technologies in <a href=\"/scenario/demand/transport\" > the transport
+      sector</a>.\r\n<br/><br/>\r\nIn the ETM the output of the refineries is not
+      directly coupled to domestic demand for transport fuels. Potential shortages
+      can be imported and excess production can be exported. This also holds for oil
+      products that are used as feedstock in the chemical industry. Below you can
+      set the growth and efficiency improvements of the refineries separately. Note
+      that the demand for refinery products is set by global markets. "
+    content_nl: "Raffinaderijen maken van ruwe olie olieproducten. Deze olieproducten
+      worden ingezet als brandstof in de transportsector of als grondstof in de chemische
+      industrie. Raffinaderijen verdienen het meeste geld aan de transportbrandstoffen.
+      Als gevolg van veranderende technologieën in de transportsector zal de vraag
+      naar deze brandstoffen veranderen. Deze technologieën zijn in te stellen in
+      <a href=\"/scenario/demand/transport\" > de transportsector van het ETM</a>.\r\n<br/><br/>\r\nDe
+      productie van de raffinaderijen is in het ETM niet direct gekoppeld aan de binnenlandse
+      vraag naar transportbrandstoffen. Eventuele tekorten worden geïmporteerd en
+      eventuele overschotten worden geëxporteerd. Dit geldt ook voor de olieproducten
+      die worden ingezet als grondstof in de chemische industrie. Hieronder kun je
+      het productievolume en de efficiëntieverbeteringen van de raffinaderijen afzonderlijk
+      instellen. Let hierbij op dat de vraag naar raffinageproducten wordt bepaald
+      door de wereldwijde markt. "
+    short_content_en: 
+    short_content_nl: 
 - id: 201
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2394,6 +4203,25 @@
   output_element_id: 184
   alt_output_element_id: 184
   dependent_on: has_detailed_chemical_industry
+  description:
+    content_en: "Ammonia (NH<sub>3</sub>) constitutes the basis of all nitrogen-based
+      fertilizers. The most important step in producing ammonia is reacting hydrogen
+      with nitrogen. At the moment the required hydrogen is produced locally by stripping
+      natural gas in a steam methane reforming (SMR) plant, which produces CO<sub>2</sub>
+      as a side product. In the future, it may become possible to use hydrogen from
+      a central hydrogen network. This network delivers hydrogen originating from
+      different processes that can be chosen in the \r\n<a href=\"/scenario/supply/hydrogen/hydrogen-production\"
+      >hydrogen production slide</a>."
+    content_nl: Ammoniak (NH<sub>3</sub>) vormt de basis voor alle op stikstof gebaseerde
+      kunstmest. De belangrijkste stap in het produceren van ammoniak is het reageren
+      van waterstof met stikstof. Op dit moment wordt de benodigde waterstof lokaal
+      gemaakt door aardgas om te zetten in een stoomreformingproces (SMR), waarbij
+      CO<sub>2</sub> vrijkomt. Het is in de toekomst wellicht ook mogelijk om de waterstof
+      te gebruiken van een centraal waterstofnetwerk. Dit netwerk bevat waterstof
+      van verschillende productieprocessen die te kiezen zijn in de slide <a href="/scenario/supply/hydrogen/hydrogen-production"
+      >'waterstofproductie'</a>.
+    short_content_en: 
+    short_content_nl: 
 - id: 202
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2413,6 +4241,24 @@
   output_element_id: 182
   alt_output_element_id: 182
   dependent_on: ''
+  description:
+    content_en: "This sector includes the production of chemicals. Fertilizer production
+      has been excluded from this sector and is represented as a <a href=\"/scenario/demand/industry/fertilizers\"
+      > separate sector</a>. \r\n<br><br/>\r\nThe growth you indicate here is due
+      to economic and population growth. This growth is excluding efficiencies and
+      technological changes you can indicate in the subsections below.\r\n<br></br>\r\nCaution:
+      not all heat production technologies are suited to supply the full heat demand.
+      More information on this can be found in the \"?\" next to the slider."
+    content_nl: "Binnen deze sector vallen de productie van chemicaliën. De productie
+      van kunstmest is hiervan afgesplitst en is als <a href=\"/scenario/demand/industry/fertilizers\"
+      > aparte sector</a> opgenomen in het model.\r\n<br></br>\r\nDe groei die je
+      hier aangeeft is het gevolg van economische groei en bevolkingsgroei. Dit is
+      dus <strong>exclusief</strong> efficiëntieverbeteringen en andere technologieën
+      die je in de gedeeltes hieronder kunt aangeven.\r\n<br></br>\r\nLet op: de warmtetechnologieën
+      zijn niet allemaal geschikt om de volledige warmtevraag in te vullen. Meer informatie
+      hierover is te vinden bij het \"?\" naast de schuifjes."
+    short_content_en: 
+    short_content_nl: 
 - id: 203
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2432,6 +4278,15 @@
   output_element_id: 183
   alt_output_element_id: 183
   dependent_on: ''
+  description:
+    content_en: This sector includes the manufacturing of food products, beverages
+      and tobacco. Below you can set the growth and efficiency improvements of this
+      sector separately.
+    content_nl: Deze sector omvat de productie van voedselproducten, drank en tabaksproducten.
+      Hieronder kun je de groei en efficiëntieverbeteringen van deze sector afzonderlijk
+      instellen.
+    short_content_en: 
+    short_content_nl: 
 - id: 204
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2451,6 +4306,16 @@
   output_element_id: 181
   alt_output_element_id: 181
   dependent_on: ''
+  description:
+    content_en: This sector includes the manufacturing of paper and paper products
+      as well as printing and reproduction of recorded media. Below you can set the
+      growth and efficiency improvements of this sector separately.
+    content_nl: In deze sector vind je het energiegebruik voor zowel het maken van
+      papier en papierproducten als voor het drukken en printen van boeken, kranten
+      en tijdschriften. Hieronder kun je de groei en efficiëntieverbeteringen van
+      deze sector afzonderlijk instellen.
+    short_content_en: 
+    short_content_nl: 
 - id: 205
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2470,6 +4335,15 @@
   output_element_id: 186
   alt_output_element_id: 186
   dependent_on: ''
+  description:
+    content_en: The other industry comprises all sectors that are not shown explicitly
+      above. Since the specific technologies used in this sector are not known, you
+      can directly set the shares of energy carriers below.
+    content_nl: De overige industrie beslaat de sectoren die hierboven niet expliciet
+      zijn vermeld. Omdat de specifieke technologieën niet bekend zijn voor deze sector,
+      kan je hieronder direct de verdeling van energiedragers instellen.
+    short_content_en: 
+    short_content_nl: 
 - id: 207
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2489,6 +4363,14 @@
   output_element_id: 182
   alt_output_element_id: 182
   dependent_on: _always_hidden
+  description:
+    content_en: The growth you indicate here is due to economic and population growth.
+      This growth is excluding efficiencies and technological changes you can indicate
+      in the subsections below.
+    content_nl: Binnen deze sector vallen de productie van chemicaliën en chemische
+      producten, inclusief kunstmest.
+    short_content_en: 
+    short_content_nl: 
 - id: 208
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2506,8 +4388,32 @@
   position: 5
   sidebar_item_id: 47
   output_element_id: 188
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "Usually no CO<sub>2</sub> emissions are attributed to biomass as
+      biomass absorbs as much CO<sub>2</sub> as is emitted during combustion (over
+      the complete life cycle). However, the CO<sub>2</sub> emitted by combustion
+      of biomass is not always absorbed within a time-scale that is relevant for climate
+      change (the life cycle of biomass varies from a couple of months to over a century).
+      Therefore, it is possible to experience what the on-the-spot CO<sub>2</sub>
+      emissions of biomass are by including them in the chart on the right. <a href=\"https://github.com/quintel/documentation/blob/master/general/co2_biomass.md\"
+      target =\"_blank\">learn more</a>\r\n</br></br>\r\n<strong>NOTE: the CO<sub>2</sub>
+      emissions that you include here are only shown in the chart and not included
+      in your scenario!</strong>"
+    content_nl: "Er wordt doorgaans geen CO<sub>2</sub>-uitstoot aan biomassa toegekend
+      omdat biomassa (over de hele levenscyclus) evenveel CO<sub>2</sub> opneemt als
+      wordt uitgestoten bij verbranding. Echter wordt de uitgestoten CO<sub>2</sub>
+      niet per se weer opgenomen binnen een voor de klimaatverandering relevante termijn
+      (de levenscyclus van biomassa is enkele maanden tot meer dan honderd jaar).
+      Daarom is het hier mogelijk om te weten te komen wat de directe CO<sub>2</sub>-uitstoot
+      van biomassa is door de uitstoot toe te voegen aan de grafiek hier rechts. <a
+      href=\"https://github.com/quintel/documentation/blob/master/general/co2_biomass.md\"
+      target =\"_blank\">lees verder</a> \r\n</br></br>\r\n<strong>LET OP: de CO<sub>2</sub>-uitstoot
+      die je hier instelt wordt enkel in de grafiek weergegeven en wordt op geen enkele
+      manier meegenomen in jouw scenario.</strong>"
+    short_content_en: 
+    short_content_nl: 
 - id: 211
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2527,6 +4433,15 @@
   output_element_id: 189
   alt_output_element_id: 189
   dependent_on: ''
+  description:
+    content_en: This sector encompasses all centralized ICT services. Its most notable
+      components are datacenters and telecom. Below you can set the growth and efficiency
+      improvements of this sector separately.
+    content_nl: Deze sector omvat alle gecentraliseerde ICT services. De voornaamste
+      onderdelen hiervan zijn datacenters en telecom. Hieronder kun je de groei en
+      efficiëntieverbeteringen van deze sector afzonderlijk instellen.
+    short_content_en: 
+    short_content_nl: 
 - id: 212
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2544,10 +4459,26 @@
   position: 10
   sidebar_item_id: 55
   output_element_id: 194
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "Demand response is a form of flexibility where energy demand is adjusted
+      or shifted in time. The goal is to reduce peaks in energy demand. With the sliders
+      in this section, you can adjust the charging behaviour of electric vehicles.
+      The chart shows the impact this has on the shape of the electricity demand curve.
+      \r\n<p>\r\nThe total set of electric vehicles can be set in the <a href=\"/scenario/demand/transport_passenger_transport/car-technology\"
+      >car technology section</a>."
+    content_nl: "Vraagsturing is een vorm van flexibiliteit waarbij de energievraag
+      wordt aangepast of verschoven in de tijd. Vaak is het doel hierbij om pieken
+      in de energievraag te voorkomen. Met de schuifjes in deze sectie kun je het
+      laadgedrag van elektrische auto's aanpassen. De grafiek toont de impact hiervan
+      op de vorm van de totale elektriciteitsvraag.\r\n<p>\r\nHet totale aandeel van
+      elektrische auto's is in te stellen in de <a href=\"/scenario/demand/transport_passenger_transport/car-technology\"
+      >technologie auto's sectie</a>."
+    short_content_en: 
+    short_content_nl: 
 - id: 214
-  image:
+  image: 
   created_at: !ruby/object:ActiveSupport::TimeWithZone
     utc: 2017-08-11 16:16:45.000000000 Z
     zone: *1
@@ -2556,17 +4487,30 @@
     utc: 2017-08-11 16:16:45.000000000 Z
     zone: *1
     time: 2017-08-11 18:16:45.000000000 Z
-  general_sub_header:
-  group_sub_header:
-  subheader_image:
+  general_sub_header: 
+  group_sub_header: 
+  subheader_image: 
   key: data_export_application_demands
   position: 2
   sidebar_item_id: 48
   output_element_id: 45
-  alt_output_element_id:
-  dependent_on:
+  alt_output_element_id: 
+  dependent_on: 
+  description:
+    content_en: |
+      Download information about the primary and final demands, and also the primary CO<sub>2</sub> emissions of applications (such as cooking, appliances, heating, transport, etc).
+      <ul class="data-download">
+        <li><a href="%{etengine_url}/api/v3/scenarios/%{scenario_id}/application_demands.csv"><span class="fa fa-download"></span> Application primary and final demands <span class="filetype">(40KB CSV)</span></a></li>
+      </ul>
+    content_nl: |
+      Download informatie over de primaire en finale vraag – en de primaire CO<sub>2</sub>-uitstoot – van toepassingen van energie (zoals koken, apparaten, ruimterverwarming en transport).
+      <ul class="data-download">
+        <li><a href="%{etengine_url}/api/v3/scenarios/%{scenario_id}/application_demands.csv"><span class="fa fa-download"></span> Primaire en finale vraag per toepassing <span class="filetype">(40KB CSV)</span></a></li>
+      </ul>
+    short_content_en: 
+    short_content_nl: 
 - id: 215
-  image:
+  image: 
   created_at: !ruby/object:ActiveSupport::TimeWithZone
     utc: 2017-08-11 16:16:45.000000000 Z
     zone: *1
@@ -2575,15 +4519,28 @@
     utc: 2017-08-11 16:16:45.000000000 Z
     zone: *1
     time: 2017-08-11 18:16:45.000000000 Z
-  general_sub_header:
-  group_sub_header:
-  subheader_image:
+  general_sub_header: 
+  group_sub_header: 
+  subheader_image: 
   key: data_export_production
   position: 3
   sidebar_item_id: 48
   output_element_id: 142
-  alt_output_element_id:
-  dependent_on:
+  alt_output_element_id: 
+  dependent_on: 
+  description:
+    content_en: |
+      Download details of heat and electricity producers. Includes information about the electrical and heat capacities, number of units, and costs.
+      <ul class="data-download">
+        <li><a href="%{etengine_url}/api/v3/scenarios/%{scenario_id}/production_parameters.csv"><span class="fa fa-download"></span> Production capacity and costs <span class="filetype">(15KB CSV)</span></a></li>
+      </ul>
+    content_nl: |
+      Download details over de technologieën die elektriciteit en warmte produceren. Bevat informatie over de elektrische en warmtecapaciteit, het aantal opgestelde eenheden en de kosten.
+      <ul class="data-download">
+        <li><a href="%{etengine_url}/api/v3/scenarios/%{scenario_id}/production_parameters.csv"><span class="fa fa-download"></span> Capaciteiten en kosten <span class="filetype">(15KB CSV)</span></a></li>
+      </ul>
+    short_content_en: 
+    short_content_nl: 
 - id: 216
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2601,8 +4558,33 @@
   position: 10
   sidebar_item_id: 55
   output_element_id: 194
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "In the ETM all heat pumps have the option to install a buffer for
+      space heating and a buffer for hot water. The default settings of these buffers
+      represent a common setup of heat pumps in households. However, in the future
+      these buffers might also be used to store larger amounts of heat. \r\n<br></br>\r\nThe
+      efficiency of (hybrid) heat pumps is dependent on the ambient temperature and
+      is depicted by the coefficient of performance (COP). When the COP is low it
+      can be desirable (for example for financial reasons) to only use the gas part
+      of the hybrid heat pump. The default threshold COP represents using the electric
+      part of the hybrid heat pump maximally for space heating and using gas for hot
+      water. The sliders below allow you to indicate the buffer size and the threshold
+      COP."
+    content_nl: "In het ETM hebben alle warmtepompen een optie voor een buffer voor
+      ruimteverwarming en een buffer voor warm water. Deze buffers zijn gemodelleerd
+      met een standaard warmtepompopstelling in huishoudens. Buffers kunnen in de
+      toekomst wellicht ook gebruikt worden om grotere hoeveelheden warmte op te slaan.
+      \r\n<br></br>\r\nDe efficiëntie van (hybride) warmtepompen is afhankelijk van
+      de buitentemperatuur en wordt aangegeven met de 'coefficient of performance'
+      (COP). Bij lage COP kan het (bijvoorbeeld om financiële redenen) wenselijk zijn
+      om alleen het gasgedeelte van hybride warmtepompen te gebruiken. De standaard
+      omslag-COP representeert dat voor ruimteverwarming het elektrisch deel van de
+      hybride warmtepomp maximaal wordt gebruikt en voor warm water het gasdeel.\r\n<br></br>\r\nMet
+      de schuifjes hieronder kun je de buffergrootte en de omslag-COP instellen."
+    short_content_en: 
+    short_content_nl: 
 - id: 218
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2620,8 +4602,23 @@
   position: 1
   sidebar_item_id: 48
   output_element_id: 123
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "The Energy Transition Model describes the energy flows through several\r\nhundred
+      uses and conversions; this CSV provides a list of each of\r\nthese flows (inputs
+      and outputs).\r\n<ul class=\"data-download\">\r\n  <li><a href=\"%{etengine_url}/api/v3/scenarios/%{scenario_id}/energy_flow.csv\"><span
+      class=\"fa fa-download\"></span> Energy flows <span class=\"filetype\">(375KB
+      CSV)</span></a></li>\r\n</ul>\r\n"
+    content_nl: "Het Energietransitiemodel beschrijft het energiesysteem als een verzameling
+      van honderden energie-omzetters (nodes) die verbonden zijn met energiestromen
+      (edges). \r\nDeze CSV geeft een lijst van alle energie-omzetters en de energiestromen
+      die daar ingaan en uitkomen (uitgesplitst naar drager).\r\n<ul class=\"data-download\">\r\n
+      \ <li><a href=\"%{etengine_url}/api/v3/scenarios/%{scenario_id}/energy_flow.csv\"><span
+      class=\"fa fa-download\"></span> Energiestromen <span class=\"filetype\">(375KB
+      CSV)</span></a></li>\r\n</ul>\r\n"
+    short_content_en: 
+    short_content_nl: 
 - id: 219
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2641,6 +4638,25 @@
   output_element_id: 209
   alt_output_element_id: 198
   dependent_on: ''
+  description:
+    content_en: Currently emissions from international transport are not included
+      in national energy statistics, since it is complex to decide to which country
+      they should be allocated. However, international aviation and navigation are
+      responsible for more than 4.5% of the global GHG emissions (<a href="https://ec.europa.eu/clima/policies/transport_en">EC
+      Climate Action</a>). Insight in the energy demand is needed in this sector in
+      order to take measures reducing their emissions. Therefore, in this model it
+      is possible to include international aviation and navigation to a desired percentage
+      by using the sliders below.
+    content_nl: Internationaal transport is op dit moment geen onderdeel van nationale
+      energiestatistieken, omdat het complex is om emissies hiervan toe te wijzen
+      aan een specifiek land. Internationale lucht- en scheepvaart zijn echter wel
+      verantwoordelijk voor meer dan 4.5% van de wereldwijde uitstoot van broeikasgassen
+      (<a href="https://ec.europa.eu/clima/policies/transport_en">EC Climate Action</a>).
+      Om emissiereductiemaatregelen te kunnen nemen is inzicht nodig in dit energiegebruik.
+      Daarom kun je hier kiezen welk percentage van de internationale lucht- en scheepvaart
+      je mee wilt laten tellen.
+    short_content_en: 
+    short_content_nl: 
 - id: 220
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2658,8 +4674,23 @@
   position: 5
   sidebar_item_id: 26
   output_element_id: 199
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "Will bio-kerosene contribute more to the aviation fuels mix in the
+      future? You can choose your blend of kerosene here. \r\n</br></br>\r\nIf you
+      have moments of excess electricity in your scenario, it is possible to use this
+      electricity to generate synthetic kerosene. This option can be chosen in the
+      <a href=\"/scenario/flexibility/flexibility_conversion/conversion-to-kerosene-for-aviation\"
+      > flexibility section</a>. "
+    content_nl: "Hoeveel zal bio-kerosene gebruikt worden in de toekomstige internationale
+      luchtvaart? Hier kan je het aandeel bepalen.\r\n</br></br>\r\nAls er in jouw
+      scenario elektriciteitsoverschotten zijn door de inzet van wind en/of zonne-energie,
+      dan kun je deze overschotten gebruiken om synthetische kerosine te produceren.
+      Dit kun je kiezen in <a href=\"/scenario/flexibility/flexibility_conversion/conversion-to-kerosene-for-aviation\"
+      > de flexibiliteitssectie</a>. "
+    short_content_en: 
+    short_content_nl: 
 - id: 221
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2679,6 +4710,18 @@
   output_element_id: 199
   alt_output_element_id: 190
   dependent_on: ''
+  description:
+    content_en: The transport fuels for international navigation depend directly on
+      the type of ship engines you choose. In the <a href="/scenario/demand/transport_international_transport/international-navigation-technology"
+      >international navigation section</a> you can select the engines (HFO or LNG)
+      your international ships will be equipped with. Note that use biofuels is not
+      yet possible for this sector.
+    content_nl: 'De brandstoffen voor internationale scheepvaart hangen direct af
+      van het type motor wat je voor deze schepen hebt gekozen. In de <a href="/scenario/demand/transport_international_transport/international-navigation-technology"
+      >internationale scheepvaart</a> kan je het type motor (HFO of LNG) kiezen. Merk
+      op dat het nog niet mogelijk is om biobrandstoffen in te zetten in deze sector. '
+    short_content_en: 
+    short_content_nl: 
 - id: 222
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2698,6 +4741,15 @@
   output_element_id: 209
   alt_output_element_id: 198
   dependent_on: ''
+  description:
+    content_en: International transportation has grown as a result of increasing globalisation.
+      Will this trend continue in the future? The growth rates that you indicate here
+      apply to the sector as a whole and are not influenced by the population growth.
+    content_nl: Internationaal transport is gegroeid als gevolg van globalisering.
+      Zal deze trend zich doorzetten? Het groeitempo dat je hier invult gaat over
+      de hele sector en hangt niet af van de bevolkingsgroei.
+    short_content_en: 
+    short_content_nl: 
 - id: 223
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2717,6 +4769,15 @@
   output_element_id: 198
   alt_output_element_id: 199
   dependent_on: ''
+  description:
+    content_en: Will ships owners hold on to conventional ships running on heavy fuel
+      oil (HFO) or will they make a transition to liquefied natural gas-fired (LNG)
+      ships for international navigation?
+    content_nl: Zullen schepen blijven varen op zware stookolie (heavy fuel oil =
+      HFO) of zullen ze overstappen op vloeibaar aardgas (LNG) voor internationaal
+      transport?
+    short_content_en: 
+    short_content_nl: 
 - id: 224
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2734,8 +4795,19 @@
   position: 3
   sidebar_item_id: 50
   output_element_id: 198
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: 'For international aviation primarily large aircrafts are used that
+      consume kerosene. Therefore, different aviation technologies cannot be chosen
+      here, but in the <a href="/scenario/supply/transport_fuels/international-aviation"
+      >fuels</a> section it is possible to choose the blend of kerosene for your planes. '
+    content_nl: Voor internationaal vliegverkeer worden vooral grote vliegtuigen ingezet
+      die kerosine gebruiken. Het is daarom niet mogelijk om hier alternatieve technologieën
+      te kiezen, maar je kunt wel het kerosinemengsel kiezen in de <a href="/scenario/supply/transport_fuels/international-aviation"
+      >brandstoffen </a>sectie.
+    short_content_en: 
+    short_content_nl: 
 - id: 225
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2755,6 +4827,31 @@
   output_element_id: 211
   alt_output_element_id: 200
   dependent_on: ''
+  description:
+    content_en: "Excess electricity can be used to produce synthetic kerosene for
+      aviation. For this process carbon is needed which can be recycled, for example
+      from flue gasses from industries or directly from the air. Hence the production
+      of synthetic kerosene brings about CO<sub>2</sub> reduction for the country
+      as a whole. However, it remains questionable to which sector within one country
+      this CO<sub>2</sub> reduction should be allocated in case CO or CO<sub>2</sub>
+      from flue gasses is used; to the industry or to the international transportation
+      sector?  \r\n<br/><br/> \r\nThe sliders below allow you to decide how much synthetic
+      kerosene should be produced. Any excess kerosene will be exported. Furthermore,
+      it is possible to choose the carbon source for the kerosene and allocate the
+      CO<sub>2</sub> reduction to either the industry or international transport sector.\r\n<br/><br/>"
+    content_nl: "Overschotten aan elektriciteit kunnen gebruikt worden om synthetische
+      kerosine te produceren voor de luchtvaart. Voor dit proces is koolstof nodig
+      wat kan worden hergebruikt, bijvoorbeeld uit rookgassen van industriën of direct
+      uit de lucht. Daardoor bewerkstelligt de productie van synthetische kerosene
+      een CO<sub>2</sub>-reductie voor het gehele land. Echter blijft het discutabel
+      aan welke sector binnen een land deze CO<sub>2</sub>-reductie moet worden toegeschreven
+      wanneer CO of CO<sub>2</sub> uit rookgassen wordt gebruikt: aan de industrie
+      of de internationale luchtvaart?\r\n<br/><br/>\r\nMet de onderstaande sliders
+      kan je aangeven hoeveel synthetische kerosine er moet worden geproduceerd. Overtollige
+      kerosine wordt geëxporteerd. Verder kun je ook kiezen welke koolstofbron je
+      nodig hebt en aan welke sector de CO<sub>2</sub>-reductie moet worden toegeschreven.\r\n<br/><br/>"
+    short_content_en: 
+    short_content_nl: 
 - id: 226
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2772,8 +4869,18 @@
   position: 6
   sidebar_item_id: 51
   output_element_id: 206
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: Nowadays most busses are powered by diesel or gas. What will happen
+      in the future? In the <a href="/scenario/supply/transport_fuels/road-transport"
+      >road fuels section</a> you can determine which fuel blends busses will use.
+    content_nl: 'Veruit de meeste bussen rijden vandaag de dag op diesel of gas. Hoe
+      zal dit veranderen in de toekomst? In de <a href="/scenario/supply/transport_fuels/road-transport"
+      >sectie wegverkeer brandstoffen</a> kun je bepalen op welke brandstofmix bussen
+      zullen rijden. '
+    short_content_en: 
+    short_content_nl: 
 - id: 227
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2791,8 +4898,13 @@
   position: 8
   sidebar_item_id: 51
   output_element_id: 204
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: E-bikes are upcoming; will this trend continue?
+    content_nl: E-bikes worden steeds meer gebruikt; zet deze trend door?
+    short_content_en: 
+    short_content_nl: 
 - id: 228
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2810,8 +4922,15 @@
   position: 7
   sidebar_item_id: 51
   output_element_id: 204
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: What will the share of gasoline and electric motorcycles and scooters
+      be in the future?
+    content_nl: Wat zal het aandeel van elektrische en benzinemotorfietsen zijn in
+      de toekomst? Ook scooters vallen onder deze categorie.
+    short_content_en: 
+    short_content_nl: 
 - id: 229
   image: truck.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2829,8 +4948,29 @@
   position: 11
   sidebar_item_id: 52
   output_element_id: 208
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "Will freight transport increase or decrease in the future? The growth
+      rate that you indicate here determines the future demand for 'freight tonne
+      kilometres', the total number of kilometres freight is shipped per year. This
+      number includes all freight transport applications (trucks, trains and ships).\r\n<br
+      /> <br />\r\nBesides growth rate you can choose the division of transport applications
+      here. What percentage of freight tonne kilometres is covered by trucks, by trains
+      and by inland ships?\r\n<br /> <br /> \r\nNote that international container
+      ships are part of the <a href=\"/scenario/demand/transport_international_transport/international-transport\">international
+      transport section</a>."
+    content_nl: "Zal vrachtvervoer toenemen of afnemen in de toekomst? De groeifactor
+      die je hier invoert, bepaalt onze toekomstige vraag naar 'ladingtonkilometers',
+      het totaal aantal transportkilometers van vracht per jaar. Dit getal omvat alle
+      vrachtvervoersmiddelen (vrachtwagens, goederentreinen en binnenvaartsschepen).\r\n\r\n<br
+      /> <br />\r\nNaast de groeifactor kun je hier de verdeling van vrachtvervoersmiddelen
+      bepalen. Hoeveel procent van de ladingtonkilometers wordt afgelegd door vrachtwagens,
+      hoeveel door goederentreinen en hoeveel door binnenvaartsschepen?\r\n\r\n<br
+      /> <br />\r\nLet op: containerschepen vallen onder de categorie <a href=\"/scenario/demand/transport_international_transport/international-transport\">'internationaal
+      transport'</a>."
+    short_content_en: 
+    short_content_nl: 
 - id: 230
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2848,8 +4988,20 @@
   position: 13
   sidebar_item_id: 52
   output_element_id: 207
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: Which train technologies will be mostly used? Electric trains are
+      cleaner and more efficient than diesel trains, but require more infrastructure
+      to run. In the <a href="/scenario/supply/transport_fuels/rail-transport" >train
+      fuels section</a> you can determine which fuels diesel trains will use.
+    content_nl: Welke trein-technologiën zullen voornamelijk gebruikt worden? Elektrische
+      treinen zijn schoner en efficiënter dan dieseltreinen, maar hebben wel meer
+      infrastructuur nodig om te kunnen rijden. In de <a href="/scenario/supply/transport_fuels/rail-transport"
+      > brandstoffensectie van treinen</a> kun je aangeven welke brandstoffen dieseltreinen
+      zullen gebruiken.
+    short_content_en: 
+    short_content_nl: 
 - id: 232
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2867,8 +5019,17 @@
   position: 1
   sidebar_item_id: 44
   output_element_id: 48
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: Excess electricity can temporarily be stored in for example household
+      batteries. Below, you can specify how much the investment costs of this technology
+      will change in the future.
+    content_nl: Overschotten aan elektriciteit kunnen tijdelijk worden opgeslagen
+      in bijvoorbeeld batterijen in huizen. Hieronder kun je aangeven hoeveel de investeringskosten
+      van deze technologie in de toekomst zullen veranderen.
+    short_content_en: 
+    short_content_nl: 
 - id: 233
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2886,8 +5047,18 @@
   position: 2
   sidebar_item_id: 44
   output_element_id: 48
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "(Excess) electricity can be converted to other energy carriers, like
+      hydrogen or heat. Below, you can specify how much the investment costs of these
+      conversion devices (like boilers and electrolysers) will change in the future."
+    content_nl: "(Overtollige) elektriciteit kan worden geconverteerd naar andere
+      energiedragers, zoals waterstof of warmte. Hieronder kun je aangeven hoeveel
+      de investeringskosten van deze conversie-apparaten (zoals boilers en elektrolysers)
+      in de toekomst zullen veranderen."
+    short_content_en: 
+    short_content_nl: 
 - id: 234
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2905,8 +5076,13 @@
   position: 5
   sidebar_item_id: 51
   output_element_id: 206
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: 'The ETM only models electric trams and metros. '
+    content_nl: Het ETM modelleert alleen elektrische trams en metro's.
+    short_content_en: 
+    short_content_nl: 
 - id: 235
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2924,8 +5100,23 @@
   position: 1
   sidebar_item_id: 3
   output_element_id: 201
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: In the side bar on the left you can click on <a href="/scenario/demand/transport_passenger_transport/applications">'Passenger
+      transport'</a>, <a href="/scenario/demand/transport_freight_transport/applications">'Freight
+      transport'</a> and <a href="/scenario/demand/transport_international_transport/international-transport">'International
+      transport'</a>. There you can specify how our transport demand will change in
+      the future, which means of transport we will use and which drive technologies
+      will prevail.
+    content_nl: In de zijbalk links kun je klikken op <a href="/scenario/demand/transport_passenger_transport/applications">'Passagiersvervoer'</a>,
+      <a href="/scenario/demand/transport_freight_transport/applications">'Vrachtvervoer'</a>
+      en <a href="/scenario/demand/transport_international_transport/international-transport">'Internationaal
+      transport'</a>. Daar kun je aangeven hoe onze transportvraag zal veranderen
+      in de toekomst, welke vervoersmiddelen we gaan gebruiken en welke aandrijftechnologieën
+      zullen domineren.
+    short_content_en: 
+    short_content_nl: 
 - id: 236
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2943,8 +5134,27 @@
   position: 1
   sidebar_item_id: 40
   output_element_id: 46
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "In some scenarios you will import electricity from outside your area.
+      The production and distribution of this electricity could have caused CO<sub>2</sub>
+      emissions elsewhere. How much of these emissions do you want to attribute to
+      your region? As a default, gram CO<sub>2</sub> per kWh of imported electricity
+      is set equal to the Dutch electricity mix, but you can change it yourself below.
+      For more information checkout the '?'.<br/><br/>\r\n\r\nThe costs related to
+      this imported electricity can be set in the <a href=\"/scenario/costs/electricity_import_costs/costs-of-imported-electricity\">
+      section of costs</a>."
+    content_nl: "In sommige scenario's is het nodig om elektriciteit te importeren
+      van buiten jouw gebied. De productie en distributie van deze elektriciteit kan
+      CO<sub>2</sub>-emissies hebben veroorzaakt. Hoeveel van deze emissies wil je
+      toekennen aan jouw gebied? Op dit moment is de gemiddelde elektriciteitsmix
+      van Nederland genomen als startwaarde. Je kunt dit zelf hieronder aanpassen.
+      Voor meer informatie klik op de '?' achter de slider.\r\n\r\n<br/><br/>\r\nDe
+      kosten voor geïmporteerde elektriciteit kunnen in de<a href=\"/scenario/costs/electricity_import_costs/costs-of-imported-electricity\">
+      sectie kosten</a> worden gezet."
+    short_content_en: 
+    short_content_nl: 
 - id: 237
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2960,10 +5170,15 @@
   subheader_image: ''
   key: flexibility_flexibility_power_to_methane
   position: 9
-  sidebar_item_id:
-  output_element_id:
-  alt_output_element_id:
+  sidebar_item_id: 
+  output_element_id: 
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: ''
+    content_nl: ''
+    short_content_en: 
+    short_content_nl: 
 - id: 238
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -2983,6 +5198,12 @@
   output_element_id: 171
   alt_output_element_id: 102
   dependent_on: ''
+  description:
+    content_en: What will be the costs of imported electricity in the future?
+    content_nl: Wat zijn volgens jou de kosten van geïmporteerde elektriciteit in
+      de toekomst?
+    short_content_en: 
+    short_content_nl: 
 - id: 239
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3000,8 +5221,23 @@
   position: 6
   sidebar_item_id: 23
   output_element_id: 99
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: Hydrogen power plants use hydrogen to generate electricity. As the
+      market share of volatile production technologies like solar and wind increases,
+      the importance of dispatchable power plants that can supply power at moments
+      without sun or wind also increases. Hydrogen power plants are flexible in their
+      output and can therefore play a role in balancing the sustainable energy system
+      of the future.
+    content_nl: Waterstofcentrales produceren elektriciteit uit waterstof. Bij een
+      stijgend martkaandeel van volatiele productietechnieken zoals zon en wind neemt
+      ook het belang toe van energiecentrales die stroom kunnen leveren op momenten
+      dat er weinig wind en zon is. Waterstofcentrales zijn flexibel inzetbaar en
+      kunnen daarmee een rol spelen in het balanceren van het duurzame energiesysteem
+      van de toekomst.
+    short_content_en: 
+    short_content_nl: 
 - id: 240
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3019,8 +5255,35 @@
   position: 3
   sidebar_item_id: 45
   output_element_id: 214
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "How will hydrogen be transported in the future? At the moment, two
+      distribution methods seem to be the most viable: compressed hydrogen transport
+      via pipelines and via trucks.\r\n<br/><br/>\r\nTransport via pipelines can be
+      relatively cheap, especially if distribution distances are long, the volume
+      of the distributed hydrogen is large and demand for hydrogen is concentrated.
+      Trucks, on the other hand, are much more flexible than pipelines. They are suitable
+      for delivering smaller quantities of hydrogen and for delivery to remote areas.\r\n<br/><br/>\r\nBelow,
+      you can choose the percentage of total hydrogen supply in your scenario that
+      is transported by pipelines and by trucks. The costs of both technologies can
+      be adjusted in the <a href=\"/scenario/costs/costs_hydrogen/hydrogen-transport\"
+      >costs section</a>."
+    content_nl: "Hoe zal waterstof getransporteerd worden in de toekomst? Op dit moment
+      lijken twee distributiemethodes het meest voor de hand te liggen: waterstof-onder-druk
+      via pijpleidingen en met vrachtwagens.\r\n<br/><br/>\r\nTransport via pijpleidingen
+      is relatief goedkoop, vooral als de distributie-afstanden langer zijn, het volume
+      van waterstof in je scenario groot is en als de vraag naar waterstof zich op
+      een geconcentreerd gebied bevindt (bijvoorbeeld een industrieterrein). Transport
+      via vrachtwagens is meer flexibel. Het gebruik van vrachtwagens ligt meer voor
+      de hand voor distributie van kleinere hoeveelheden waterstof of als de afnemers
+      over een groter gebied verspreid zijn. \r\n<br/><br/>\r\nHieronder kun je aangeven
+      hoeveel van het totale waterstofaanbod in je scenario via pijpleidingen getransporteerd
+      wordt en hoeveel via vrachtwagens. De kosten van beide technologieën kunnen
+      aangepast worden bij <a href=\"/scenario/costs/costs_hydrogen/hydrogen-transport\"
+      >kosten</a>."
+    short_content_en: 
+    short_content_nl: 
 - id: 242
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3038,10 +5301,34 @@
   position: 5
   sidebar_item_id: 45
   output_element_id: 46
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "In some scenarios hydrogen will be imported from outside your area.
+      This depends on how much hydrogen you chose to produce locally in the <a href=\"/scenario/supply/hydrogen/hydrogen-production\">'Hydrogen
+      production'</a> tab. The production and distribution of imported hydrogen could
+      have caused CO<sub>2</sub> emissions elsewhere. How much of these emissions
+      do you want to attribute to your region? As a default, the emissions (in kg
+      CO<sub>2</sub> per MWh hydrogen) are set equal to the emissions of hydrogen
+      produced with Steam Methane Reforming (SMR), since over 90% of hydrogen produced
+      today comes from SMR. However, you can change the emissions yourself below.
+      Click on the '?' for some reference values.<br/><br/>\r\n\r\nThe costs related
+      to this imported hydrogen can be set in the <a href=\"/scenario/costs/fuel_costs/combustion-fuel\">costs
+      section</a>.\r\n\r\n"
+    content_nl: "In sommige scenario's wordt er waterstof geïmporteerd van buiten
+      jouw gebied. Hoeveel waterstof er geïmporteerd wordt, hangt af van jouw keuzes
+      in het tabblad <a href=\"/scenario/supply/hydrogen/hydrogen-production\">'Waterstofproductie'</a>.
+      De productie en distributie van geïmporteerde waterstof kan CO<sub>2</sub>-emissies
+      hebben veroorzaakt. Hoeveel van deze emissies wil je toekennen aan jouw gebied?
+      De standaardwaarde (in kg CO<sub>2</sub> per MWh waterstof) staat op de hoeveelheid
+      emissies die vrijkomt bij waterstofproductie met Steam Methane Reforming (SMR),
+      omdat op dit moment meer dan 90% van de waterstof met deze methode wordt geproduceerd.
+      Je kunt dit zelf hieronder aanpassen. Klik op het vraagteken voor referentiewaarden.\r\n\r\n<br/><br/>\r\nDe
+      kosten voor geïmporteerde waterstof kunnen worden aangepast in de <a href=\"/scenario/costs/fuel_costs/combustion-fuel\">kostensectie</a>."
+    short_content_en: 
+    short_content_nl: 
 - id: 243
-  image:
+  image: 
   created_at: !ruby/object:ActiveSupport::TimeWithZone
     utc: 2018-04-18 11:19:45.000000000 Z
     zone: *1
@@ -3050,14 +5337,14 @@
     utc: 2018-04-18 11:19:45.000000000 Z
     zone: *1
     time: 2018-04-18 13:19:45.000000000 Z
-  general_sub_header:
-  group_sub_header:
-  subheader_image:
+  general_sub_header: 
+  group_sub_header: 
+  subheader_image: 
   key: costs_infrastructure_electricity
   position: 3
   sidebar_item_id: 28
   output_element_id: 61
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
 - id: 244
   image: ''
@@ -3075,9 +5362,14 @@
   key: costs_infrastructure_electricity_investement_regime
   position: 4
   sidebar_item_id: 28
-  output_element_id:
-  alt_output_element_id:
+  output_element_id: 
+  alt_output_element_id: 
   dependent_on: _always_hidden
+  description:
+    content_en: ''
+    content_nl: ''
+    short_content_en: 
+    short_content_nl: 
 - id: 245
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3095,8 +5387,16 @@
   position: 3
   sidebar_item_id: 18
   output_element_id: 48
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: has_detailed_chemical_industry
+  description:
+    content_en: 'What will CCS in industry cost on average? Note: this is an expert
+      function which shall be superseded by more detailed modelling soon.'
+    content_nl: 'Wat zullen de gemiddelde kosten van CCS in de industrie zijn? NB:
+      dit is een expert functie die op korte termijn vervangen zal worden door meer
+      gedetailleerde modellering.'
+    short_content_en: 
+    short_content_nl: 
 - id: 246
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3114,8 +5414,17 @@
   position: 1
   sidebar_item_id: 4
   output_element_id: 46
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: has_detailed_chemical_industry
+  description:
+    content_en: 'What percentage of direct CO2 emissions in industry will be captured
+      and stored? Note: this is an expert function which will be superseded by more
+      detailed modelling soon.'
+    content_nl: 'Welk percentage van de directe CO2 emissies van de industrie zal
+      worden afgevangen en opgeslagen? N.b.: dit is een expert functie die op korte
+      termijn vervangen zal worden door meer gedetailleerde modellering.'
+    short_content_en: 
+    short_content_nl: 
 - id: 248
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3133,8 +5442,25 @@
   position: 5
   sidebar_item_id: 48
   output_element_id: 196
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "Download information about demand and supply of (individual) heat
+      in households per hour (space heating and tap water); including deficits, buffering,
+      and time-shifting.\r\n<ul class=\"data-download\">\r\n  <li><a href=\"%{etengine_url}/api/v3/scenarios/%{scenario_id}/curves/household_heat.csv\"><span
+      class=\"fa fa-download\"></span> Household heat curves <span class=\"filetype\">(400KB
+      CSV)</span></a></li>\r\n</ul>\r\n"
+    content_nl: "Download informatie over de individuele warmtevraag en -productie
+      van huishoudens (ruimteverwarming en warm water). Het bestand laat op uurbasis
+      zien hoeveel warmte er gevraagd wordt, hoeveel warmte de geïnstalleerde technieken
+      leveren en of er sprake is van warmtebuffering, uitstel van warmtelevering of
+      tekorten. Dit kan het geval zijn als de gekozen verwarmingstechnieken onvoldoende
+      capaciteit hebben om op bepaalde momenten aan de vraag te voldoen.\r\n\r\n<ul
+      class=\"data-download\">\r\n  <li><a href=\"%{etengine_url}/api/v3/scenarios/%{scenario_id}/curves/household_heat.csv\"><span
+      class=\"fa fa-download\"></span> Warmteprofiel huishoudens <span class=\"filetype\">(400KB
+      CSV)</span></a></li>\r\n</ul>\r\n"
+    short_content_en: 
+    short_content_nl: 
 - id: 249
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3152,8 +5478,21 @@
   position: 1
   sidebar_item_id: 57
   output_element_id: 213
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "The scenario report is a printable description of the decisions you
+      made in your current scenario, progress made towards important goals, and includes
+      charts showing breakdowns of energy use, electricity production, and much more.\r\n\r\n<ul
+      class=\"data-download\">\r\n  <li><a href=\"/scenario/reports/auto\"><span class=\"fa
+      fa-book\"></span> View the report →</a></li>\r\n</ul>\r\n"
+    content_nl: "Het scenarioverslag beschrijft je scenario in woord en beeld. Het
+      bevat informatie over de behaalde doelen, toont uitsplitsingen van energiegebruik
+      en elektriciteitsproductie, wijst je op mogelijke inconsistenties en nog veel
+      meer.\r\n\r\n<ul class=\"data-download\">\r\n  <li><a href=\"/scenario/reports/auto\"><span
+      class=\"fa fa-book\"></span> Bekijk het verslag →</a></li>\r\n</ul>\r\n"
+    short_content_en: 
+    short_content_nl: 
 - id: 250
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3171,8 +5510,19 @@
   position: 2
   sidebar_item_id: 57
   output_element_id: 213
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "A printable A3 or A4 factsheet describing how energy is produced
+      and consumed in your scenario. Unfortunately, the factsheet is currently available
+      in Dutch only.\r\n\r\n<ul class=\"data-download\">\r\n  <li><a href=\"/scenarios/%{scenario_id}/factsheet\"><span
+      class=\"fa fa-newspaper-o\"></span> View the factsheet →</a></li>\r\n</ul>\r\n"
+    content_nl: "Een printklare A3 'factsheet' waarin de energie-mix voor zowel vraag
+      als aanbod wordt samengevat voor je scenario.\r\n\r\n<ul class=\"data-download\">\r\n
+      \ <li><a href=\"/scenarios/%{scenario_id}/factsheet\"><span class=\"fa fa-newspaper-o\"></span>
+      Bekijk de factsheet →</a></li>\r\n</ul>\r\n"
+    short_content_en: 
+    short_content_nl: 
 - id: 251
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3190,8 +5540,20 @@
   position: 4
   sidebar_item_id: 57
   output_element_id: 213
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "A detailed breakdown of energy flows throughout the Energy Transition
+      Model for your scenario. Recommended only for advanced users.\r\n\r\n<ul class=\"data-download\">\r\n
+      \ <li><a href=\"%{etengine_url}/data/%{scenario_id}/layout\" target=\"_blank\"><span
+      class=\"fa fa-object-group\"></span> View the graph →</a></li>\r\n</ul>\r\n"
+    content_nl: "Gedetailleerde en interactieve weergave van de energiestromen en
+      energie-omzetters van het Energietransitiemodel. Bedoeld voor gevorderde gebruikers.\r\n\r\n<ul
+      class=\"data-download\">\r\n  <li><a href=\"%{etengine_url}/data/%{scenario_id}/layout\"
+      target=\"_blank\"><span class=\"fa fa-object-group\"></span> Bekijk de energiegraaf
+      →</a></li>\r\n</ul>\r\n"
+    short_content_en: 
+    short_content_nl: 
 - id: 252
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3209,8 +5571,24 @@
   position: 3
   sidebar_item_id: 53
   output_element_id: 163
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: _always_hidden
+  description:
+    content_en: "Pumped storage provides a cheap way for large-scale storage of electricity.
+      Electricity can be used to pump water from the lower reservoir to a higher reservoir.
+      At times of high electricity demand electricity is generated by realising the
+      stored water through turbines.\r\n<br/><br/>\r\nIn the ETM pumped storage can
+      only be used with excess electricity and the stored energy will be provided
+      as soon as there is no more excess production."
+    content_nl: "Stuwmeren zijn een goedkope, grootschalige manier om elektriciteit
+      op te slaan. Elektriciteit wordt gebruikt om water omhoog te pompen van een
+      lager gelegen naar een hoger gelegen stuwmeer. Als de elektriciteitsvraag hoog
+      is kan het opgeslagen water via turbines ontsnappen waarmee elektriciteit wordt
+      opgewekt.\r\n<br/><br/>\r\nIn het ETM kunnen stuwmeren worden 'opgeladen' met
+      overschotten elektriciteit. Zodra er geen elektriciteitsoverschotten meer zijn
+      wordt de opgeslagen energie teruggeleverd aan het elektriciteitsnet."
+    short_content_en: 
+    short_content_nl: 
 - id: 253
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3228,8 +5606,13 @@
   position: 1
   sidebar_item_id: 58
   output_element_id: 228
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: What do you think imported hydrogen will cost in the future?
+    content_nl: Wat gaat geïmporteerde waterstof volgens jou kosten in de toekomst?
+    short_content_en: 
+    short_content_nl: 
 - id: 254
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3247,8 +5630,13 @@
   position: 2
   sidebar_item_id: 58
   output_element_id: 48
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: What do you think the costs for hydrogen storage will be in the future?
+    content_nl: Wat denk je dat de kosten van waterstofopslag zullen zijn in de toekomst?
+    short_content_en: 
+    short_content_nl: 
 - id: 255
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3266,8 +5654,15 @@
   position: 3
   sidebar_item_id: 58
   output_element_id: 48
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: What will the costs for different hydrogen transport technologies
+      be in the future?
+    content_nl: Wat zullen de kosten voor de verschillende waterstof transporttechnologieën
+      zijn in de toekomst?
+    short_content_en: 
+    short_content_nl: 
 - id: 256
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3285,8 +5680,28 @@
   position: 4
   sidebar_item_id: 45
   output_element_id: 227
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "The ETM calculates hydrogen demand and supply on an hourly-basis
+      which makes it possible to identify moments of excess hydrogen production and
+      shortages. The ETM ensures that hydrogen supply matches demand for every hour
+      per year in your scenario. It does so by automatically storing excess hydrogen
+      production in a buffer, drawing from this buffer at demand peaks and by importing/exporting
+      any shortage/excess of hydrogen. \r\n<br><br />\r\nThe storage volume that is
+      needed for that is shown in the chart on the right. The costs for storage can
+      be adjusted in the <a href=\"/scenario/costs/costs_hydrogen/hydrogen-storage\"
+      >costs section</a>."
+    content_nl: "Het ETM modelleert waterstofvraag en -aanbod op uurbasis. Het ETM
+      zorgt ervoor dat waterstofvraag en -aanbod met elkaar in balans zijn voor ieder
+      uur per jaar in jouw scenario. Het ETM slaat productieoverschotten automatisch
+      op in een buffer, gebruikt waterstof uit deze buffer tijdens vraagpieken en
+      importeert/exporteert eventuele tekorten/overschotten. \r\n<br><br />\r\nHet
+      opslagvolume dat daarvoor nodig is, is te zien in de grafiek hiernaast. De opslagkosten
+      kunnen worden aangepast bij <a href=\"/scenario/costs/costs_hydrogen/hydrogen-storage\"
+      >kosten</a>."
+    short_content_en: 
+    short_content_nl: 
 - id: 257
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3304,8 +5719,35 @@
   position: 2
   sidebar_item_id: 45
   output_element_id: 226
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "There is a growing interest in using hydrogen as energy carrier,
+      for instance for heat production, electricity production, transport fuel or
+      as a feedstock for the chemical industry. The ETM allows you to explore a future
+      hydrogen economy by allowing you to use hydrogen for:\r\n<ul>\r\n  <li><a href=\"/scenario/supply/electricity_renewable/hydrogen-plants\"
+      >electricity production</a></li>\r\n  <li>district heating for <a href=\"/scenario/demand/households/district-heating\">households</a>
+      and <a href=\"/scenario/demand/buildings/district-heating\">buildings</a></li>\r\n
+      \ <li>heat production in <a href=\"/scenario/demand/industry/refineries\">industry</a>
+      and <a href=\"/scenario/demand/agriculture/heat\">agriculture</a><br>\r\n  <li><a
+      href=\"/scenario/demand/industry/fertilizers\" >fertilizer production</a> (as
+      feedstock)</li>\r\n  <li>transport vehicles (<a href=\"/scenario/demand/transport_passenger_transport/car-technology\">cars</a>,
+      <a href=\"/scenario/demand/transport_passenger_transport/bus-technology\">busses</a>
+      and <a href=\"/scenario/demand/transport_freight_transport/truck-technology\">trucks</a>)</li></ul>"
+    content_nl: "Er is een groeiende interesse in het gebruik van waterstof als energiedrager,
+      bijvoorbeeld voor warmteproductie, elektriciteitsproductie, transportbrandstof
+      of als grondstof in de chemie. In het ETM kun je een toekomstige waterstofeconomie
+      verkennen door waterstof in te zetten voor:\r\n\r\n<ul>\r\n  <li><a href=\"/scenario/supply/electricity_renewable/hydrogen-plants\"
+      >elektricititeitsproductie</a></li>\r\n  <li>warmtenetten voor <a href=\"/scenario/demand/households/district-heating\">huishoudens</a>
+      en <a href=\"/scenario/demand/buildings/district-heating\">gebouwen</a></li>\r\n
+      \ <li>warmteproductie in <a href=\"/scenario/demand/industry/refineries\">industrie</a>
+      en <a href=\"/scenario/demand/agriculture/heat\">landbouw</a></li>\r\n  <li><a
+      href=\"/scenario/demand/industry/fertilizers\" >kunstmestproductie</a> (als
+      grondstof)</li>\r\n  <li>transport (<a href=\"/scenario/demand/transport_passenger_transport/car-technology\">auto's</a>,
+      <a href=\"/scenario/demand/transport_passenger_transport/bus-technology\">bussen</a>
+      en <a href=\"/scenario/demand/transport_freight_transport/truck-technology\">vrachtwagens</a>)</li></ul>"
+    short_content_en: 
+    short_content_nl: 
 - id: 258
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3323,8 +5765,24 @@
   position: 7
   sidebar_item_id: 48
   output_element_id: 226
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "Below you can download information about hydrogen demand, supply
+      and storage per hour in your scenario.\r\n\r\n<ul class=\"data-download\">\r\n
+      \ <li>\r\n    <a href=\"%{etengine_url}/api/v3/scenarios/%{scenario_id}/curves/hydrogen.csv\">\r\n
+      \     <span class=\"fa fa-download\"></span>\r\n      Hydrogen demand, production
+      and storage per hour\r\n      <span class=\"filetype\">(750KB CSV)</span>\r\n
+      \   </a>\r\n  </li>\r\n</ul>"
+    content_nl: "Het Energietransitiemodel rekent op uurbasis de vraag, productie
+      en opslag van waterstof uit. Hieronder kun je deze gegevens downloaden als CSV-bestand,
+      uitgesplitst naar technologie/sector.\r\n\r\n\r\n<ul class=\"data-download\">\r\n
+      \ <li>\r\n    <a href=\"%{etengine_url}/api/v3/scenarios/%{scenario_id}/curves/hydrogen.csv\">\r\n
+      \     <span class=\"fa fa-download\"></span>\r\n      Waterstofvraag, -productie
+      en -opslag per uur\r\n      <span class=\"filetype\">(750KB CSV)</span>\r\n
+      \   </a>\r\n  </li>\r\n</ul>"
+    short_content_en: 
+    short_content_nl: 
 - id: 259
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3342,8 +5800,36 @@
   position: 1
   sidebar_item_id: 47
   output_element_id: 242
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "Biomass can be used in different places throughout the model:\r\n<ul>\r\n
+      \ <li>as <a href=\"/scenario/supply/biomass/green-gas-in-gas-network\">green
+      gas</a> in the gas network</li>\r\n  <li>in biomass heaters for <a href=\"/scenario/supply/renewable_heat/biomass\">(local)
+      heat networks</a></li>\r\n  <li>as <a href=\"/scenario/supply/transport_fuels/road-transport\">transport
+      fuel</a>: bio-ethanol, biodiesel, bio-LNG and biokerosene</li>\r\n  <li>as co-firing
+      in <a href=\"/scenario/supply/electricity/coal-plants\" >coal plants</a></li>\r\n
+      \ <li>as <a href=\"/scenario/supply/biomass/biocoal-en-bio-oil-in-energy-plants\">biocoal
+      or bio-oil</a> in power plants</li>\r\n  <li>to produce <a href=\"/scenario/supply/hydrogen/hydrogen-production\">hydrogen</a>
+      through gasification</li>\r\n</ul>\r\n</br>\r\nBiomass is often grown at the
+      expense of food crops. Careful consideration is required when using large amounts
+      of biomass. The data used for biomass in the ETM can be found in our <a href=\"https://github.com/quintel/documentation/blob/master/general/biomass.md\"
+      target=\"_blank\">documentation</a>."
+    content_nl: "Biomassa kan op verschillende plekken in het model worden ingezet:\r\n<ul>\r\n
+      \ <li>als <a href=\"/scenario/supply/biomass/green-gas-in-gas-network\">groengas</a>
+      in het gas netwerk</li>\r\n  <li>in biomassaketels voor <a href=\"/scenario/supply/renewable_heat/biomass\">(lokale)
+      warmtenetten</a></li>\r\n  <li>als <a href=\"/scenario/supply/transport_fuels/road-transport\">transportbrandstof</a>:
+      bio-ethanol, biodiesel, bio-LNG and biokerosine</li>\r\n  <li>als meestook in
+      <a href=\"/scenario/supply/electricity/coal-plants\" >kolencentrales</a></li>\r\n
+      \ <li>als <a href=\"/scenario/supply/biomass/biocoal-en-bio-oil-in-energy-plants\">biokolen
+      of bio-olie</a> in energiecentrales</li>\r\n  <li>voor <a href=\"/scenario/supply/hydrogen/hydrogen-production\">waterstofproductie</a>
+      d.m.v. vergassing</li>\r\n</ul>\r\n</br>\r\nDe inzet van biomassa kan ten koste
+      gaan van de productie van voedsel of bossen. Zorgvuldigheid bij de inzet van
+      grote hoeveelheden biomassa is noodzakelijk. De data achter de biomassa-modellering
+      in het ETM vind je in onze <a href=\"https://github.com/quintel/documentation/blob/master/general/biomass.md\"
+      target=\"_blank\">documentatie</a>."
+    short_content_en: 
+    short_content_nl: 
 - id: 260
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3361,8 +5847,17 @@
   position: 6
   sidebar_item_id: 47
   output_element_id: 168
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: _always_hidden
+  description:
+    content_en: What is the future biomass footprint of this region? The chart shown
+      on the right shows how much arable land you would need to cover this region's
+      biomass demand.
+    content_nl: Wat is de 'biomassavoetafdruk' van deze regio? De grafiek hiernaast
+      toont het landoppervlakte die je nodig zou hebben voor het biomassagebruik in
+      jouw scenario.
+    short_content_en: 
+    short_content_nl: 
 - id: 263
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3380,8 +5875,15 @@
   position: 1
   sidebar_item_id: 36
   output_element_id: 254
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: What do you think the costs for heat network infrastructure will be
+      in the future?
+    content_nl: Wat denk je dat de kosten van warmtenetinfrastructuur zullen zijn
+      in de toekomst?
+    short_content_en: 
+    short_content_nl: 
 - id: 264
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3399,8 +5901,15 @@
   position: 4
   sidebar_item_id: 36
   output_element_id: 48
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: What would the costs of residual heat from industry and imported heat
+      be in the future?
+    content_nl: Wat zijn volgens jou de toekomstige kosten van industriële restwarmte
+      en geïmporteerde warmte?
+    short_content_en: 
+    short_content_nl: 
 - id: 265
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3418,8 +5927,74 @@
   position: 1
   sidebar_item_id: 59
   output_element_id: 241
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "The ETM helps you explore future energy scenarios for a region of
+      your choice. The model is easy to use.\r\n<ol>\r\n<li>Before you start, think
+      about the goal of your scenario, then you know what to focus on.</li>\r\n<li>The
+      menu on the left displays all sectors that either use (<a href=\"/scenario/demand/households/population-housing-stock\"
+      >Demand</a>) or produce energy (<a href=\"/scenario/supply/electricity/coal-plants\"
+      >Supply</a>). For each sector you can use sliders to indicate what you think
+      the future will be like. You can easily undo your changes by resetting your
+      slider, so just play around! For example you can start with <a href=\"/scenario/demand/households/space-heating-hot-water\"
+      >space heating in households</a> or explore <a href=\"/scenario/demand/transport/overview\"
+      >transport and mobility</a>.</li>\r\n<li>Optional: Advanced users can use the
+      <a href=\"/scenario/flexibility/excess_electricity/order-of-flexibility-options\"
+      >Flexibility</a> section to match demand and supply and the <a href=\"/scenario/costs/merit_order/merit-order\"
+      >Costs</a> section for cost assumptions.</li>\r\n<li>You can test your ideas
+      by taking a look at the scenario report under the header '<a href=\"/scenario/data/data_visuals/scenario-report\"
+      >Results</a>'. You can always return to a certain part of the model to make
+      more changes.</li>\r\n<li>You can share your scenario with others by saving
+      your scenario: go to 'Settings -> Save scenario' (top right). <br /><i>Please
+      note: The ETM is updated periodically. Save your scenario to ensure that outcomes
+      stay stable over time!</i></li>\r\n</ol>\r\n</br>\r\nThe ETM will immediately
+      show you the impact of your choices: on the right, charts display specific information
+      for each section of the model. At the bottom of your screen, indicators show
+      the impact on the entire system (e.g. CO<sub>2</sub> reduction, energy savings,
+      costs etc.). If you lock the chart it will remain visible as you navigate through
+      the model. You can add charts by clicking \"see more charts\" (top right). \r\n</br></br>\r\nYou
+      are in the driver's seat. The ETM contains no hidden assumptions, like price
+      or technology developments over time etc. If you do nothing, the future will
+      not change.\r\n</br></br>\r\nDo you have questions or need help? Please, feel
+      free to contact <a href=\"https://quintel.com/contact\" >Quintel</a>, the developers
+      of the Energy Transition Model."
+    content_nl: "Het Energietransitiemodel (ETM) biedt ondersteuning in het verkennen
+      van de (on)mogelijkheden voor een regio van jouw keuze. Het model werkt eenvoudig.
+      Onderstaande stappen helpen je bij het opstellen van een scenario:\r\n<ol>\r\n<li>Bedenk
+      voordat je start wat het doel is van jouw scenario, zodat je weet wat je te
+      doen staat.</li>\r\n<li>In het menu aan de linkerkant staan alle sectoren waar
+      energie wordt gebruikt (<a href=\"/scenario/demand/households/population-housing-stock\"
+      >Vraag</a>) en geproduceerd (<a href=\"/scenario/supply/electricity/coal-plants\"
+      >Aanbod</a>). Per sector kun je met schuifjes aangeven hoe je denkt dat de toekomst
+      eruit gaat zien. Een verandering kan altijd weer ongedaan gemaakt worden door
+      het schuifje te resetten, dus probeer vooral uit! Begin bijvoorbeeld eens met
+      de <a href=\"/scenario/demand/households/space-heating-hot-water\" >warmtevoorziening
+      in huishoudens</a> of de impact van <a href=\"/scenario/demand/transport/overview\"
+      >vervoer</a>.</li>\r\n<li>Optioneel: gevorderde gebruikers kunnen aanpassingen
+      doen in <a href=\"/scenario/flexibility/excess_electricity/order-of-flexibility-options\"
+      >flexibiliteit</a> (matchen van vraag en aanbod van uur tot uur) en <a href=\"/scenario/costs/merit_order/merit-order\"
+      >kostenontwikkelingen</a>.</li>\r\n<li>Je kunt jouw ideeën toetsen door het
+      scenario rapport te bekijken onder het kopje <a href=\"/scenario/data/data_visuals/scenario-report\"
+      >Resultaten</a>. Je kunt vervolgens altijd terugkeren naar een bepaald onderdeel
+      om nog aanpassingen te doen.</li>\r\n<li>Deel je scenario vooral ook met anderen
+      door hem op te slaan onder 'Opties -> Scenario opslaan als' (rechtsboven) en
+      de link de delen.<br /><i>Let op: Het ETM wordt periodiek bijgewerkt en verbeterd.
+      Sla je scenario op om ervoor te zorgen dat de uitkomsten stabiel blijven!</i></li>\r\n</ol>\r\n</br>\r\nHet
+      model laat direct zien wat de impact van nieuwe instellingen is: aan de rechterkant
+      zie je grafieken met specifieke informatie over het onderdeel waar je je bevindt,
+      onderaan tonen tellertjes de veranderingen voor het hele systeem (CO<sub>2</sub>-reductie,
+      energiebesparing, kosten etc.). Als je de grafiek in beeld wilt houden terwijl
+      je door het model beweegt, kan je deze vastzetten met het slotje. Klik op \"meer
+      grafieken bekijken\" (rechtsboven) om extra grafieken toe te voegen. \r\n</br></br>\r\nIn
+      het model zitten geen verborgen aannames, zoals ontwikkelcurves van prijzen
+      en technologieën. De gebruiker zit helemaal zelf achter het stuur: je kan (vrijwel)
+      alles instellen en als je geen schuifje aanraakt, ziet de toekomst er net zo
+      uit als het heden.\r\n</br></br>\r\nHeb je vragen of hulp nodig? Neem dan contact
+      op met <a href=\"https://quintel.com/contact\" >Quintel</a>, de makers van het
+      Energietransitiemodel."
+    short_content_en: 
+    short_content_nl: 
 - id: 266
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3437,8 +6012,35 @@
   position: 3
   sidebar_item_id: 59
   output_element_id: 240
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "How much energy is used by the different sectors in your region and
+      what is the impact of adjustments to the energy system?\r\n</br> </br>\r\nThe
+      chart on the right gives you an overview of the total <em>energetic</em> energy
+      demand per sector (excl. feedstocks). Which sector is the biggest consumer of
+      energy? That sector might be a good place to start your scenario; go to \"Demand\"
+      and select that sector.\r\n</br> </br>\r\nWithout any adjustments, the energy
+      demand remains virtually the same, because no assumptions have yet been made
+      about the future. The fact that there is a slight difference in energy use between
+      the future and the present at the start, can be attributed to the use of the
+      electricity market module: it is not used in the current year and is used in
+      the future year (the <a href =\"/scenario/costs/merit_order/merit-order\">merit
+      order section </a> has more information about the electricity market module)."
+    content_nl: "Hoeveel energie wordt er gebruikt door de verschillende sectoren
+      in jouw regio  en wat is de impact van aanpassingen aan het energiesysteem?
+      \r\n</br></br>\r\nDe grafiek rechts geeft je een overzicht van de totale <em>energetische</em>
+      energievraag per sector (excl. grondstoffen). Welke sector gebruikt het meeste
+      energie? Wellicht is dat de sector waar je zou willen starten met verkennen
+      in de 'Vraag'-sectie.\r\n</br></br>\r\nAls je nog geen schuifje hebt aangeraakt,
+      zie je dat de energievraag nagenoeg gelijkt blijft, omdat er nog geen aannames
+      zijn gedaan over de toekomst. Dat er ook zonder aanpassingen een gering verschil
+      is in energiegebruik tussen toekomst en heden is toe te schrijven aan het gebruik
+      van de elektriciteitsmarktsmodule: deze wordt namelijk niet gebruikt in het
+      huidige jaar en wel in het toekomstige jaar (de <a href=\"/scenario/costs/merit_order/merit-order\"
+      >merit order pagina</a> bevat meer informatie over de elektriciteitsmarkt)."
+    short_content_en: 
+    short_content_nl: 
 - id: 267
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3456,8 +6058,30 @@
   position: 2
   sidebar_item_id: 59
   output_element_id: 46
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "How much CO<sub>2</sub> is currently emitted by the various sectors
+      in your region and what is the impact of adjustments to the energy system?\r\n</br></br>\r\nThe
+      chart on the right shows the total <em>energetic</em> CO<sub>2</sub>-emissions
+      for three different years: the reference year 1990, the year we use for the
+      present situation and the year of your scenario. Do you prefer to see the values
+      of the chart in a table? Click on the table icon at the top right of the chart.\r\n</br></br>\r\nThe
+      percentage of CO<sub>2</sub>-reduction with respect to 1990 remains visible
+      in the bar at the bottom as you navigate through the ETM. You can re-visit the
+      chart on the right at any time by clicking on this number at the bottom. "
+    content_nl: "Hoeveel CO<sub>2</sub> wordt er op dit moment uitgestoten door de
+      verschillende sectoren in jouw regio en wat is de impact van aanpassingen aan
+      het energiesysteem? \r\n</br></br>\r\nIn de grafiek rechts zie je de totale
+      <em>energetische</em> CO<sub>2</sub>-uitstoot voor drie verschillende jaren:
+      het referentiejaar 1990, het jaar waar we nu gegevens over hebben en het toekomstjaar
+      van jouw scenario. Zie je de waardes van de grafiek liever in een tabel? Klik
+      dan rechtsbovenaan in de grafiek op het tabel-icoontje.\r\n</br></br>\r\nHet
+      percentage CO<sub>2</sub>-reductie ten opzichte van 1990 blijft zichtbaar in
+      de balk onderaan terwijl je door het ETM navigeert. Je kunt de grafiek rechts
+      altijd oproepen door op dit getal onderaan te klikken."
+    short_content_en: 
+    short_content_nl: 
 - id: 268
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3475,8 +6099,36 @@
   position: 3
   sidebar_item_id: 47
   output_element_id: 242
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "How will green gas be produced in the future? Currently fermentation
+      is the dominant production technology. In the future, gasification may become
+      an important technology as well. Below you can specify the future market shares
+      of green gas production technologies. \r\n<br /><br />\r\nCaution: The costs
+      of green gas do not change automatically when altering the green gas production
+      mix. This is because the price of green gas is not fully determined by its production
+      costs. Green gas is a scarce resource, which means that its market price may
+      be well above (levelised) production costs. In the costs section you can change
+      the <a href=\"/scenario/costs/fuel_costs/biofuels\">price of green gas</a> and
+      see how this price relates to the average production costs. Also note that the
+      production costs of green gas are not optimized, mainly for the gasification
+      technologies. Since the technologies are fairly new; there are not many practical
+      examples on which the costs can be based.\r\n<br /><br />"
+    content_nl: "Op dit moment wordt in Nederland nagenoeg al het groengas geproduceerd
+      middels vergisting. Welke rol zal vergassing spelen in de toekomst? Hieronder
+      kun je de productiemix van groengas aanpassen.\r\n<br /><br />\r\nLet op: De
+      kosten van groengas veranderen niet automatisch mee als je de productiemix aanpast.
+      Dit is omdat de prijs van groengas niet alleen bepaald wordt door de productiekosten.
+      Groengas is een schaars goed waardoor de prijs (flink) hoger kan liggen. In
+      de kostensectie kun je de <a href=\"/scenario/costs/fuel_costs/biofuels\">prijs
+      van groengas</a> aanpassen en zien hoe deze prijs zich verhoudt tot de gemiddelde
+      productiekosten. Let er ook op dat de productiekosten van groengas nog niet
+      geoptimaliseerd zijn, met name voor de vergassingstechnologieën. Deze technologieën
+      zijn namelijk redelijk nieuw, dus er zijn minder praktische voorbeelden om de
+      kosten op te baseren.\r\n<br /><br />"
+    short_content_en: 
+    short_content_nl: 
 - id: 269
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3494,8 +6146,15 @@
   position: 2
   sidebar_item_id: 37
   output_element_id: 244
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: 'What do you think these biofuels will cost in the future? Note: choices
+      made here may impact the electricity merit order. '
+    content_nl: 'Wat zullen biobrandstoffen volgens jou kosten in de toekomst? Let
+      op: onderstaande brandstofprijzen hebben invloed op de merit order van elektriciteit.'
+    short_content_en: 
+    short_content_nl: 
 - id: 270
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3513,8 +6172,23 @@
   position: 2
   sidebar_item_id: 47
   output_element_id: 243
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: 'The ETM distinguishes four resource categories: wet, dry, oil-containing
+      biomass and biogenic waste. How much biomass will be available within your region
+      in the future? We have made estimations based on national potentials (for more
+      information see our <a href="https://github.com/quintel/documentation/blob/master/general/biomass.md"
+      target="_blank">documentation</a>). When you would like to adjust the potential,
+      you can do that here.'
+    content_nl: 'Het ETM maakt onderscheid tussen vier grondstofcategorieën: natte,
+      droge, oliehoudende biomassa en biogeen afval. Hoeveel grondstoffen zullen er
+      in de toekomst beschikbaar zijn binnen jouw regio? Wij hebben inschattingen
+      gemaakt o.b.v. nationale potenties, zie hiervoor onze <a href="https://github.com/quintel/documentation/blob/master/general/biomass.md"
+      target="_blank">documentatie</a>. Indien je de potenties wil aanpassen, kan
+      je dat hier doen.'
+    short_content_en: 
+    short_content_nl: 
 - id: 271
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3532,8 +6206,24 @@
   position: 6
   sidebar_item_id: 48
   output_element_id: 245
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "Below you can download information about network gas demand, supply
+      and storage per hour in your scenario.\r\n\r\n<ul class=\"data-download\">\r\n
+      \ <li>\r\n    <a href=\"%{etengine_url}/api/v3/scenarios/%{scenario_id}/curves/network_gas.csv\">\r\n
+      \     <span class=\"fa fa-download\"></span>\r\n      Network gas demand, production
+      and storage per hour\r\n      <span class=\"filetype\">(3MB CSV)</span>\r\n
+      \   </a>\r\n  </li>\r\n</ul>"
+    content_nl: "Het Energietransitiemodel rekent op uurbasis de vraag, productie
+      en opslag van netwerkgas uit. Hieronder kun je deze gegevens downloaden als
+      CSV-bestand, uitgesplitst naar technologie/sector.\r\n\r\n<ul class=\"data-download\">\r\n
+      \ <li>\r\n    <a href=\"%{etengine_url}/api/v3/scenarios/%{scenario_id}/curves/network_gas.csv\">\r\n
+      \     <span class=\"fa fa-download\"></span>\r\n      Netwerkgasvraag, -productie
+      en -opslag per uur\r\n      <span class=\"filetype\">(3MB CSV)</span>\r\n    </a>\r\n
+      \ </li>\r\n</ul>"
+    short_content_en: 
+    short_content_nl: 
 - id: 272
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3551,8 +6241,26 @@
   position: 3
   sidebar_item_id: 54
   output_element_id: 163
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "At times of excess electricity supply, an electric boiler in industry
+      could convert excess electricity into heat. This in turn lowers the gas and
+      hydrogen demands (if present). This hybrid heating option can be used in these
+      industry sub sectors: \r\n<ul>\r\n  <li><a href=\"/scenario/demand/industry/refineries\"
+      >refineries</a></li>\r\n  <li><a href=\"/scenario/demand/industry/chemicals\">chemical
+      industry</a></li>\r\n  <li><a href=\"/scenario/demand/industry/food\">food industry</a></li>\r\n
+      \ <li><a href=\"/scenario/demand/industry/paper\">paper industry</a></li></ul>"
+    content_nl: "Wanneer er elektriciteitsoverschotten zijn, kunnen elektrische boilers
+      in de industrie deze overschotten omzetten in warmte. Dit heeft als gevolg dat
+      de vraag naar gas en waterstof wordt verlaagd (indien aanwezig). Deze hybride
+      warmte opties kunnen in de vraag-sectie van volgende industriële sectoren worden
+      ingesteld:\r\n<ul>\r\n  <li><a href=\"/scenario/demand/industry/refineries\"
+      >raffinaderijen</a></li>\r\n  <li><a href=\"/scenario/demand/industry/chemicals\">chemische
+      industrie</a></li>\r\n  <li><a href=\"/scenario/demand/industry/food\">voedingsmiddelenindustrie</a></li>\r\n
+      \ <li><a href=\"/scenario/demand/industry/paper\">papierindustrie</a></li></ul>"
+    short_content_en: 
+    short_content_nl: 
 - id: 273
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3570,8 +6278,19 @@
   position: 3
   sidebar_item_id: 57
   output_element_id: 213
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "A printable sheet depicting the CO<sub>2</sub> footprint for your
+      scenario.\r\n  <ul class=\"data-download\">\r\n    <li><a href=\"%{api_url}/regions/%{area_code}?time=future&scenario=%{scenario_id}\"
+      target=\"_blank\"><span class=\"fa fa-newspaper-o\"></span> View the sheet →</a></li>\r\n
+      \ </ul>\r\n"
+    content_nl: "Een printklare sheet met een visuele samenvatting van de CO<sub>2</sub>-voetafdruk
+      voor jouw scenario.\r\n<ul class=\"data-download\">\r\n  <li><a href=\"%{api_url}/regions/%{area_code}?time=future&scenario=%{scenario_id}\"
+      target=\"_blank\"><span class=\"fa fa-newspaper-o\"></span> Bekijk de sheet
+      →</a></li>\r\n</ul>\r\n"
+    short_content_en: 
+    short_content_nl: 
 - id: 274
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3589,8 +6308,22 @@
   position: 1
   sidebar_item_id: 61
   output_element_id: 48
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: 'With the sliders below you can adjust the future WACC for different
+      categories. Note: this is the real WACC, so corrected for inflation. The ETM
+      does not take inflation into account. The sources used to determine the current
+      WACC percentages can be found on our <a href="https://github.com/quintel/documentation/blob/master/general/cost_calculations.md"
+      target ="_blank">documentation</a>.'
+    content_nl: 'Met onderstaande sliders kun je de toekomstige WACC (gewogen kapitaalskosten)
+      voor verschillende categorieën aanpassen. Let op: het gaat hier om de reële
+      WACC, dus exclusief inflatie. Het ETM rekent namelijk niet met inflatie. De
+      bronnen die gebruikt zijn voor de huidige percentages zijn te vinden op onze
+      <a href="https://github.com/quintel/documentation/blob/master/general/cost_calculations.md"
+      target ="_blank">documentatie</a>.'
+    short_content_en: 
+    short_content_nl: 
 - id: 275
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3608,10 +6341,35 @@
   position: 4
   sidebar_item_id: 62
   output_element_id: 253
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "The ETM makes a distinction between 'must-run' / volatile heat sources
+      (such as geothermal, solar thermal and residual heat) and dispatchable heat
+      sources. In contrast to the first category, dispatchable heat sources can be
+      turned on or off at will. The ETM calculates for every hour per year how much
+      heat from must-run and volatile sources is available. If heat demand exceeds
+      this supply in a given hour, dispatchable heat sources will be switched on to
+      ensure that no deficit occurs.\r\n<br /><br />\r\nBelow it is possible to change
+      the (merit) order of dispatchable heat sources: which heat source is switched
+      on first in case of a heat deficit? The chart to the right shows the marginal
+      costs of each dispatchable source."
+    content_nl: "Het ETM maakt een onderscheid tussen 'must-run' / volatiele warmtebronnen
+      (zoals geothermie, zonthermie en industriële restwarmte) en regelbare warmtebronnen.
+      De warmteproductie van de eerste categorie bronnen is moeilijk regelbaar, zonthermieproductie
+      is bijvoorbeeld afhankelijk van het weer. Regelbare bronnen daarentegen kunnen
+      aan- en uitgeschakeld worden op momenten dat dat nodig is. Het ETM kijkt voor
+      elk uur per jaar hoeveel warmte er uit 'must-run' en volatiele bronnen beschikbaar
+      is. Als de vraag in een bepaald uur hoger is dan deze productie, wordt er een
+      regelbare bron ingeschakeld om te zorgen dat er voldoende warmte is.\r\n<br
+      /><br />\r\nHieronder is het mogelijk om de inzetvolgorde van de regelbare warmtebronnen
+      in te stellen: welke bron springt er als eerste aan als er een warmtetekort
+      is? In de grafiek hiernaast kun je zien hoe hoog de marginale kosten zijn van
+      de verschillende regelbare bronnen."
+    short_content_en: 
+    short_content_nl: 
 - id: 276
-  image:
+  image: 
   created_at: !ruby/object:ActiveSupport::TimeWithZone
     utc: 2019-12-20 10:54:31.000000000 Z
     zone: *1
@@ -3620,15 +6378,44 @@
     utc: 2019-12-20 10:54:31.000000000 Z
     zone: *1
     time: 2019-12-20 11:54:31.000000000 Z
-  general_sub_header:
-  group_sub_header:
-  subheader_image:
+  general_sub_header: 
+  group_sub_header: 
+  subheader_image: 
   key: data_export_heat_network
   position: 8
   sidebar_item_id: 48
   output_element_id: 249
-  alt_output_element_id:
-  dependent_on:
+  alt_output_element_id: 
+  dependent_on: 
+  description:
+    content_en: |
+      Download information about the hourly demands and supplies of heat
+      through the central heat network for households, buildings and agriculture.
+
+      <ul class="data-download">
+        <li>
+          <a href="%{etengine_url}/api/v3/scenarios/%{scenario_id}/curves/heat_network.csv">
+            <span class="fa fa-download"></span>
+            Heat network curves
+            <span class="filetype">(1.5MB CSV)</span>
+          </a>
+        </li>
+      </ul>
+    content_nl: |
+      Download informatie over de uurlijkse vraag en productie van collectieve
+      warmte voor warmtenetten in huishoudens, gebouwen en landbouw.
+
+      <ul class="data-download">
+        <li>
+          <a href="%{etengine_url}/api/v3/scenarios/%{scenario_id}/curves/heat_network.csv">
+            <span class="fa fa-download"></span>
+            Warmtenetcurves
+            <span class="filetype">(1.5MB CSV)</span>
+          </a>
+        </li>
+      </ul>
+    short_content_en: 
+    short_content_nl: 
 - id: 277
   image: house_direct_heating.gif
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3646,8 +6433,45 @@
   position: 1
   sidebar_item_id: 24
   output_element_id: 248
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "District heating can be used as heating technology in <a href=\"/scenario/demand/households/space-heating-hot-water\"
+      >households</a>, <a href=\"/scenario/demand/buildings/space-heating\" >buildings</a>
+      and <a href=\"/scenario/demand/agriculture/heat\" >agriculture</a>. There are
+      roughly two types of heat sources: dispatchable and must-run heat sources. Dispatchable
+      heat sources can be switched on/ off depending on the heat demand at that time,
+      while must-run heat sources supply the heat network regardless of heat demand.
+      For the second type in particular <a href=\"/scenario/supply/heat/seasonal-storage-of-heat\"
+      >(seasonal) storage of heat</a> is an interesting option.\r\n<br /><br />\r\nBelow
+      you can find several technologies for both types of heat sources. The chart
+      on the right shows whether demand and supply add up. In addition, it is possible
+      to use residual heat from (large-scale) power plants in the power sector. This
+      can be done in the 'Electricity' and 'Renewable Electricity' side bar items
+      for the following power plants: <a href=\"/scenario/supply/electricity/gas-plants\"
+      >(Natural) gas plants</a>, <a href=\"/scenario/supply/electricity/coal-plants\"
+      >Coal plants</a>, <a href=\"/scenario/supply/electricity_renewable/biomass-plants\"
+      >Biomass plants</a> and <a href=\"/scenario/supply/electricity_renewable/waste-power\"
+      >Waste incineration</a>"
+    content_nl: "Warmtenetten kunnen worden ingezet als verwarmingstechnologie in
+      <a href=\"/scenario/demand/households/space-heating-hot-water\" >huishoudens</a>,
+      <a href=\"/scenario/demand/buildings/space-heating\" >gebouwen</a> en <a href=\"/scenario/demand/agriculture/heat\"
+      >landbouw</a>. Er bestaan grofweg twee soorten warmtebronnen voor warmtenetten:
+      regelbare en niet-regelbare warmtebronnen. Regelbare warmtebronnen kunnen aan/uit
+      worden gezet afhankelijk van de warmtevraag op dat moment, terwijl niet-regelbare
+      warmtebronnen het warmtenet beleveren ongeacht de warmtevraag. Met name voor
+      het laatste type bronnen is <a href=\"/scenario/supply/heat/seasonal-storage-of-heat\"
+      >(seizoens)opslag</a> interessant.\r\n<br /><br />\r\nHieronder kun je voor
+      beide typen bronnen instellen hoeveel warmtecapaciteit er beschikbaar is. De
+      grafiek hiernaast laat zien of vraag en aanbod in balans zijn. Ook is het mogelijk
+      om restwarmte uit de elektriciteitssector te voeden in het warmtenet. Dit kan
+      in de menu-items 'Elektriciteit' en 'Hernieuwbare Elektriciteit' voor de volgende
+      centrales: <a href=\"/scenario/supply/electricity/gas-plants\" >(Aard)gascentrales</a>,
+      <a href=\"/scenario/supply/electricity/coal-plants\" >Kolencentrales</a>, <a
+      href=\"/scenario/supply/electricity_renewable/biomass-plants\" >Biomassacentrales</a>
+      en <a href=\"/scenario/supply/electricity_renewable/waste-power\" >Afvalverbranding</a>"
+    short_content_en: 
+    short_content_nl: 
 - id: 278
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3665,8 +6489,50 @@
   position: 3
   sidebar_item_id: 24
   output_element_id: 252
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "Scenarios with large amounts of \"must-run\" and volatile heat sources
+      will often\r\nhave considerable heat production during hours of low demand.
+      (Seasonal) storage allows you to preserve\r\nthis heat for later use, reducing
+      the amount of dispatchable capacity (such as back-up heaters) required to meet
+      demand. \r\n</br></br>\r\nIf you decide to switch the toggle below to 'On',
+      the ETM will add heat storage to your scenario. This ensures that all excess
+      heat production is saved and can be used in a later moment. The chart to the
+      right shows you storage in and outflows for every hour of the year.\r\n<br /><br
+      />\r\nCaution: If you install too much must-run or volatile capacity in your
+      scenario you may end up with a heat surplus in the storage at the end of the
+      'heat year' (which runs from 1 April to 31 March). To avoid dumping this heat
+      surplus, you could try decreasing <a href=\"/scenario/supply/heat/heat-sources\"
+      >installed capacity of must-runs / volatile heat sources</a>, increasing district
+      heating demand or changing the position of heat storage in <a href=\"/scenario/supply/heat_merit/priority-of-dispatchable-heat-producers\"
+      >the priority list of dispatchable heat producers</a>.\r\n</br></br>\r\nStorage
+      losses can be updated with the slider below the toggle. The costs for storage
+      can be adjusted in the <a href=\"/scenario/costs/costs_heat/district-heating-infrastructure\"
+      >costs section</a>."
+    content_nl: "Scenario's met veel 'must run' en volatiele warmtebronnen zoals zonthermie,
+      geothermie of restwarmte, hebben vaak een aanzienlijke warmteproductie in uren
+      met geen of weinig warmtevraag. (Seizoens)opslag stelt je in staat om deze warmte
+      op te slaan en op een later moment in te zetten. Hierdoor is er minder regelbaar
+      vermogen nodig, zoals back-up ketels, om in de vraag te voorzien. \r\n</br></br>\r\nAls
+      je ervoor kiest om de knop hieronder op 'Aan' te zetten, plaatst het ETM automatisch
+      voldoende opslagvolume in jouw scenario om voor elk uur per jaar de overschotten
+      aan warmte op te kunnen slaan. Deze warmte wordt weer uit de opslag gehaald
+      op momenten dat de vraag hoger is dan de (niet-regelbare) productie. De grafiek
+      hiernaast laat het verloop van de opslag zien.\r\n<br /><br />Let op: Als je
+      teveel \"must-run\" of volatiel vermogen in je scenario hebt, kan het voorkomen
+      dat er aan het einde van het 'warmtejaar' (dat loopt van 1 april tot 31 maart)
+      een warmteoverschot in de opslag achterblijft. Om te voorkomen dat deze warmte
+      verloren gaat, kun je proberen om <a href=\"/scenario/supply/heat/heat-sources\"
+      >het geïnstalleerd vermogen van niet-regelbare / volatiele warmtebronnen</a>
+      te verlagen, de warmtevraag in je scenario te verhogen of de positie van warmteopslag
+      in <a href=\"/scenario/supply/heat_merit/priority-of-dispatchable-heat-producers\"
+      >de inzetvolgorde van regelbare warmtebronnen</a> te veranderen.\r\n<br><br
+      />\r\nOpslagverliezen kunnen worden aangepast met het schuifje onder de knop.
+      De opslagkosten kunnen worden aangepast bij <a href=\"/scenario/costs/costs_hydrogen/hydrogen-storage\"
+      >kosten</a>.\r\n"
+    short_content_en: 
+    short_content_nl: 
 - id: 279
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3684,8 +6550,13 @@
   position: 4
   sidebar_item_id: 23
   output_element_id: 99
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: How much heat will be produced with biomass?
+    content_nl: Hoeveel warmte wordt er d.m.v. biomassa geproduceerd?
+    short_content_en: 
+    short_content_nl: 
 - id: 280
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3703,8 +6574,23 @@
   position: 2
   sidebar_item_id: 24
   output_element_id: 248
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: "In a district heating network, heat is generated in a centralised
+      location and subsequently distributed to residential and commercial facilities
+      via a network of insulated pipes. This transportation of heat leads to energy
+      losses which can range from 10-15% in modern district heating networks to 30%
+      or even higher in older networks. \r\n<br /><br />\r\nBelow you change the distribution
+      losses in your scenario."
+    content_nl: "Bij warmtenetten wordt warmte op een centrale locatie geproduceerd
+      en vervolgens via een netwerk van geïsoleerde pijpleidingen getransporteerd
+      naar huizen en bedrijven. Dit transport van warmte leidt tot energieverliezen,
+      die typisch rond de 10-15% liggen voor moderne warmtenetten en kunnen oplopen
+      naar 30% of hoger voor oudere infrastructuur.\r\n<br /><br />\r\nHieronder kun
+      je de distributieverliezen in jouw scenario instellen."
+    short_content_en: 
+    short_content_nl: 
 - id: 281
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3722,8 +6608,17 @@
   position: 3
   sidebar_item_id: 36
   output_element_id: 48
-  alt_output_element_id:
+  alt_output_element_id: 
   dependent_on: ''
+  description:
+    content_en: Solar thermal energy is an interesting sustainable heat source. Both
+      individual and collective systems are available on the market. How will the
+      investment costs and operation costs change for this technology in the future?
+    content_nl: Zonthermie is een interessante duurzame bron voor warmte, zowel via
+      individuele zonneboilers als collectieve systemen. Hoe veranderen de investeringskosten
+      en onderhoudskosten van deze technologie in de toekomst?
+    short_content_en: 
+    short_content_nl: 
 - id: 282
   image: ''
   created_at: !ruby/object:ActiveSupport::TimeWithZone
@@ -3743,3 +6638,46 @@
   output_element_id: 250
   alt_output_element_id: 249
   dependent_on: ''
+  description:
+    content_en: "Will the future supply of heat be sufficient during every hour per
+      year to meet demand of district heating networks? This depends of course on
+      the heat sources connected to the network. We distinguish between 'must-run'
+      sources have a constant production of heat and 'dispatchable' sources that can
+      be switched on during demand peaks. If none of these sources can supply sufficient
+      heat, emergency supply is activated to prevent shortages.\r\n<br /><br />\r\n<b>Emergency
+      supply</b><br />\r\nAn ideal back-up supply can be turned on quickly, has low
+      installation and maintenance costs and uses a fuel that is easy to store or
+      transport. For this reason, district heating networks often use gas burners
+      as emergency supply in case (part of) the baseload heat sources fail. Smaller
+      heating networks are typically connected to a smaller number of heat sources
+      which increases the importance of a proper back-up system.\r\n<br /><br />\r\n<b>Peak
+      demand</b><br />\r\nSome heat sources are better suited for supplying demand
+      peaks than others. A heat buffer is able to respond quickly to changes in demand,
+      but has to be big enough and needs to be filled first. A geothermal heat well
+      is expensive and is therefore best used to produce heat non-stop. Burners using
+      (green) gas or hydrogen can supply heat at any moment and are therefore a logical
+      choice for meeting demand peaks.\r\n<br /><br />\r\n<strong>Tip:</strong> Take
+      a look at the\r\n<a href=\"/scenario/flexibility/flexibility_weather/extreme-weather-conditions\">Weather
+      Conditions</a> slide to explore how variations in outdoor temperature affect
+      heat demand peaks in your scenario.\r\n"
+    content_nl: "Is er in de toekomst op ieder moment voldoende warmte om aan de vraag
+      op de warmtenetten te voldoen? Dat hangt natuurlijk af van welke warmtebronnen
+      zijn aangesloten op het warmtenet. We onderscheiden bronnen die (bijna) altijd
+      warmte leveren en bronnen die vooral bij pieken in de vraag ingezet worden.
+      Als geen van deze bronnen voldoende kunnen leveren, gaat de noodvoorziening
+      aan. \r\n<br /><br />\r\n<b>Noodvoorziening</b><br />\r\nDe ideale noodvoorziening
+      kan snel starten, heeft lage installatie- en onderhoudskosten en gebruikt brandstof
+      die makkelijk op te slaan is of beschikbaar gemaakt kan worden. Warmtenetten
+      hebben daarom vaak een gasketel als noodvoorziening voor als (een deel van de)
+      warmtebronnen wegvallen. Hoe kleinschaliger het warmtenet, hoe kleiner het aantal
+      aangesloten bronnen en hoe belangrijker een noodvoorziening wordt.\r\n<br /><br
+      />\r\n<b>Piekvraag</b><br />\r\nNiet alle bronnen zijn even goed geschikt om
+      de piekvraag in te vullen. Een warmteopslag kan snel reageren, maar moet wel
+      groot genoeg en gevuld zijn. Een geothermiebron is duur om te boren, dus die
+      kan het beste non-stop warmte leveren. Ketels op (groen) gas of waterstof kunnen
+      ieder moment leveren en zijn daarom een voor de hand liggende optie voor pieken.\r\n<br
+      /><br />\r\n<strong>Tip:</strong> Op de pagina\r\n<a href=\"/scenario/flexibility/flexibility_weather/extreme-weather-conditions\">Weersomstandigheden</a>
+      kun je verschillende weerjaren inladen, om te zien hoe de warmtevraagpieken
+      in je scenario afhangen van het weer.\r\n"
+    short_content_en: 
+    short_content_nl: 

--- a/db/migrate/20200227131821_flatten_descriptions_for_input_elements.rb
+++ b/db/migrate/20200227131821_flatten_descriptions_for_input_elements.rb
@@ -1,0 +1,42 @@
+class FlattenDescriptionsForInputElements < ActiveRecord::Migration[5.2]
+  def up
+    records =
+      YAML.load_file(yaml_path).map do |record|
+        desc = Description.find_by(describable_type: model_name,
+                                  describable_id: record['id'])
+        if desc
+          record['description'] = {}
+          record['description']['content_en'] = desc&.content_en
+          record['description']['content_nl'] = desc&.content_nl
+          record['description']['short_content_en'] = desc&.short_content_en
+          record['description']['short_content_nl'] = desc&.short_content_nl
+        end
+        record
+      end
+
+    File.write(yaml_path, records.to_yaml)
+    Description.where(describable_type: model_name)
+      .destroy_all
+  end
+
+  def down
+    YAML.load_file(yaml_path).each do |record|
+      Description.create!(describable_type: model_name,
+                          describable_id: record['id'],
+                          content_en: record['content_en'],
+                          content_nl: record['content_nl'],
+                          short_content_en: record['short_content_en'],
+                          short_content_nl: record['short_content_nl'])
+    end
+  end
+
+  def yaml_path
+    Rails.root.join('config',
+                    'ymodel',
+                    "#{model_name.underscore.pluralize}.yml")
+  end
+
+  def model_name
+    'InputElement'
+  end
+end

--- a/db/migrate/20200227145059_flatten_descriptions_for_slides.rb
+++ b/db/migrate/20200227145059_flatten_descriptions_for_slides.rb
@@ -1,0 +1,42 @@
+class FlattenDescriptionsForSlides < ActiveRecord::Migration[5.2]
+  def up
+    records =
+      YAML.load_file(yaml_path).map do |record|
+        desc = Description.find_by(describable_type: model_name,
+                                  describable_id: record['id'])
+        if desc
+          record['description'] = {}
+          record['description']['content_en'] = desc&.content_en
+          record['description']['content_nl'] = desc&.content_nl
+          record['description']['short_content_en'] = desc&.short_content_en
+          record['description']['short_content_nl'] = desc&.short_content_nl
+        end
+        record
+      end
+
+    File.write(yaml_path, records.to_yaml)
+    Description.where(describable_type: model_name)
+      .destroy_all
+  end
+
+  def down
+    YAML.load_file(yaml_path).each do |record|
+      Description.create!(describable_type: model_name,
+                          describable_id: record['id'],
+                          content_en: record['content_en'],
+                          content_nl: record['content_nl'],
+                          short_content_en: record['short_content_en'],
+                          short_content_nl: record['short_content_nl'])
+    end
+  end
+
+  def yaml_path
+    Rails.root.join('config',
+                    'ymodel',
+                    "#{model_name.underscore.pluralize}.yml")
+  end
+
+  def model_name
+    'Slide'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_17_095430) do
+ActiveRecord::Schema.define(version: 2020_02_27_145059) do
 
   create_table "area_dependencies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "dependent_on"

--- a/lib/tasks/ymodel.rake
+++ b/lib/tasks/ymodel.rake
@@ -11,11 +11,13 @@ namespace :ymodel do
 
       desc = Description.find_by(describable_type: record.class.name,
                                  describable_id: record.id)
-      attributes['description']['content_en'] = desc&.content_en
-      attributes['description']['content_nl'] = desc&.content_nl
-      attributes['description']['short_content_en'] = desc&.short_content_en
-      attributes['description']['short_content_en'] = desc&.short_content_nl
-
+      if desc
+        attributes['description'] = {}
+        attributes['description']['content_en'] = desc&.content_en
+        attributes['description']['content_nl'] = desc&.content_nl
+        attributes['description']['short_content_en'] = desc&.short_content_en
+        attributes['description']['short_content_nl'] = desc&.short_content_nl
+      end
       attributes
     end
   end

--- a/lib/tasks/ymodel.rake
+++ b/lib/tasks/ymodel.rake
@@ -8,6 +8,14 @@ namespace :ymodel do
       dep = AreaDependency.find_by(dependable_type: record.class.name,
                                    dependable_id: record.id)
       attributes['dependent_on'] = dep&.dependent_on
+
+      desc = Description.find_by(describable_type: record.class.name,
+                                 describable_id: record.id)
+      attributes['description']['content_en'] = desc&.content_en
+      attributes['description']['content_nl'] = desc&.content_nl
+      attributes['description']['short_content_en'] = desc&.short_content_en
+      attributes['description']['short_content_en'] = desc&.short_content_nl
+
       attributes
     end
   end

--- a/spec/models/input_element_spec.rb
+++ b/spec/models/input_element_spec.rb
@@ -80,10 +80,10 @@ describe InputElement do
 
   describe '#sanitized_description' do
     subject do
-      ie = described_class.new(description: { 'content_en' => 'foobar' })
+      ie = described_class.new(description: { 'content_en' => "'foobar'" })
       ie.sanitized_description
     end
 
-    it { is_expected.to eq 'foobar' }
+    it { is_expected.to eq '&#39;foobar&#39;' }
   end
 end

--- a/spec/models/input_element_spec.rb
+++ b/spec/models/input_element_spec.rb
@@ -32,6 +32,7 @@ describe InputElement do
     it { is_expected.to respond_to(:related_converter) }
     it { is_expected.to respond_to(:slide_id) }
     it { is_expected.to respond_to(:position) }
+    it { is_expected.to respond_to(:description) }
 
     # Methods
     it { is_expected.to respond_to(:title_for_description) }
@@ -76,5 +77,12 @@ describe InputElement do
         expect(input.url_components).to eq([])
       end
     end
+  end
+
+  describe '#sanitized_description' do
+    let(:ie) { described_class.new ({description: {"content_en" => "foobar"}}) }
+    subject { ie.sanitized_description }
+
+    it { is_expected.to eq "foobar"}
   end
 end

--- a/spec/models/input_element_spec.rb
+++ b/spec/models/input_element_spec.rb
@@ -16,7 +16,6 @@ describe InputElement do
     # Relations
 
     it { is_expected.to respond_to(:slide) }
-    it { is_expected.to respond_to(:description) }
 
     # Attributes
     it { is_expected.to respond_to(:key) }
@@ -80,9 +79,11 @@ describe InputElement do
   end
 
   describe '#sanitized_description' do
-    let(:ie) { described_class.new ({description: {"content_en" => "foobar"}}) }
-    subject { ie.sanitized_description }
+    subject do
+      ie = described_class.new(description: { 'content_en' => 'foobar' })
+      ie.sanitized_description
+    end
 
-    it { is_expected.to eq "foobar"}
+    it { is_expected.to eq 'foobar' }
   end
 end


### PR DESCRIPTION
We can now edit the descriptions of slides/sliders in the config .yml files. 

Requested by @michieldenhaan. In the current state of the YModel migration, it's still neccessary to edit the descriptions of slides and sliders through migrations. This is a pain with the deploy coming up.

I dumped these descriptions to the config files for slides and sliders and added a describable module for the YModel models. 