### PR TITLE
Add sliders for heat storage output capacity

### DIFF
--- a/config/interface/input_elements/supply_heat_network_storage_toggle.yml
+++ b/config/interface/input_elements/supply_heat_network_storage_toggle.yml
@@ -25,19 +25,6 @@
   position: 1
   dependent_on:
   slide_key: supply_heat_network_storage_toggle
-- key: energy_heat_network_storage_output_capacity_share
-  share_group: ''
-  step_value: 0.1
-  draw_to_min:
-  draw_to_max:
-  unit: "%"
-  fixed: false
-  interface_group: ''
-  command_type: ''
-  related_converter: ''
-  position: 5
-  dependent_on: ''
-  slide_key: supply_heat_network_storage_toggle
 - key: energy_heat_network_storage_loss_share
   share_group: ''
   step_value: 0.1
@@ -48,6 +35,19 @@
   interface_group: heat_storage_losses
   command_type: ''
   related_converter: ''
-  position: 6
+  position: 2
+  dependent_on: ''
+  slide_key: supply_heat_network_storage_toggle
+- key: energy_heat_network_storage_output_capacity_share
+  share_group: ''
+  step_value: 0.1
+  draw_to_min:
+  draw_to_max:
+  unit: "%"
+  fixed: false
+  interface_group: 'heat_storage_capacity'
+  command_type: ''
+  related_converter: ''
+  position: 3
   dependent_on: ''
   slide_key: supply_heat_network_storage_toggle

--- a/config/interface/input_elements/supply_heat_network_storage_toggle.yml
+++ b/config/interface/input_elements/supply_heat_network_storage_toggle.yml
@@ -25,6 +25,19 @@
   position: 1
   dependent_on:
   slide_key: supply_heat_network_storage_toggle
+- key: energy_heat_network_storage_output_capacity_share
+  share_group: ''
+  step_value: 0.1
+  draw_to_min:
+  draw_to_max:
+  unit: "%"
+  fixed: false
+  interface_group: ''
+  command_type: ''
+  related_converter: ''
+  position: 5
+  dependent_on: ''
+  slide_key: supply_heat_network_storage_toggle
 - key: energy_heat_network_storage_loss_share
   share_group: ''
   step_value: 0.1
@@ -35,6 +48,6 @@
   interface_group: heat_storage_losses
   command_type: ''
   related_converter: ''
-  position: 5
+  position: 6
   dependent_on: ''
   slide_key: supply_heat_network_storage_toggle

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -304,6 +304,7 @@ en:
     non_dispatchable_heat: "Must-run / volatile heat sources"
     dispatchable_heat: "Dispatchable heat sources"
     heat_storage_losses: "Storage losses"
+    heat_storage_capacity: "Storage output capacity"
     must_run_dispatchable: "Dispatchable [OFF] / must-run [ON]"
     consumer_price: "Consumer price incl. taxes"
     curtailment: "Curtailment"

--- a/config/locales/interface/input_elements/en_supply_heat.yml
+++ b/config/locales/interface/input_elements/en_supply_heat.yml
@@ -194,6 +194,10 @@ en:
         larger storage systems, for example, the percentage of losses decrease. On
         the other hand, the losses increase when an open system is used (eg WKO) instead
         of a closed system such as Ecovat.'
+    energy_heat_network_storage_output_capacity_share:
+      title: Output capacity ??
+      short_description:
+      description: '??'
     energy_heat_distribution_loss_share:
       title: Transport and distribution losses
       short_description: 

--- a/config/locales/interface/input_elements/en_supply_heat.yml
+++ b/config/locales/interface/input_elements/en_supply_heat.yml
@@ -3,7 +3,7 @@ en:
   input_elements:
     volume_of_imported_heat:
       title: Imported heat
-      short_description: 
+      short_description:
       description: "How much (residual) heat can be imported from outside your region?
         With this slider you can set the amount. \r\n</br></br>\r\nAdditionally, with
         the slider below you can set the CO<sub>2</sub>-emissions of imported heat
