### PR TITLE
Remove unnecessary calls to SavedScenario#scenario

### DIFF
--- a/app/assets/javascripts/factsheet.js
+++ b/app/assets/javascripts/factsheet.js
@@ -84,10 +84,6 @@ jQuery(function() {
     var units = preferredUnits(response.gqueries);
     var gqueries = transformGqueries(response.gqueries, units);
 
-    if (response.scenario.title && response.scenario.title !== 'API') {
-      $('#title').append($('<h2/>').text(response.scenario.title));
-    }
-
     assignQueryValues(document, gqueries);
 
     // Must show the factsheet prior to rendering the charts to get accurate

--- a/app/controllers/scenarios_controller.rb
+++ b/app/controllers/scenarios_controller.rb
@@ -35,8 +35,7 @@ class ScenariosController < ApplicationController
     else
       current_user.saved_scenarios
     end
-    @saved_scenarios = items.order('created_at DESC').page(params[:page]).per(50)
-    SavedScenario.batch_load(@saved_scenarios)
+    @saved_scenarios = items.order('updated_at DESC').page(params[:page]).per(50)
 
     respond_to do |format|
       format.html

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -122,34 +122,6 @@ module LayoutHelper
     number_to_percentage(percent, precision: precision)
   end
 
-  # Public: Creates a drop-down of preset and user-saved scenarios.
-  def presets_select
-    grouped = Api::Scenario.in_groups(Api::Scenario.all(from: :templates))
-
-    # Global presets.
-    grouped_options = grouped.map do |group|
-      options   = group[:scenarios].map { |s| [s.title, s.id] }
-      group_key = group[:name].to_s.downcase.gsub(/\s+/, '_').presence
-
-      [t("scenario.#{ group_key }", default: group[:name]), options]
-    end
-
-    # Logged-in user's saved scenarios.
-    if current_user
-      available_scenarios = current_user.saved_scenarios.select(&:scenario)
-
-      if available_scenarios.any?
-        user_scenarios = available_scenarios.reverse.map do |ss|
-          [ss.scenario.title, ss.scenario.id]
-        end
-
-        grouped_options.unshift([t('scenario.saved'), user_scenarios])
-      end
-    end
-
-    select_tag 'id', grouped_options_for_select(grouped_options), id: :preset_id
-  end
-
   def flags
     @flags ||= Dir.chdir(Rails.root.join('app/assets/images')) do
       Dir.glob("flags-24/*.png")

--- a/app/models/saved_scenario.rb
+++ b/app/models/saved_scenario.rb
@@ -71,4 +71,13 @@ class SavedScenario < ActiveRecord::Base
       Setting.load_from_scenario(scenario)
     end
   end
+
+  # Public: Determines if this scenario can be loaded.
+  def loadable?
+    Api::Area.code_exists?(area_code)
+  end
+
+  def days_until_last_update
+    (Time.current - updated_at) / 60 / 60 / 24
+  end
 end

--- a/app/views/factsheets/show.html.haml
+++ b/app/views/factsheets/show.html.haml
@@ -9,6 +9,9 @@
       %h1
         Energiemix
         %strong= t("areas.#{@scenario.area_code}")
+      - if @saved_scenario
+        %h2
+          = @saved_scenario.title
     %dl.detail-list
       %dt Inwoners
       %dd(data-query="households_number_of_inhabitants" data-period="future") &mdash;

--- a/app/views/scenarios/_scenarios_slice.html.haml
+++ b/app/views/scenarios/_scenarios_slice.html.haml
@@ -1,10 +1,10 @@
 - @saved_scenarios.each do |ss|
-  - if ss.scenario&.loadable?
+  - if ss.loadable?
     %tr{class: cycle('even', 'odd') + (' highlight' if @student_ids.include?(ss.user_id)).to_s}
-      %td= check_box_tag 'scenario_ids[]', ss.scenario.id
+      %td= check_box_tag 'scenario_ids[]', ss.scenario_id
       %td= link_to ss.title, ss
-      %td= ss.scenario.end_year
-      %td= ss.scenario.parsed_created_at&.to_formatted_s(:long)
+      %td= ss.end_year
+      %td= ss.updated_at.to_formatted_s(:long)
       %td= ss.user.name
   - elsif current_user.admin?
     %tr{class: "unavailable #{cycle('even', 'odd')}" }
@@ -14,12 +14,10 @@
         = ss.title
         == (#{ss.scenario_id})
         &ndash;
-        - if ss.scenario
-          cannot be loaded
-        - else
-          does not exist
+        = t('scenario.area_not_exists')
+        (#{ss.area_code})
       %td= ""
-      %td= ss.created_at.to_datetime&.to_formatted_s(:long)
+      %td= ss.updated_at.to_datetime&.to_formatted_s(:long)
       %td= ss.user.email
 %tr#scenario_paginator
   %td{colspan: 5}= link_to_next_page @saved_scenarios, 'More...', remote: true

--- a/app/views/scenarios/index.html.haml
+++ b/app/views/scenarios/index.html.haml
@@ -13,7 +13,7 @@
           %th= t 'scenario.compare'
           %th.tal{:width => 450}= t("scenario.title")
           %th.tal{:width => 80}= t("scenario.end_year")
-          %th.tal= t("scenario.created")
+          %th.tal= t("scenario.updated")
           %th.tal= t("scenario.created_by")
       %tbody
         = render 'scenarios_slice'

--- a/app/views/scenarios/info.html.haml
+++ b/app/views/scenarios/info.html.haml
@@ -1,2 +1,0 @@
-%h1=raw @title
-%section.description= raw @description

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -181,6 +181,7 @@ en:
     end_year: "End Year"
     go_back: "Or go back to"
     link: "Save your current settings into a scenario"
+    area_not_exists: 'Area does not exist'
     load: "Open this scenario"
     load_factsheet: "Open energy mix infographic"
     no_title: "Scenario without title"

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -181,6 +181,7 @@ nl:
     end_year: "Eindjaar"
     go_back: " of ga anders terug naar"
     link: "Sla uw huidige instellingen op in een scenario"
+    area_not_exists: 'Regio bestaat niet'
     load: "Open dit scenario"
     load_factsheet: "Open energie-mix infographic"
     no_title: "Scenario zonder titel"

--- a/spec/cassettes/SavedScenariosController/a_regular_user/GET_load/with_a_not-loadable_scenario/redirects_to_show.yml
+++ b/spec/cassettes/SavedScenariosController/a_regular_user/GET_load/with_a_not-loadable_scenario/redirects_to_show.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://beta-engine.energytransitionmodel.com/api/v3/scenarios.json
+    body:
+      encoding: UTF-8
+      string: '{"scenario":{"scenario_id":648695}}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.14.0
+      Date:
+      - Fri, 03 Jul 2020 07:44:53 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      - Origin
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Etag:
+      - W/"9f55a80b710dcc4c6a75581707f6f9d3"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - ebd08faa-75b9-42c8-ae96-c2e69bdd89e2
+      X-Runtime:
+      - '0.045532'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":1322708,"title":"API","area_code":"nl","start_year":2015,"end_year":2050,"url":"https://beta-engine.energytransitionmodel.com/api/v3/scenarios/1322708","ordering":null,"display_group":null,"scaling":null,"source":null,"template":648695,"created_at":"2020-07-03T07:44:53.000Z","protected":false}'
+    http_version: 
+  recorded_at: Fri, 03 Jul 2020 07:44:53 GMT
+recorded_with: VCR 3.0.3

--- a/spec/controllers/saved_scenarios_controller_spec.rb
+++ b/spec/controllers/saved_scenarios_controller_spec.rb
@@ -52,6 +52,20 @@ describe SavedScenariosController, vcr: true do
           expect(response).to redirect_to play_path
         end
       end
+
+      it 'with a not-loadable scenario redirects to #show' do
+        allow(user_scenario.scenario).to receive(:loadable?).and_return(false)
+        get :load, params: { id: user_scenario.id }
+        expect(response).to be_redirect
+      end
+
+      it 'with a non-existent scenario redirects to #show' do
+        allow(Api::Scenario)
+          .to receive(:find)
+          .and_raise(ActiveResource::ResourceNotFound.new(nil))
+        get :load, params: { id: user_scenario.id }
+        expect(response).to be_redirect
+      end
     end
   end
 
@@ -59,23 +73,6 @@ describe SavedScenariosController, vcr: true do
     it 'has an ok status' do
       get :show, params: { id: user_scenario.id }
       expect(response).to be_successful
-    end
-
-    it 'with a not-loadable scenario' do
-      expect(user_scenario.scenario).to receive(:loadable?).and_return(false)
-
-      get :show, params: { id: user_scenario.id }
-
-      expect(response).to be_redirect
-    end
-
-
-    it 'with a non-existent scenario' do
-      allow(Api::Scenario)
-        .to receive(:find)
-        .and_raise(ActiveResource::ResourceNotFound.new(nil))
-      get :show, params: { id: user_scenario.id }
-      expect(response).to be_redirect
     end
 
     it 'responds to the .csv format' do


### PR DESCRIPTION
One's barely merged, and I've already got you a new PR.

* Scenarios#index: now sort on SavedScenario#updated_at; check loadability on SavedScenario; remove calls to SavedScenario#scenario in views

* EnergyMix: use title from SavedScenario

* LayoutHelper: remove unused method preset_select

* SavedScenarioController: only call Api::Scenario on #load; redirect to #show when #load fails; base days_old warning check on SavedScenario#updated_at.