### PR TITLE
Style Scenarios#index like #show and root-page

### DIFF
--- a/app/assets/stylesheets/scenarios.sass
+++ b/app/assets/stylesheets/scenarios.sass
@@ -142,14 +142,13 @@ table.default
           font-size: 1rem
           display: inline-block
           width: 100%
-
-          &:hover
-            color: darken($landing-blue, 4%)
-            text-decoration: underline
         .info
           color: black
         .author
           color: $landing-grey
+        &:hover .title
+          color: darken($landing-blue, 4%)
+          text-decoration: underline
 
       #scenario_paginator td
         border: none

--- a/app/assets/stylesheets/scenarios.sass
+++ b/app/assets/stylesheets/scenarios.sass
@@ -31,10 +31,7 @@ table.default
   height: max-content
 
 .scenario_wrapper
-  &#index
-    padding: 5px 20px 110px 20px
-
-  &#show_scenario, &#feature_scenario
+  &#show_scenario, &#feature_scenario, &#index
     width: $landing-width
     margin: 0 auto 3rem
     background: white
@@ -105,12 +102,38 @@ table.default
           background: linear-gradient(darken($landing-blue, 1%), darken($landing-blue, 7%))
         &.dim
           background: linear-gradient(lighten($landing-blue, 25%), lighten($landing-blue, 18%))