@@ -11,7 +11,7 @@ en:
         you can set the costs for imported heat."
     co2_emissions_of_imported_heat:
       title: CO2 emissions of imported heat
-      short_description: 
+      short_description:
       description: "How much CO<sub>2</sub>-emissions are associated with the imported
         heat? \r\n</br></br>\r\nThis strongly depends on the heat source. For reference:
         when heat originates from a gas CCGT plant, the emissions are around 36,0
@@ -19,7 +19,7 @@ en:
         >source</a>(in Dutch!))"
     capacity_of_energy_heat_well_geothermal:
       title: Geothermal
-      short_description: 
+      short_description:
       description: 'Thermal energy from below 500 meters depth is called geothermal
         energy. This heat can be used to heat buildings. How much heat in your scenario
         comes from geothermal heat pumps? Caution: geothermal heat pumps typically
@@ -28,45 +28,45 @@ en:
         that heat produced in summer can be utilised in winter'
     capacity_of_energy_heat_solar_thermal:
       title: Solar thermal
-      short_description: 
+      short_description:
       description: Solar thermal collectors generate heat from the sun and use this
         to heat water. This heat production is especially high in the summer. Heat
         demand, on the other hand, peaks in the winter. Use seasonal heat storage
         for effective deployment.
     capacity_of_energy_heat_heatpump_water_water_electricity:
       title: Collective heat pump
-      short_description: 
+      short_description:
       description: A heat pump produces heat with electricity and ambient heat. Specify
         here the capacity of collective heat pumps that supplies heat for district
         heating
     capacity_of_energy_heat_burner_network_gas:
       title: Gas heater (network gas)
-      short_description: 
+      short_description:
       description: A burner produces heat. Specify here the capacity of gas heaters
         that supplies heat for district heating.
     capacity_of_energy_heat_burner_hydrogen:
       title: Hydrogen heater
-      short_description: 
+      short_description:
       description: A burner produces heat. Specify here the capacity of hydrogen heaters
         that supplies heat for district heating.
     capacity_of_energy_heat_burner_wood_pellets:
       title: Biomass heater
-      short_description: 
+      short_description:
       description: A burner produces heat. Specify here the capacity of biomass heaters
         that supplies heat for district heating.
     capacity_of_energy_heat_burner_waste_mix:
       title: Waste heater
-      short_description: 
+      short_description:
       description: A burner produces heat. Specify here the capacity of waste heaters
         that supplies heat for district heating.
     capacity_of_energy_heat_burner_crude_oil:
       title: Oil heater
-      short_description: 
+      short_description:
       description: A boiler produces heat. Specify here the capacity of oil heaters
         that supplies heat for district heating.
     share_of_industry_chemicals_other_reused_residual_heat:
       title: Chemical industry
-      short_description: 
+      short_description:
       description: "What percentage of the available residual heat from the chemical
         industry do you want to use in heat networks? How the residual heat potential
         is determined can be read in our <a href=\"https://github.com/quintel/documentation/blob/master/general/residual_heat_industry.md\"
@@ -75,7 +75,7 @@ en:
         The costs of using residual heat can be adjusted <a href=\"/scenario/costs/costs_heat/residual-heat\">here</a>.\r\n</br>"
     share_of_industry_chemicals_fertilizers_reused_residual_heat:
       title: Fertilizer industry
-      short_description: 
+      short_description:
       description: "What percentage of the available residual heat from the fertilizer
         industry do you want to use in heat networks? How the residual heat potential
         is determined can be read in our <a href=\"https://github.com/quintel/documentation/blob/master/general/residual_heat_industry.md\"
@@ -84,7 +84,7 @@ en:
         The costs of using residual heat can be adjusted <a href=\"/scenario/costs/costs_heat/residual-heat\">here</a>.\r\n</br>"
     share_of_industry_chemicals_refineries_reused_residual_heat:
       title: Refineries
