### PR TITLE
Remove memoization for area dependent sliders

### DIFF
--- a/app/models/slide.rb
+++ b/app/models/slide.rb
@@ -58,8 +58,7 @@ class Slide < YModel::Base
   # See Current.view
   # Some sliders cannot be used on some areas. Let's filter them out
   def safe_input_elements
-    @safe_input_elements ||= sliders.reject(&:area_dependent)
-      .sort_by(&:position)
+    sliders.reject(&:area_dependent).sort_by(&:position)
   end
 
   # Complementary to grouped_input_elements


### PR DESCRIPTION
After changing areas area dependent sliders sometimes still showed for the dependencies of the previous area. Removing the memoization should fix this.
Closes issue #3269