### PR TITLE
Add page titles

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,7 +1,7 @@
 !!! 5
 %html
   %head
-    %title= t("meta.name")
+    %title= content_for?(:page_title) ? yield(:page_title) : t("meta.name")
     %meta{:content => "text/html; charset=utf-8", "http-equiv" => "Content-Type" }
     %meta{:description => "#{t('meta.description')}" }
     %meta{:name=>"google-site-verification", :content=>"ILDmdAxQTYxcPyy969IJXq7YlXKzhGFfGCHqFi8fiWA"}

--- a/app/views/pages/whats_new.html.haml
+++ b/app/views/pages/whats_new.html.haml
@@ -1,3 +1,5 @@
+- content_for(:page_title) { "#{t('updated.name')} - #{t('meta.name')}" }
+
 .information_page.whats_new
   = render partial: 'whats_new_content'
 

--- a/app/views/saved_scenarios/show.html.haml
+++ b/app/views/saved_scenarios/show.html.haml
@@ -1,3 +1,5 @@
+- content_for(:page_title) { "#{@scenario.title} - #{t('meta.name')}" }
+
 .scenario_wrapper#show_scenario
 
   - if @warning

--- a/app/views/scenarios/index.html.haml
+++ b/app/views/scenarios/index.html.haml
@@ -1,3 +1,5 @@
+- content_for(:page_title) { "#{t('scenario.saved')} - #{t('meta.name')}" }
+
 .scenario_wrapper
   %h3= link_to t("scenario.link"), new_scenario_path
   = form_tag compare_scenarios_path, method: 'get' do

--- a/app/views/scenarios/new.html.haml
+++ b/app/views/scenarios/new.html.haml
@@ -1,3 +1,5 @@
+- content_for(:page_title) { "#{t('scenario.save')} - #{t('meta.name')}" }
+
 .scenario_wrapper
   %h1= t("scenario.save")
   %p= t("scenario.save_desc")

--- a/app/views/scenarios/show.html.haml
+++ b/app/views/scenarios/show.html.haml
@@ -1,3 +1,5 @@
+- content_for(:page_title) { "#{@scenario.title} - #{t('meta.name')}" }
+
 .scenario_wrapper#show_scenario
 
   - if @warning

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -133,6 +133,7 @@ en:
         short: residents
 
   updated:
+    name: "What's new"
     title: The ETM has been updated!
     description:
       This update includes curtailment of solar PV panels, improved heat demand

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -133,6 +133,7 @@ nl:
         short: inwoners
 
   updated:
+    name: "Laatste updates"
     title: Het ETM is geüpdatet!
     description:
       "Deze update bevat productiebeperking van zonnepanelen, verbeterde warmtevraagprofielen


### PR DESCRIPTION
Add page titles to pages that have the blue etm header but are not in the play environnement:

- Show (saved) scenario: use the scenario title as page title

- What's new, saved scenario index, new scenario

We might also want to add titles to compare and multi year?