-      short_description: 
+      short_description:
       description: "What percentage of the available residual heat from refineries
         do you want to use in heat networks? How the residual heat potential is determined
         can be read in our <a href=\"https://github.com/quintel/documentation/blob/master/general/residual_heat_industry.md\"
@@ -93,7 +93,7 @@ en:
         The costs of using residual heat can be adjusted <a href=\"/scenario/costs/costs_heat/residual-heat\">here</a>.\r\n</br>"
     share_of_industry_other_ict_reused_residual_heat:
       title: Central ICT
-      short_description: 
+      short_description:
       description: "What percentage of the available residual heat from data centers
         do you want to use in heat networks? How the residual heat potential is determined
         can be read in our <a href=\"https://github.com/quintel/documentation/blob/master/general/residual_heat_industry.md\"
@@ -120,7 +120,7 @@ en:
         which 6000 hours to supply heat as steam.  "
     capacity_of_industry_chp_turbine_gas_power_fuelmix:
       title: Gas turbine CHP
-      short_description: 
+      short_description:
       description: "This gas turbine CHP is typically found at a medium-sized industrial
         firm to deliver power and steam. Several units are sometimes found on one
         site in order to deliver steam to neighboring firms.\r\n<br/><br/>\r\nFirms
@@ -130,7 +130,7 @@ en:
         are lower at 6000 hours per year. "
     capacity_of_industry_chp_engine_gas_power_fuelmix:
       title: Gas motor CHP
-      short_description: 
+      short_description:
       description: "This gas-powered engine may well produce heat and power for local
         use in the food industry.\r\nFor a three-shift work rotation common in the
         food industry, the number of full load hours would be ~6000 hours per year.\r\n<br/><br/>\r\nGenerating
@@ -138,7 +138,7 @@ en:
         power from the grid and generating heat with a burner. "
     capacity_of_industry_chp_ultra_supercritical_coal:
       title: Coal CHP
-      short_description: 
+      short_description:
       description: "Combined heat and power (CHP) plants generate both heat and electricity.
         The combination of heat and electricity makes this option quite energy efficient.
         Also, locally producing and using heat and electricity reduces transportation
@@ -148,31 +148,31 @@ en:
         CHP plants can be installed as well."
     capacity_of_industry_chp_wood_pellets:
       title: Biomass CHP
-      short_description: 
+      short_description:
       description: A CHP produces electricity and heat. In the industry sector this
         heat is very often stored in steam. Here you can choose the capacity of wood
         pellet CHPs delivering to the industrial steam network.
     capacity_of_industry_heat_burner_coal:
       title: Coal heater
-      short_description: 
+      short_description:
       description: A burner produces heat. In the industry sector this heat is very
         often stored in steam. Here you can choose the capacity of coal burner delivering
         to the industrial steam network.”
     capacity_of_industry_heat_burner_crude_oil:
       title: Oil heater
-      short_description: 
+      short_description:
       description: A burner produces heat. In the industry sector this heat is very
         often stored in steam. Here you can choose the capacity of oil burners delivering
         to the industrial steam network.”
     capacity_of_industry_heat_burner_lignite:
       title: Lignite heater
-      short_description: 
+      short_description:
       description: A burner produces heat. In the industry sector this heat is very
         often stored in steam. Here you can choose the capacity of lignite burners
         delivering to the industrial steam network.”
     capacity_of_industry_heat_well_geothermal:
       title: Geothermal heat
-      short_description: 
+      short_description:
       description: Geothermal heat wells extract heat from the earth. In many cases
         the temperature of this heat is too low for industrial processes. However,
         in some sectors like Food and Paper geothermal heat could be an interesting
@@ -180,14 +180,14 @@ en:
         heat to the industry sector.”
     capacity_of_energy_heat_burner_coal:
       title: Coal heater
-      short_description: 
+      short_description:
       description: A burner produces heat. Specify here the capacity of coal heaters
         that supplies heat for district heating.
     heat_storage_enabled:
       description: ''
     energy_heat_network_storage_loss_share:
       title: Yearly losses
