### PR TITLE
Add listeners for attached custom curves before rendering

### DIFF
--- a/app/assets/javascripts/lib/views/custom_curve_chooser_view.js
+++ b/app/assets/javascripts/lib/views/custom_curve_chooser_view.js
@@ -548,8 +548,6 @@
         scenarios: scenarios
       });
 
-      view.render();
-
       // If the el data specifies to enable/disable a slider when a custom curve
       // is set, listen to the view events...
       if (disableInputKey) {
@@ -561,6 +559,8 @@
           }
         });
       }
+
+      view.render();
     });
   };
 


### PR DESCRIPTION
Fixes #3389 

The average price slider was not disabled when returning to a slide containing a previously uploaded interconnector price curve. Cause: the `curveIsSet` event was triggered before the listeners were added.