### PR TITLE
Tweak title of "peak load" and "mean load" in chart date picker

### DIFF
--- a/config/locales/en_output_elements.yml
+++ b/config/locales/en_output_elements.yml
@@ -37,8 +37,8 @@ en:
       read_more: "read more"
       empty: "There is no data to display for this chart"
       whole_year: "Whole year"
-      whole_year_daily_max: "Whole year (peak daily load)"
-      whole_year_daily_mean: "Whole year (mean daily load)"
+      whole_year_daily_max: "Whole year (daily peak)"
+      whole_year_daily_mean: "Whole year (daily mean)"
     dynamic_demand_curve: "Electricity demand per hour"
     electricity_network_capacity_and_peaks: "Electricity network capacity and peaks"
     empty:

--- a/config/locales/nl_output_elements.yml
+++ b/config/locales/nl_output_elements.yml
@@ -34,8 +34,8 @@ nl:
       total: "Totaal"
       empty: "Er is geen data om te tonen voor deze grafiek"
       whole_year: "Hele jaar"
-      whole_year_daily_max: "Hele jaar (piekbelasting per dag)"
-      whole_year_daily_mean: "Hele jaar (gem. belasting per dag)"
+      whole_year_daily_max: "Hele jaar (dagelijkse piek)"
+      whole_year_daily_mean: "Hele jaar (dagelijks gemiddelde)"
     electricity_network_capacity_and_peaks: "Elektriciteitsnetwerk capaciteit en pieken"
     empty:
       hydrogen_production_for_transport: "Er is geen vraag naar waterstof voor transport"


### PR DESCRIPTION
We recently added text to the "Select date" field for hourly charts to include "peak daily load" or "mean daily load". This unfortunately makes no sense in at least one chart: the electricity price per hour.

This PR adjusts the wording slightly:

* peak daily load → daily peak
* mean daily load → daily mean

@marliekeverweij Would you mind double-checking the NL translations please?