-      short_description: 
+      short_description:
       description: 'The start value (15%) is based on the yearly losses of an ''Ecovat''
         system (link: https://www.ecovat.eu/): a large underground buffer tank filled
         with water. Storage losses are highly dependent on the type of system. For
@@ -195,12 +195,22 @@ en:
         the other hand, the losses increase when an open system is used (eg WKO) instead
         of a closed system such as Ecovat.'
     energy_heat_network_storage_output_capacity_share:
-      title: Output capacity ??
+      title: Output capacity (as % of average hourly load)
       short_description:
-      description: '??'
+      description: 'Here you can specify the heat output capacity per hour of heat storage.
+        By default, this capacity is unlimited, meaning that there is no limit to the amount
+        of heat that can be drawn from heat storage in one hour (given that enough heat is
+        available in the storage). With this slider you can limit this. This can result
+        in a slower depletion of heat storage. A consequence of this could be that other
+        dispatchable heat sources (such as gas heaters) need to be switched on earlier.<br/><br/>
+        The slider is a percentage of the average heat demand per hour. E.g. a slider value of
+        200% means that, in a given hour, up to 2 times the average heat demand per hour can
+        be drawn from the storage. To see the resulting capacity in MW, please open the chart
+        "District heating sources: capacities and marginal costs".<br/><br/>
+        This slider is aimed at expert users. In many cases the default setting will suffice.'
     energy_heat_distribution_loss_share:
       title: Transport and distribution losses
-      short_description: 
+      short_description:
       description: The default value for the distribution losses slider is typically
         low or even zero for many regions modelled in the ETM. This is mainly due
         to a lack of reliable data for the present year. Please make sure to change

--- a/config/locales/interface/input_elements/nl_supply_heat.yml
+++ b/config/locales/interface/input_elements/nl_supply_heat.yml
@@ -200,6 +200,10 @@ nl:
         grotere opslagsystemen verminderen bijvoorbeeld het verliespercentage. Daarentegen
         nemen de verliezen juist toe wanneer een open systeem wordt gebruikt (bijv.
         WKO) in plaats van een gesloten systeem zoals Ecovat.'
+    energy_heat_network_storage_output_capacity_share:
+      title: Output capacity ??
+      short_description:
+      description: '??'
     energy_heat_distribution_loss_share:
       title: Transport- en distributieverliezen
       short_description: 

--- a/config/locales/interface/input_elements/nl_supply_heat.yml
+++ b/config/locales/interface/input_elements/nl_supply_heat.yml
@@ -3,7 +3,7 @@ nl:
   input_elements:
     volume_of_imported_heat:
       title: Geïmporteerde warmte
-      short_description: 
+      short_description:
       description: "Hoeveel (rest)warmte kan er geïmporteerd worden van buiten jouw
         regio? Met deze slider kan jij bepalen hoeveel dat zal zijn.\r\n</br></br>\r\nDaarbij
         kan je met het schuifje hieronder de CO<sub>2</sub>-uitstoot van geïmporteerde
@@ -11,7 +11,7 @@ nl:
         >'Kosten'</a> de kosten voor geïmporteerde warmte bepalen."
     co2_emissions_of_imported_heat:
       title: CO<sub>2</sub>-uitstoot van geïmporteerde (rest)warmte
-      short_description: 
+      short_description:
       description: "Hoeveel CO<sub>2</sub>-uitstoot hoort er bij de geïmporteerde
         warmte? \r\n</br></br>\r\nDit afhankelijk van de warmtebron. Ter referentie:
         wanneer de warmte van een STEG gascentrale komt, hoort hier een CO<sub>2</sub>-uitstoot
@@ -19,7 +19,7 @@ nl:
         >deze bron</a>)"
     capacity_of_energy_heat_well_geothermal:
       title: Geothermie
