### PR TITLE
Separates demand series on "Electricity production"

### DIFF
--- a/config/interface/output_element_series/source_of_electricity_production.yml
+++ b/config/interface/output_element_series/source_of_electricity_production.yml
@@ -132,8 +132,20 @@
   output_element_key: source_of_electricity_production
   key: solar_source_of_electricity_production
 - label: demand_incl_export
-  color: "#FF0000"
+  color: "#5D59C7"
   order_by: 14
+  group: ''
+  show_at_first: false
+  is_target_line: true
+  target_line_position: '2'
+  gquery: future_demand_and_export_in_source_of_electricity_production
+  is_1990:
+  dependent_on:
+  output_element_key: source_of_electricity_production
+  key: future_demand_and_export_source_of_electricity_production
+- label: domestic_demand
+  color: "#FF0000"
+  order_by: 15
   group: ''
   show_at_first: false
   is_target_line: true
@@ -143,9 +155,9 @@
   dependent_on:
   output_element_key: source_of_electricity_production
   key: present_demand_source_of_electricity_production
-- label: demand_incl_export
+- label: domestic_demand
   color: "#FF0000"
-  order_by: 15
+  order_by: 16
   group: ''
   show_at_first: false
   is_target_line: true

--- a/config/locales/interface/output_element_series/en_labels.yml
+++ b/config/locales/interface/output_element_series/en_labels.yml
@@ -221,6 +221,7 @@ en:
         diff_20xx: "diff 20xx"
         dish_washer: "Dish washer"
         dispatchable_electricity_production_capacity: "Dispatchable production capacity"
+        domestic_demand: "Demand (domestic)"
         domestic_planes: "Domestic planes"
         elec_p2g: "Electricity (power-to-gas)"
         electric_bicycles: "Electric bicycles"

--- a/config/locales/interface/output_element_series/nl_labels.yml
+++ b/config/locales/interface/output_element_series/nl_labels.yml
@@ -212,6 +212,7 @@ nl:
         diff_20xx: "versch 20xx"
         dish_washer: "Vaatwasser"
         dispatchable_electricity_production_capacity: "Thermische productiecapaciteit"
+        domestic_demand: "Vraag (binnenlandse)"
         domestic_planes: "Binnenlandse vliegtuigen"
         elec_p2g: "Elektriciteit (power-to-gas)"
         electric_bicycles: "E-bikes"


### PR DESCRIPTION
Adds a "Demand (domestic)" series which does not include export, shown only for the future. Please merge https://github.com/quintel/etsource/pull/2308 first.

I'd appreciate a quick sanity check on [the "Demand (domestic)" translation](https://github.com/quintel/etmodel/blob/0ce5730dd639ec192be8e05db2972ec6605cece1/config/locales/interface/output_element_series/nl_labels.yml#L215). "binnenlandse" is used elsewhere in the ETM, but Google thinks it should be "huiselijk" (I'm guessing this refers to a house or household, rather than an area?).

<img width="610" alt="Screenshot 2020-06-16 at 10 30 42" src="https://user-images.githubusercontent.com/4383/84763668-7df6d280-afc4-11ea-9e83-ce3848e72dcf.png">
