### PR TITLE
Remove InputElementView smartStep

### DIFF
--- a/app/assets/javascripts/lib/views/input_element_view.js
+++ b/app/assets/javascripts/lib/views/input_element_view.js
@@ -70,12 +70,6 @@
       }
     }
 
-    if (delta != undefined && delta > 100) {
-      // Don't use decimal places for sliders whose range of values exceeds the
-      // typical width of the slider.
-      precision = 0;
-    }
-
     return precision;
   };
 
@@ -178,22 +172,6 @@
 
     BODY_HIDE_EVENT = true;
   };
-
-  /**
-   * Adjusts the step value of a slider in the event that the default step is
-   * far to small to be useful.
-   *
-   * This is only ~100px available to the slider, therefore having more than 100
-   * discrete steps available to select is usless.
-   */
-  function smartStep(model) {
-    var min = model.get('min_value'),
-      max = model.get('max_value'),
-      step = model.get('step_value'),
-      perPixel = (max - min) / 100;
-
-    return perPixel > step * 1.5 ? perPixel : step;
-  }
 
   // # UnitConversion --------------------------------------------------------
 
@@ -671,9 +649,9 @@
       }
 
       if (isIncreasing) {
-        this.quinn.setTentativeValue(initialValue + smartStep(this.model));
+        this.quinn.setTentativeValue(initialValue + this.model.get('step_value'));
       } else {
-        this.quinn.setTentativeValue(initialValue - smartStep(this.model));
+        this.quinn.setTentativeValue(initialValue - this.model.get('step_value'));
       }
 
       initialValue = this.quinn.model.value;


### PR DESCRIPTION
Input value step values would be overridden whenever there were insufficient pixels to display each value discretely. If the slider is 100px wide and represents values between 0 and 1000 and the step value was 0.1, the step value would be overridden with a value equivalent to 1px (10).

This behaviour has been removed, and the values set in the interface YAML files will be trusted.