-      short_description: 
+      short_description:
       description: 'Aardwarmte dieper dan 500 meter wordt geothermie genoemd. Deze
         warmte kan gebruikt worden om gebouwen mee te verwarmen. Hoeveel warmte haal
         jij in je scenario uit geothermie? Let op: geothermieputten schakelen niet
@@ -28,45 +28,45 @@ nl:
         zomer in de winter in te kunnen zetten.'
     capacity_of_energy_heat_solar_thermal:
       title: Zonthermie
-      short_description: 
+      short_description:
       description: Bij zonthermie wordt de warmte van de zon omgezet in warm water.
         Deze warmteproductie is vooral groot in de zomer, terwijl de vraag naar warmte
         hoog is in de winter. Maak gebruik van seizoensopslag voor een effectieve
         inzet.
     capacity_of_energy_heat_heatpump_water_water_electricity:
       title: Collectieve warmtepomp
-      short_description: 
+      short_description:
       description: Een warmtepomp produceert warmte uit elektriciteit en omgevingswarmte.
         Stel hier het vermogen aan collectieve warmtepompen in dat warmte levert aan
         warmtenetten.
     capacity_of_energy_heat_burner_network_gas:
       title: Gasketel (netwerk gas)
-      short_description: 
+      short_description:
       description: Een ketel produceert warmte. Stel hier het vermogen aan gasketels
         in dat warmte levert aan warmtenetten.
     capacity_of_energy_heat_burner_hydrogen:
       title: Waterstofketel
-      short_description: 
+      short_description:
       description: Een ketel produceert warmte. Stel hier het vermogen aan waterstofketels
         in dat warmte levert aan warmtenetten.
     capacity_of_energy_heat_burner_wood_pellets:
       title: Biomassaketel
-      short_description: 
+      short_description:
       description: Een ketel produceert warmte. Stel hier het vermogen aan biomassaketels
         in dat warmte levert aan warmtenetten.
     capacity_of_energy_heat_burner_waste_mix:
       title: Afvalketel
-      short_description: 
+      short_description:
       description: Een ketel produceert warmte. Stel hier het vermogen aan afvalverbranders
         in dat warmte levert aan warmtenetten.
     capacity_of_energy_heat_burner_crude_oil:
       title: Olieketel
-      short_description: 
+      short_description:
       description: Een ketel produceert warmte. Stel hier het vermogen aan olieketels
         in dat warmte levert aan warmtenetten.
     share_of_industry_chemicals_other_reused_residual_heat:
       title: Chemische industrie
-      short_description: 
+      short_description:
       description: "Hoeveel procent van de beschikbare restwarmte uit de chemische
         industrie wil je uitkoppelen? Hoe de restwarmte potentie is bepaald, is te
         lezen in onze <a href=\"https://github.com/quintel/documentation/blob/master/general/residual_heat_industry.md\"
@@ -77,7 +77,7 @@ nl:
         worden.\r\n</br>"
     share_of_industry_chemicals_fertilizers_reused_residual_heat:
       title: Kunstmestindustrie
-      short_description: 
+      short_description:
       description: "Hoeveel procent van de beschikbare restwarmte uit de kunstmestindustrie
         wil je uitkoppelen? Hoe de restwarmte potentie is bepaald, is te lezen in
         onze <a href=\"https://github.com/quintel/documentation/blob/master/general/residual_heat_industry.md\"
@@ -88,7 +88,7 @@ nl:
         worden.\r\n</br>"
     share_of_industry_chemicals_refineries_reused_residual_heat:
       title: Raffinaderijen
-      short_description: 
+      short_description:
       description: "Hoeveel procent van de beschikbare restwarmte uit raffinaderijen
         wil je uitkoppelen? Hoe de restwarmte potentie is bepaald, is te lezen in
         onze <a href=\"https://github.com/quintel/documentation/blob/master/general/residual_heat_industry.md\"
@@ -99,7 +99,7 @@ nl:
         worden.\r\n</br>"
     share_of_industry_other_ict_reused_residual_heat:
       title: Centrale ICT
