### PR TITLE
Change "max" chart downsample to use all series

### DIFF
--- a/app/assets/javascripts/d3/dynamic_demand_curve.coffee
+++ b/app/assets/javascripts/d3/dynamic_demand_curve.coffee
@@ -45,6 +45,8 @@ seriesOpacity = (visibleSeries) ->
 
 D3.dynamic_demand_curve =
   View: class extends D3YearlyChartView
+    downsampleWith: 'max'
+
     initialize: ->
       D3YearlyChartView.prototype.initialize.call(this)
 

--- a/app/assets/javascripts/d3/merit_transformator.js
+++ b/app/assets/javascripts/d3/merit_transformator.js
@@ -1,6 +1,7 @@
 /* globals d3 */
 
-var MeritTransformator = (function () {
+// eslint-disable-next-line no-unused-vars
+var MeritTransformator = (function() {
   'use strict';
 
   function downsampleFunc(name) {
@@ -11,7 +12,134 @@ var MeritTransformator = (function () {
     return d3[name || 'mean'];
   }
 
+  /**
+   * Returns the index of the maximum value in the array of values.
+   */
+  function indexOfMax(values) {
+    var index = 0;
+    var max = values[0];
+
+    for (var i = 1; i < values.length; i++) {
+      if (values[i] > max) {
+        max = values[i];
+        index = i;
+      }
+    }
+
+    return index;
+  }
+
+  /**
+   * Sums a two-dimensional array of values from one or more series.
+   *
+   * @example Summing two arrays
+   *
+   *   sumMatrix([
+   *     [1, 2, 3],
+   *     [10, 20, 30]
+   *   ])
+   *   // => [11, 22, 33]
+   */
+  function sumMatrix(matrix) {
+    var sums = matrix[0].slice();
+
+    for (var row = 1; row < matrix.length; row++) {
+      var line = matrix[row];
+
+      for (var col = 0; col < line.length; col++) {
+        sums[col] = (sums[col] || 0) + (line[col] || 0);
+      }
+    }
+
+    return sums;
+  }
+
+  /**
+   * Takes values from multiple series and downsamples to return the maximum
+   * daily load.
+   *
+   * This is different to using `downsampleWith: 'max'` on each individual
+   * series: that method selects the maximum value of each series, no matter
+   * which hour that occurs in (series 1 may be hour 0, series 2 may be hour 12,
+   * etc). `downsampleCumulativeMax` finds the hour in each day where there is
+   * the largest cumulative load, then returns the loads for each series in that
+   * hour.
+   *
+   * @param {Array[Array[number]]} series
+   *   An array of arrays. Each subarray contains all 8760 values for the year
+   *   for each series.
+   *
+   * @return {Array}
+   *   Returns an array of arrays. Contains the same number of arrays as the
+   *   input, in the same order.
+   */
+  function downsampleCumulativeMax(series) {
+    var sampled = [];
+
+    var weekSlices;
+    var hourlyMax;
+    var allSame;
+    var index;
+
+    for (var day = 0; day < 365; day++) {
+      // Create an array where each value is an array of values from each
+      // series, for each hour in the current week.
+      weekSlices = series.map(function(serieValues) {
+        return serieValues.slice(day * 24, (day + 1) * 24);
+      });
+
+      // Create the array of hourly sums for the current week.
+      hourlyMax = sumMatrix(weekSlices);
+
+      allSame = hourlyMax.every(function(value) {
+        return value !== hourlyMax[0];
+      });
+
+      // When the day peak load is flat, we sample loads from mid-day.
+      index = 11;
+
+      if (!allSame) {
+        index = indexOfMax(hourlyMax);
+      }
+
+      weekSlices.map(function(serieValues, serieIndex) {
+        sampled[serieIndex] = sampled[serieIndex] || [];
+        sampled[serieIndex].push(serieValues[index]);
+      });
+    }
+
+    return sampled;
+  }
+
   return {
+    /**
+     * Samples multiple series.
+     *
+     * @param {Array[Array[number]]} series
+     *   An array of arrays; each subarray contains the full 8760 values from
+     *   each series to be downsampled.
+     * @param {number} weekNum
+     *   The week number to be sampled. If a number is present, the loads for
+     *   that week are extracted from `series` without any further sampling.
+     * @param {String} downsampleWith
+     *   When `weekNum` is 0, the full yearly values are downsamples either
+     *   using "mean" (get the mean value per day) or "max" (find the peak hour
+     *   in the day and extract the load for each series in that hour).
+     *
+     * @return {Array[Array[number]]}
+     *   Returns downsamples values for each series, in the same order as the
+     *   `series` argument.
+     */
+    transformMany: function(series, weekNum, downsampleWith) {
+      if (weekNum || downsampleWith !== 'max') {
+        return series.map(function(values) {
+          return MeritTransformator.transform(values, weekNum, downsampleWith);
+        });
+      }
+
+      return downsampleCumulativeMax(series);
+    },
+
     transform: function(values, weekNum, downsampleWith) {
       if (weekNum) {
         return this.sliceValues(values, weekNum);
@@ -56,4 +184,4 @@ var MeritTransformator = (function () {
       return values.slice((weekNum - 1) * weekLen, weekNum * weekLen);
     }
   };
-}());
+})();

--- a/app/assets/javascripts/lib/views/d3_yearly_chart_view.coffee
+++ b/app/assets/javascripts/lib/views/d3_yearly_chart_view.coffee
@@ -170,13 +170,16 @@ class @D3YearlyChartView extends D3ChartView
       .tickValues(@dateSelect.tickValues()).tickFormat(formatter)
 
   visibleData: =>
-    @rawChartData
-      .filter (serie) ->
-        serie.values.length
-      .map (serie) =>
-        $.extend({}, serie, values: MeritTransformator.transform(
-          serie.values, this.dateSelect.val(), @downsampleWith
-        ))
+    availableSeries = @rawChartData.filter((serie) -> serie.values.length)
+
+    sampledData = MeritTransformator.transformMany(
+      availableSeries.map((serie) -> serie.values),
+      this.dateSelect.val(),
+      @downsampleWith
+    )
+
+    availableSeries.map (serie, index) ->
+      $.extend({}, serie, values: sampledData[index])
 
   convertData: =>
     @convertToXY(@visibleData())


### PR DESCRIPTION
Changes the "max" downsampling method for hourly charts to instead select the maximum cumulative load in each 24-hour period, and show the loads of each serie in that hour, rather than selecting the maximum of each series in any hour.

It also sets the dynamic demand chart to use "max" downsampling. This affects the annual views of:

* Demand curve of hybrid heat pump in households
* Electricity demand per hour
* Electricity demand on high voltage net
* Electricity demand on low voltage net
* Electricity demand on medium voltage net
* Hourly heat demand for district heating
* Hourly heat production for district heating
* Hydrogen demand / production / storage
* Network gas demand / production / storage
* (Seasonal) storage of heat
* Solar PV curtailment

**This is quite a lot of changes!** I'm not sure it makes sense for all these charts to show the "max"/peak load in the annual view. I'd be fine delaying this until we support per-chart interpolation settings.

@marliekeverweij What do you think?

Closes #2867 