### PR TITLE
Charts that only have one relatee output element show hourly toggle

### DIFF
--- a/app/assets/javascripts/lib/models/chart.coffee
+++ b/app/assets/javascripts/lib/models/chart.coffee
@@ -256,4 +256,4 @@ class @Chart extends Backbone.Model
     @get('related_id')?
 
   wants_previous_button: =>
-    @get('previous_id')?
+    @get('previous_id')? || @get('relatee_id')?

--- a/app/assets/javascripts/lib/models/chart_list.coffee
+++ b/app/assets/javascripts/lib/models/chart_list.coffee
@@ -363,7 +363,8 @@ class @ChartList extends Backbone.Collection
 
       if chart = @chart_in_holder holder_id
         chart.delete()
-        @load_related(holder_id, chart.get('previous_id'))
+        chart_id = chart.get('previous_id') || chart.get('relatee_id')
+        @load_related(holder_id, chart_id)
         @remove chart
 
     # Toggle chart/table format

--- a/app/models/output_element.rb
+++ b/app/models/output_element.rb
@@ -107,6 +107,18 @@ class OutputElement < ActiveRecord::Base
     description.present?
   end
 
+  # some charts only have one relatee output element, in that case
+  # the hourly/yearly toggle should also show on the current chart
+  def has_one_relatee_output_element?
+    relatee_output_elements.length == 1
+  end
+
+  def relatee_output_element
+    return unless has_one_relatee_output_element?
+
+    relatee_output_elements[0]
+  end
+
   # rubocop:enable Naming/PredicateName
 
   def self.select_by_group

--- a/app/models/output_element_presenter.rb
+++ b/app/models/output_element_presenter.rb
@@ -18,6 +18,7 @@ class OutputElementPresenter
     key: true,
     under_construction: true,
     related_id: ->(oe) { oe.related_output_element&.id },
+    relatee_id: ->(oe) { oe.relatee_output_element&.id },
     has_description: ->(oe) { oe.has_description? },
     requires_merit_order: ->(oe) { oe.requires_merit_order? }
   }.freeze


### PR DESCRIPTION
On request of @marliekeverweij. Charts that are only linked to by one yearly table now show a toggle to said table.

Closes #3290