-      &.cancel
+      &.cancel, &.compare
         &:hover
           color: lighten(black, 15%)
           background: linear-gradient(lighten(#eee, 9%), lighten(#eee, 2%))
         &:active
           background: linear-gradient(#eee, darken(#eee, 7%))
+      &.compare
+        font-size: 0.7rem
+        padding: 5px 8px
+
+  &#index
+    table
+      width: 100%
+      margin: 10px 0
+      .box
+        border-right: none
+      .info
+        border-left: none
+        padding: 5px 4px
+        a
+          font-weight: bold
+          text-decoration: none
+          margin-right: 4px
+          &:hover
+            color: darken($landing-blue, 4%)
+            text-decoration: underline
+        .by
+          font-size: 0.7rem
+          color: $landing-grey
+
+      #scenario_paginator td
+        border: none
 
   &#show_scenario
     .title

--- a/app/assets/stylesheets/scenarios.sass
+++ b/app/assets/stylesheets/scenarios.sass
@@ -84,14 +84,6 @@ table.default
       padding: 10px 15px
       margin: 0.5rem 0.5rem 1rem 0
       -webkit-font-smoothing: antialiased
-      &.save
-        background: $landing-green
-        background: linear-gradient(lighten($landing-green, 10%), $landing-green)
-        color: white
-        &:hover
-          background: linear-gradient(lighten($landing-green, 14%), lighten($landing-green, 7%))
-        &:active
-          background: linear-gradient(darken($landing-green, 1%), darken($landing-green, 7%))
       &.load
         background-color: $landing-blue
         background: linear-gradient(lighten($landing-blue, 10%), $landing-blue)
@@ -108,28 +100,55 @@ table.default
           background: linear-gradient(lighten(#eee, 9%), lighten(#eee, 2%))
         &:active
           background: linear-gradient(#eee, darken(#eee, 7%))
+      &.save
+        background: $landing-green
+        background: linear-gradient(lighten($landing-green, 10%), $landing-green)
+        color: white
+        &:hover
+          color: white
+          background: linear-gradient(lighten($landing-green, 14%), lighten($landing-green, 7%))
+        &:active
+          background: linear-gradient(darken($landing-green, 1%), darken($landing-green, 7%))
       &.compare
-        font-size: 0.7rem
+        font-size: 0.75rem
+        font-weight: normal
         padding: 5px 8px
 
   &#index
+    .vertical-bar
+      width: 0
+      height: 30px
+      border: 0.5px solid #ddd
+      display: inline-block
+      margin: 0 8px -7px 0
+    a
+      color: #3c8ee1
+
     table
       width: 100%
       margin: 10px 0
-      .box
-        border-right: none
-      .info
-        border-left: none
-        padding: 5px 4px
-        a
+      td
+        border: none
+        padding: 8px 10px
+      input
+        height: 16px
+        width: 16px
+      a
+        display: block
+        text-decoration: none
+        cursor: pointer
+        .title
           font-weight: bold
-          text-decoration: none
-          margin-right: 4px
+          font-size: 1rem
+          display: inline-block
+          width: 100%
+
           &:hover
             color: darken($landing-blue, 4%)
             text-decoration: underline
-        .by
-          font-size: 0.7rem
+        .info
+          color: black
+        .author
           color: $landing-grey
 
       #scenario_paginator td

--- a/app/views/scenarios/_scenarios_slice.html.haml
+++ b/app/views/scenarios/_scenarios_slice.html.haml
@@ -2,28 +2,34 @@
   - if ss.loadable?
     %tr
       %td.box= check_box_tag 'scenario_ids[]', ss.scenario_id
-      %td.info
-        = link_to ss.title, ss
-        = t('areas.' + ss.area_code)
-        = ss.end_year
-        .by
-          #{ss.user.name},
-          = t('scenario.updated')
-          = I18n.localize(ss.updated_at, :format => :long)
+      %td
+        %a{ href:"/saved_scenarios/#{ss.id}" }
+          %span.title= ss.title
+          %span.info
+            = t('areas.' + ss.area_code)
+            = ss.end_year
+          %span.author
+            = t('scenario.by')
+            = ss.user.name
 
   - elsif current_user.admin?
     %tr.unavailable
       %td.box= check_box_tag 'scenario_ids[]', -1, false, disabled: true
-      %td.info
-        = ss.title
-        == (#{ss.scenario_id})
-        &ndash;
-        = t('scenario.area_not_exists')
-        (#{ss.area_code})
-        .by
-          = ss.user.email
-          = t('scenario.updated')
-          = I18n.localize(ss.updated_at, :format => :long)
+      %td
+        %a
+          %span.title
+            = ss.title
+            (#{ss.scenario_id}) &ndash;
+            %em
+              = t('scenario.area_not_exists')
+          %span.info
+            = ss.area_code
+          %span.author
+            = t('scenario.by')
+            = ss.user.email
+            &ndash;
+            = t('scenario.updated')
+            = I18n.localize(ss.updated_at, :format => :long)
 %tr#scenario_paginator
   %td
   %td= link_to_next_page @saved_scenarios, 'More...', remote: true

--- a/app/views/scenarios/_scenarios_slice.html.haml
+++ b/app/views/scenarios/_scenarios_slice.html.haml
@@ -1,23 +1,29 @@
 - @saved_scenarios.each do |ss|
   - if ss.loadable?
-    %tr{class: cycle('even', 'odd') + (' highlight' if @student_ids.include?(ss.user_id)).to_s}
-      %td= check_box_tag 'scenario_ids[]', ss.scenario_id
-      %td= link_to ss.title, ss
-      %td= ss.end_year
-      %td= ss.updated_at.to_formatted_s(:long)
-      %td= ss.user.name
+    %tr
+      %td.box= check_box_tag 'scenario_ids[]', ss.scenario_id
+      %td.info
+        = link_to ss.title, ss
+        = t('areas.' + ss.area_code)
+        = ss.end_year
+        .by
+          #{ss.user.name},
+          = t('scenario.updated')
+          = I18n.localize(ss.updated_at, :format => :long)
+
   - elsif current_user.admin?
-    %tr{class: "unavailable #{cycle('even', 'odd')}" }
-      -# DEBT: use I18n here.
-      %td= check_box_tag 'scenario_ids[]', -1, false, disabled: true
-      %td
+    %tr.unavailable
+      %td.box= check_box_tag 'scenario_ids[]', -1, false, disabled: true
+      %td.info
         = ss.title
         == (#{ss.scenario_id})
         &ndash;
         = t('scenario.area_not_exists')
         (#{ss.area_code})
-      %td= ""
-      %td= ss.updated_at.to_datetime&.to_formatted_s(:long)
-      %td= ss.user.email
+        .by
+          = ss.user.email
+          = t('scenario.updated')
+          = I18n.localize(ss.updated_at, :format => :long)
 %tr#scenario_paginator
-  %td{colspan: 5}= link_to_next_page @saved_scenarios, 'More...', remote: true
+  %td
+  %td= link_to_next_page @saved_scenarios, 'More...', remote: true

--- a/app/views/scenarios/index.html.haml
+++ b/app/views/scenarios/index.html.haml
@@ -1,19 +1,13 @@
 - content_for(:page_title) { "#{t('scenario.saved')} - #{t('meta.name')}" }
 
-.scenario_wrapper#index
-  %h3= link_to t("scenario.link"), new_scenario_path
-  = form_tag compare_scenarios_path, method: 'get' do
-    %h3= t("scenario.saved")
-    = submit_tag t('scenario.compare')
-    = submit_tag t('scenario.merge'), name: 'merge'
-    = submit_tag t('scenario.local_vs_global'), name: 'combine'
-    %table.default
-      %thead
-        %tr
-          %th= t 'scenario.compare'
-          %th.tal{:width => 450}= t("scenario.title")
-          %th.tal{:width => 80}= t("scenario.end_year")
-          %th.tal= t("scenario.updated")
-          %th.tal= t("scenario.created_by")
-      %tbody
-        = render 'scenarios_slice'
+.background_wrapper#saved_scenario
+  .scenario_wrapper#index
+    %h3= link_to t("scenario.link"), new_scenario_path
+    = form_tag compare_scenarios_path, method: 'get' do
+      %h1= t("scenario.saved")
+      = submit_tag t('scenario.compare'), class: 'button compare'
+      = submit_tag t('scenario.merge'), name: 'merge', class: 'button compare'
+      = submit_tag t('scenario.local_vs_global'), name: 'combine', class: 'button compare'
+      %table.default
+        %tbody
+          = render 'scenarios_slice'

--- a/app/views/scenarios/index.html.haml
+++ b/app/views/scenarios/index.html.haml
@@ -2,12 +2,14 @@
 
 .background_wrapper#saved_scenario
   .scenario_wrapper#index
-    %h3= link_to t("scenario.link"), new_scenario_path
     = form_tag compare_scenarios_path, method: 'get' do
       %h1= t("scenario.saved")
       = submit_tag t('scenario.compare'), class: 'button compare'
       = submit_tag t('scenario.merge'), name: 'merge', class: 'button compare'
       = submit_tag t('scenario.local_vs_global'), name: 'combine', class: 'button compare'
+      - if Current.setting.api_session_id
+        .vertical-bar
+        = link_to t("scenario.link"), new_scenario_path, class: 'button compare save'
       %table.default
         %tbody
           = render 'scenarios_slice'

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -180,7 +180,8 @@ en:
     updated: "Last updated"
     end_year: "End Year"
     go_back: "Or go back to"
-    link: "Save your current settings into a scenario"
+    link: "Save current scenario"
+    by: "By"
     area_not_exists: 'Area does not exist'
     load: "Open this scenario"
     load_energy_mix: "Open energy mix infographic"

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -180,7 +180,8 @@ nl:
     updated: "Laatst gewijzigd op"
     end_year: "Eindjaar"
     go_back: " of ga anders terug naar"
-    link: "Sla uw huidige instellingen op in een scenario"
+    link: "Sla huidig scenario op"
+    by: "Door"
     area_not_exists: 'Regio bestaat niet'
     load: "Open dit scenario"
     load_energy_mix: "Open energie-mix infographic"


### PR DESCRIPTION
In view of the deploy tomorrow, I thought it would be nice to tie Scenarios#index in with its neighbours (Saved)Scenario#show, #feature and the root page.

Old look:

<img width="1419" alt="Screenshot 2020-07-27 at 15 06 54" src="https://user-images.githubusercontent.com/14875123/88545911-eb623e00-d01b-11ea-9db6-c750e32a732c.png">

New look:

<img width="1286" alt="Screenshot 2020-07-27 at 15 05 17" src="https://user-images.githubusercontent.com/14875123/88545943-f5843c80-d01b-11ea-9cd2-71d473359374.png">

I did nothing with the avaible options (compare, merge, compare and combine), this PR is just a small restyle. @antw feel free to comment on the design or to add your own changes 🙂  