-      short_description: 
+      short_description:
       description: "Hoeveel procent van de beschikbare restwarmte uit datacenters
         wil je uitkoppelen? Hoe de restwarmtepotentie is bepaald, is te lezen in onze
         <a href=\"https://github.com/quintel/documentation/blob/master/general/residual_heat_industry.md\"
@@ -127,7 +127,7 @@ nl:
         per jaar, waarvan 6000 vollasturen warmte (stoomlevering).\r\n"
     capacity_of_industry_chp_turbine_gas_power_fuelmix:
       title: Gasturbine-WKK
-      short_description: 
+      short_description:
       description: "Deze gasturbine WKK staat typisch op een middelgroot industrieel
         bedrijf en produceert elektriciteit en stoom. Soms staan er verschillende
         units naast elkaar en wordt er ook stoom geleverd aan naburige bedrijven.\r\n<br/><br/>\r\nIn
@@ -137,7 +137,7 @@ nl:
         zijn er 6000 vollasturen warmte (stoomlevering)."
     capacity_of_industry_chp_engine_gas_power_fuelmix:
       title: Gasmotor-WKK
-      short_description: 
+      short_description:
       description: "Deze gasmotor WKK staat bijvoorbeeld in de voedingsindustrie en
         maakt stroom en warmte voor lokaal gebruik. \r\nStel er wordt gedraaid in
         een drieploegendienst. Het aantal draaiuren komt uit op 6000 per jaar.\r\n<br/><br/>\r\nHet
@@ -145,7 +145,7 @@ nl:
         dan de stroom van het net te kopen en warmte met een ketel te maken. "
     capacity_of_industry_chp_ultra_supercritical_coal:
       title: Kolen-WKK
-      short_description: 
+      short_description:
       description: "Warmtekrachtkoppelingen (WKK’s) produceren warmte en elektriciteit.
         Deze combinatie maakt WKK's vrij energie-efficiënt. Lokaal produceren en gebruiken
         van warmte en elektriciteit vermijdt transportverliezen en dat bespaart weer
@@ -155,45 +155,45 @@ nl:
         kolen WKK's worden gebouwd."
     capacity_of_industry_chp_wood_pellets:
       title: Biomassa WKK
-      short_description: 
+      short_description:
       description: Een WKK produceert zowel warmte als elektriciteit. In de industrie
         is deze warmte vaak in de vorm van stoom. Kies hier het vermogen aan biomassa-WKKs
         dat levert aan het industriële stoomnetwerk.
     capacity_of_industry_heat_burner_coal:
       title: Kolenketel
-      short_description: 
+      short_description:
       description: Een ketel produceert warmte. In de industrie is deze warmte vaak
         in de vorm van stoom. Kies hier het vermogen aan kolenketels dat levert aan
         het industriële stoomnetwerk.
     capacity_of_industry_heat_burner_crude_oil:
       title: Olieketel
-      short_description: 
+      short_description:
       description: Een ketel produceert warmte. In de industrie is deze warmte vaak
         in de vorm van stoom. Kies hier het vermogen aan olieketels dat levert aan
         het industriële stoomnetwerk.
     capacity_of_industry_heat_burner_lignite:
       title: Bruinkoolketel
-      short_description: 
+      short_description:
       description: Een ketel produceert warmte. In de industrie is deze warmte vaak
         in de vorm van stoom. Kies hier het vermogen aan bruinkoolketels dat levert
         aan het industriële stoomnetwerk.
     capacity_of_industry_heat_well_geothermal:
       title: Geothermie
-      short_description: 
+      short_description:
       description: Geothermie maakt gebruik van warmte uit de bodem. Voor de industrie
         is deze warmte vaak een té lage temperatuur. Toch is het in sommige sectoren
         inzetbaar, zoals de papier- en voedselindustrie. Kies hier het vermogen aan
         geothermieputten dat warmte levert aan de industrie.
     capacity_of_energy_heat_burner_coal:
       title: Kolenketel
