### PR TITLE
Format CO2 in titles using subscript

### DIFF
--- a/app/assets/stylesheets/scenarios.sass
+++ b/app/assets/stylesheets/scenarios.sass
@@ -55,6 +55,8 @@ table.default
 
     h1
       margin-bottom: 0.5em
+      sub
+        line-height: 0
 
     .actions
       display: flex

--- a/app/helpers/scenario_helper.rb
+++ b/app/helpers/scenario_helper.rb
@@ -79,6 +79,15 @@ module ScenarioHelper
     link_stripper.inner_html
   end
 
+  # Public: Given a string, converts CO2 to have a subscript 2.
+  #
+  # Returns an HTML-safe string.
+  def format_subscripts(string)
+    # rubocop:disable Rails/OutputSafety
+    h(string).gsub(/\bCO2\b/, 'CO<sub>2</sub>').html_safe if string.present?
+    # rubocop:enable Rails/OutputSafety
+  end
+
   # Public: Renders the HTML needed to show a price curve upload form.
   #
   # curve_name - The name/type of the curve.

--- a/app/views/pages/root_page/_scenario_group.haml
+++ b/app/views/pages/root_page/_scenario_group.haml
@@ -8,9 +8,9 @@
       = link_to scenario_path(scenario) do
         - title, org = scenario.title.split(' - ', 2)
 
-        %span.who= title.html_safe
+        %span.who= format_subscripts(title)
         %span.org= org.html_safe
   - else
     %li
       = link_to scenario_path(scenario) do
-        = scenario.title.html_safe
+        = format_subscripts(scenario.title)

--- a/app/views/saved_scenarios/_scenario.html.haml
+++ b/app/views/saved_scenarios/_scenario.html.haml
@@ -1,4 +1,4 @@
-%h1= saved_scenario.title
+%h1= format_subscripts(saved_scenario.title)
 
 = render partial: 'info', locals: { scenario: saved_scenario }
 

--- a/app/views/scenarios/show.html.haml
+++ b/app/views/scenarios/show.html.haml
@@ -7,7 +7,8 @@
       .warning
         = @warning
 
-    %h1= @scenario.title ? @scenario.title : @scenario.id
+    %h1
+      = @scenario.title ? format_subscripts(@scenario.title) : @scenario.id
 
     %ul.details
       %li

--- a/spec/helpers/scenario_helper_spec.rb
+++ b/spec/helpers/scenario_helper_spec.rb
@@ -198,4 +198,38 @@ describe ScenarioHelper do
     #   ).to eq('')
     # end
   end
+
+  describe '.format_subscripts' do
+    context 'with "My CO2 scenario"' do
+      it 'returns "My CO<sub>2</sub> scenario' do
+        expect(helper.format_subscripts('My CO2 scenario')).to eq('My CO<sub>2</sub> scenario')
+      end
+    end
+
+    context 'with "My CO2A scenario"' do
+      it 'returns "My CO2A scenario' do
+        expect(helper.format_subscripts('My CO2A scenario')).to eq('My CO2A scenario')
+      end
+    end
+
+    context 'with "My CO2-sturing scenario"' do
+      it 'returns "My CO<sub>2</sub>-sturing scenario' do
+        expect(helper.format_subscripts('My CO2-sturing scenario'))
+          .to eq('My CO<sub>2</sub>-sturing scenario')
+      end
+    end
+
+    context 'with "My <strong>scenario</strong>' do
+      it 'returns "My &lt;strong&gt;scenario&lt;/strong&gt;' do
+        expect(helper.format_subscripts('My <strong>scenario</strong>'))
+          .to eq('My &lt;strong&gt;scenario&lt;/strong&gt;')
+      end
+    end
+
+    context 'with nil' do
+      it 'returns nil' do
+        expect(helper.format_subscripts(nil)).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Formats "CO2" as "CO₂" in scenario titles on the root page, and when viewing the scenario information and description.

![Screenshot 2020-07-10 at 15 02 30](https://user-images.githubusercontent.com/4383/87162883-72928080-c2be-11ea-84b2-963033fdeb0c.png)

Ref https://github.com/quintel/etsource/pull/2320