### PR TITLE
Custom curves scenario order: same end year first, exclude same area

### DIFF
--- a/app/controllers/saved_scenarios_controller.rb
+++ b/app/controllers/saved_scenarios_controller.rb
@@ -14,10 +14,10 @@ class SavedScenariosController < ApplicationController
         if current_user
           render json:
             SavedScenarioPresenter.new(
-              current_user
-                .saved_scenarios
-                .where(end_year: Current.setting.end_year)
-                .order('created_at DESC')
+              current_user.saved_scenarios.custom_curves_order(
+                Current.setting.end_year,
+                Current.setting.area_code
+              )
             )
         else
           render json: []

--- a/app/models/saved_scenario.rb
+++ b/app/models/saved_scenario.rb
@@ -28,6 +28,15 @@ class SavedScenario < ActiveRecord::Base
 
   serialize :scenario_id_history, Array
 
+  # Order as to be provided to the custom curves chooser. Scenarios with the given
+  # end_year go on top, scenarios with the given area_code are not included.
+  def self.custom_curves_order(end_year, area_code)
+    scenarios = all.where.not(area_code: area_code)
+    top = scenarios.where(end_year: end_year).order(updated_at: :desc)
+    bottom = scenarios.where.not(end_year: end_year).order(end_year: :desc, updated_at: :desc)
+    top + bottom
+  end
+
   def self.batch_load(saved_scenarios, options = {})
     saved_scenarios = saved_scenarios.to_a
     ids = saved_scenarios.map(&:scenario_id)

--- a/spec/models/saved_scenario_spec.rb
+++ b/spec/models/saved_scenario_spec.rb
@@ -76,4 +76,29 @@ describe SavedScenario do
         .not_to change{subject.scenario_id_history.count}
     end
   end
+
+  describe '.custom_curves_order' do
+    subject { described_class.custom_curves_order(2050, 'nl') }
+
+    let(:scenario_nl_2030) { FactoryBot.create(:saved_scenario, end_year: 2030) }
+    let(:scenario_nl_2050) { FactoryBot.create(:saved_scenario, end_year: 2050) }
+    let(:scenario_de_2030) { FactoryBot.create(:saved_scenario, end_year: 2030, area_code: 'de') }
+    let(:scenario_de_2050) { FactoryBot.create(:saved_scenario, end_year: 2050, area_code: 'de') }
+    let(:scenario_be_2030) { FactoryBot.create(:saved_scenario, end_year: 2030, area_code: 'be') }
+
+    before do
+      scenario_nl_2030
+      scenario_nl_2050
+      scenario_de_2030
+      scenario_de_2050
+      scenario_be_2030
+    end
+
+    it { is_expected.to include(scenario_de_2030, scenario_de_2050, scenario_be_2030) }
+    it { is_expected.not_to include(scenario_nl_2030, scenario_nl_2050) }
+
+    it 'puts the 2050 scenario first' do
+      expect(subject.first).to eq(scenario_de_2050)
+    end
+  end
 end


### PR DESCRIPTION
In #3430 there was some discussion about _not_ showing scenarios with the same end year. I changed the order into:

- Not showing scenarios that have the same area code as the current scenario

- Putting the scenarios that have the same end year as the current scenario at the top of the list

- (Sub)order on last updated