### PR TITLE
Switch to system font stack

### DIFF
--- a/app/assets/stylesheets/chart.sass
+++ b/app/assets/stylesheets/chart.sass
@@ -290,7 +290,7 @@ div.d3_container
     svg
       shape-rendering: crispEdges
   text
-    font-family: $body_font_family
+    font-family: $body-font-family
     font-size: 12px
   .year.small
     fill: #777

--- a/app/assets/stylesheets/dashboard.sass
+++ b/app/assets/stylesheets/dashboard.sass
@@ -91,7 +91,7 @@
 @media screen and (max-width: 960px)
   #dashboard_container #dashboard .dashboard_item
     .header
-      font-family: $body_font_family
+      font-family: $body-font-family
       font-size: 12px
       height: 18px
       line-height: 11px
@@ -128,7 +128,7 @@
   h1
     background: url(/assets/icons/dashboard.png) 160px 0 no-repeat
     border-bottom: 1px solid #ccc
-    font: bold 16px $body_font_family
+    font: bold 16px $body-font-family
     padding: 3px 0 20px 200px
     margin: -3px 0 21px
 

--- a/app/assets/stylesheets/dashboard_popup.sass
+++ b/app/assets/stylesheets/dashboard_popup.sass
@@ -60,14 +60,14 @@
     background: url(/assets/layout/still_to_do.png) no-repeat
 
   table#policies
-    font-family: 13px/13px $body_font_family
+    font-family: 13px/13px $body-font-family
     line-height: 0.9em
     border-collapse: collapse
     width: 100%
     td, th
       padding: 10px 12px
     th
-      font-family: $body_font_family
+      font-family: $body-font-family
       text-align: left
     tr
       &.even

--- a/app/assets/stylesheets/form.sass
+++ b/app/assets/stylesheets/form.sass
@@ -65,7 +65,7 @@ form, fieldset
     border: 1px solid #bbb
     border-radius: 3px
     padding: 7px
-    font-family: "Lucida Grande", Verdana, Arial, Helvetica, sans-serif
+    font-family: $body-font-family
     width: 300px
     transition: border-color .1s, box-shadow .1s
 

--- a/app/assets/stylesheets/general_styles.sass
+++ b/app/assets/stylesheets/general_styles.sass
@@ -1,8 +1,10 @@
-$body_font_family: "Lucida Grande", Verdana, Arial, Helvetica, sans-serif
+$body-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"
 
 body
+  font-family: $body-font-family
+  font-size: 13px
+  line-height: 20px
   margin: 0
-  font: 13px/20px $body_font_family
 
 h1
   line-height: 1em

--- a/app/assets/stylesheets/report.css.sass
+++ b/app/assets/stylesheets/report.css.sass
@@ -1,5 +1,5 @@
 $font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"
-$body_font_family: $font-family
+$body-font-family: $font-family
 
 $font-color: #333
 $grey: #7e868e

--- a/app/assets/stylesheets/root.sass
+++ b/app/assets/stylesheets/root.sass
@@ -1,4 +1,4 @@
-$landing-font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol
+$landing-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"
 $landing-width: 652px
 $landing-green: #56b351
 $landing-grey: #78818c

--- a/app/assets/stylesheets/sidebar.sass
+++ b/app/assets/stylesheets/sidebar.sass
@@ -168,7 +168,7 @@ $sidebar-active-bg: #e2e2e2
         border: 0
         color: #a29a71
         cursor: pointer
-        font-family: $body_font_family
+        font-family: $body-font-family
         font-size: 11px
         margin: -5px -7px
         outline: none


### PR DESCRIPTION
We already use the system font stack on a number of ETM pages (notably the root page where you select whether to continue a scenario, start a new one, or start a preset). This pull request changes the scenario pages to also use these fonts.

Before pushing ahead I'd like to ensure @quintel/core is on board.

> Defaulting to the system font of a particular operating system can boost performance because the browser doesn’t have to download any font files, it’s using one it already had. That’s true of any “web safe” font, though. The beauty of “system” fonts is that it matches what the current OS uses, so it can be a comfortable look.
>
> *― [System Font Stack](https://css-tricks.com/snippets/css/system-font-stack/), CSS Tricks*

In our case, the pages won't load any faster since we weren't using a web font, but the system stack does look more moder and, IMO, is a little easier to design for.

### Comparisons

| Before | After |
| --- | --- |
| ![0-before](https://user-images.githubusercontent.com/4383/86485143-dca3a680-bd4f-11ea-833d-e213b3a12c4b.png) | ![0-after](https://user-images.githubusercontent.com/4383/86485151-e0cfc400-bd4f-11ea-89f2-9fa8087fcc90.png) |
| ![1-before](https://user-images.githubusercontent.com/4383/86485166-e9c09580-bd4f-11ea-9e38-a84cde0efb56.png) | ![1-after](https://user-images.githubusercontent.com/4383/86485175-f04f0d00-bd4f-11ea-8977-f303c4ff2234.png) |
| ![2-before](https://user-images.githubusercontent.com/4383/86485180-f644ee00-bd4f-11ea-99e4-34e45b61e95d.png) | ![2-after](https://user-images.githubusercontent.com/4383/86485177-f513c100-bd4f-11ea-87a3-4716fcf88f6c.png) |

### Full-size examples

![Screenshot 2020-07-03 at 17 18 35](https://user-images.githubusercontent.com/4383/86485710-54be9c00-bd51-11ea-8a32-652e28792405.png)
![Screenshot 2020-07-03 at 17 18 53](https://user-images.githubusercontent.com/4383/86485717-57b98c80-bd51-11ea-8ee0-0f19d604d106.png)