-      short_description: 
+      short_description:
       description: Een ketel produceert warmte. Stel hier het vermogen aan kolenketels
         in dat warmte levert aan warmtenetten.
     heat_storage_enabled:
       description: ''
     energy_heat_network_storage_loss_share:
       title: Jaarlijkse verliezen
-      short_description: 
+      short_description:
       description: 'De startwaarde (15%) is gebaseerd op de jaarlijkse verliezen van
         een Evocat systeem (link: https://www.ecovat.eu/): een groot ondergronds buffervat
         gevuld met water. Opslagverliezen zijn afhankelijk van het type systeem. Bij
@@ -201,12 +201,25 @@ nl:
         nemen de verliezen juist toe wanneer een open systeem wordt gebruikt (bijv.
         WKO) in plaats van een gesloten systeem zoals Ecovat.'
     energy_heat_network_storage_output_capacity_share:
-      title: Output capacity ??
+      title: Levercapaciteit (als % van gemiddelde uurvraag)
       short_description:
-      description: '??'
+      description: 'Met deze schuif stel je de uurlijkse warmtelevercapaciteit (outputcapaciteit)
+        van warmteopslag in. Standaard is deze capaciteit onbeperkt. Dit houdt in dat er
+        geen limiet is aan de hoeveelheid warmte die in een uur uit de opslag gehaald
+        kan worden (gegeven dat er voldoende warmte in de opslag aanwezig is). Met deze
+        schuif kun je dit beperken. Hierdoor wordt de opslag gedurende het jaar langzamer
+        leeggehaald. Een gevolg is dat andere regelbare warmtebronnen (zoals piekketels)
+        mogelijk eerder moeten bijspringen.<br/><br/>
+        De schuif is een percentage van de gemiddelde uurlijkse warmtevraag. Bijvoorbeeld:
+        een waarde van 200% betekent dat de hoeveelheid warmte die in een uur uit de opslag
+        gehaald kan worden maximaal 2 keer de gemiddelde uurlijkse vraag is.
+        Bekijk de grafiek "Warmtenetbronnen: vermogens en marginale kosten" om het resulterende
+        vermogen in MW zien.<br/><br/>
+        Deze schuif is bedoeld voor expertgebruikers. In veel gevallen hoeft de standaardinstelling
+        niet aangepast te worden.'
     energy_heat_distribution_loss_share:
       title: Transport- en distributieverliezen
-      short_description: 
+      short_description:
       description: De standaardwaarde van de verliesschuif is erg laag of zelfs nul
         voor veel landen en regio's in het ETM. Dit komt omdat er vaak geen betrouwbare
         data over warmteverliezen beschikbaar is. Zorg ervoor dat de schuif hieronder

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -305,6 +305,7 @@ nl:
     non_dispatchable_heat: "Niet-regelbare / volatiele warmtebronnen"
     dispatchable_heat: "Regelbare warmtebronnen"
     heat_storage_losses: "Opslagverliezen"
+    heat_storage_capacity: "Levercapaciteit opslag"
     must_run_dispatchable: "Regelbaar [UIT] / niet-regelbaar [AAN]"
     consumer_price: "Consumentenprijs incl. belastingen"
     curtailment: "Productiebeperking"


### PR DESCRIPTION
Requires some translations and texts depending on what you want to call this slider: [EN](https://github.com/quintel/etmodel/blob/2befb7126d7d609d6b829841aa1f816de30a0f2b/config/locales/interface/input_elements/en_supply_heat.yml#L197-L200), [NL](https://github.com/quintel/etmodel/blob/2befb7126d7d609d6b829841aa1f816de30a0f2b/config/locales/interface/input_elements/nl_supply_heat.yml#L203-L206).

The slider appears on Supply → District heating → (Seasonal) storage of heat, immediately below the storage toggle.

Merge order

1. quintel/etsource#2268
2. quintel/etengine#1106
3. This PR last.