### PR TITLE
Temporarily remove links from What's new page.....

### DIFF
--- a/app/views/pages/_whats_new_content.en.md
+++ b/app/views/pages/_whats_new_content.en.md
@@ -24,8 +24,6 @@ The modeling of district heating has been improved and expanded!
 
 - The **cost calculation** for heat infrastructure has been improved. Instead of calculating a fixed amount per connection, the costs are now subdivided into indoor costs, distribution costs (pipelines, substations) and primary network costs. The cost calculation has been aligned with the Vesta MAIS model, making comparisons and exchange of outcomes between the ETM and Vesta MAIS easier. View [our documentation on GitHub][heat-infra costs documentation] for more information.
 
-Discover the improved modeling of district heating in the **[District heating → Heat sources][district heating slide]** section.
-
 ## 2. CHPs modeled differently
 
 All CHPs (with the exception of biogas-CHP) now also work as dispatchable in the electricity merit order, including the industrial CHPs. CHPs are therefore now running primarily for the electricity market. Their heat production is therefore a "given" (must-run) for heat networks. Previously, CHPs were uncontrollable and ran with a fixed, flat production profile. This change may have an impact on your scenario outcomes!
@@ -43,8 +41,6 @@ For saved scenarios it is possible to download the values ​​of your sliders 
 ## 5. Data export adjusted
 
 The format of the load and price curves of electricity has recently changed. For each column in the data export the extension "input" or "output" is used to indicate whether the data represents demand or supply of electricity. Flexibility solutions have two columns now, both for the electricity input and output. With these changes, the format of the data exports of electricity, network gas and hydrogen are more consistent.
-
-You can find the adjusted data export here in the **[Data export → Merit order price][data export slide]** section.
 
 [district heating slide]: /scenario/supply/heat/heat-sources
 

--- a/app/views/pages/_whats_new_content.nl.md
+++ b/app/views/pages/_whats_new_content.nl.md
@@ -4,9 +4,9 @@
 
 De modellering van warmtenetten is verbeterd en uitgebreid! Hieronder vindt u de wijzigingen:
 
-- Warmtenetten in huishoudens, gebouwen en landbouw zijn samengevoegd tot één net (‘**residentieel warmtenet**’). Er is geen uitwisseling van warmteoverschotten meer mogelijk tussen industriële (stoom)netten en residentiële netten
+- Warmtenetten in huishoudens, gebouwen en landbouw zijn samengevoegd tot één ‘**residentieel warmtenet**’. Er is geen uitwisseling van warmteoverschotten meer mogelijk tussen industriële (stoom)netten en residentiële netten
 
-- De vraag en productie van warmte in residentiële warmtenetten wordt vanaf nu berekend op **uurbasis** in plaats van op jaarbasis
+- De vraag en productie van warmte in residentiële warmtenetten worden vanaf nu berekend op **uurbasis** in plaats van op jaarbasis
 
   -> ![](/assets/pages/whats_new/hourly_heat_nl.png) <-
 
@@ -23,8 +23,6 @@ De modellering van warmtenetten is verbeterd en uitgebreid! Hieronder vindt u de
 - **Restwarmte** uit de kunstmest-, chemie-, raffinage- en ICT-sector kan worden uitgekoppeld en worden ingevoed op residentiële warmtenetten. Bekijk onze documentatie op [GitHub][residual heat documentation] voor de methode en gebruikte bronnen
 
 -	De **kostenberekening** voor warmte-infrastructuur is uitgebreid. In plaats van te rekenen met een vast bedrag per aansluiting, zijn de kosten nu onderverdeeld in inpandige kosten, distributiekosten (leidingen, onderstations) en primaire netkosten. De kostenberekening is afgestemd op het Vesta MAIS-model, waardoor vergelijking en uitwisseling van resultaten tussen de ETM en Vesta MAIS eenvoudiger is geworden. Bekijk onze documentatie op [GitHub][heat-infra costs documentation] voor meer informatie.
-
-[Ontdek hier de verbeterde modellering van warmtenetten!][district heating slide]
 
 ## 2. WKK's anders gemodelleerd
 
@@ -43,8 +41,6 @@ Voor opgeslagen scenarios is het vanaf nu mogelijk om de waardes van je gezette 
 ## 5. Data-export aangepast
 
 De bestandsindeling van de draaiprofielen en prijscurves van elektriciteit is veranderd. Per kolom uit de data-export wordt nu met "input" of "output" aangegeven of het om vraag of aanbod van elektriciteit gaat. Flexibiliteitsoplossingen hebben nu dus ook zowel een input als output kolom. Hiermee is de vorm van de data-export voor elektriciteit consistenter met de data-exports voor netwerkgas en waterstof.
-
-[Hier vind je de aangepaste data-export voor elektriciteit!][data export slide]
 
 [district heating slide]: /scenario/supply/heat/heat-sources
 


### PR DESCRIPTION
....as it now directs to PRO and there's nothing to see there

When deploy is done the links will be added again :) 