### PR TITLE
Updated broken links to etdataset for transport efficiencies

### DIFF
--- a/config/locales/interface/input_elements/en_demand_transport.yml
+++ b/config/locales/interface/input_elements/en_demand_transport.yml
@@ -501,7 +501,7 @@ en:
         motorcycles, bicycles.\r\n<br/><br/>\r\nMost efficiency improvement is expected
         to come from battery improvements, since electric engines are inherently very
         efficient already. Most losses occur in charge/discharge cycles.\r\n<br/><br/>\r\nSee
-        the <a href=\\\"https://github.com/quintel/etdataset-public/tree/mast\r\ner/nodes_source_analyses/transport\\\">documentation
+        the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/energy/transport\">documentation
         on GitHub</a> for detailed information on the numbers and sources used."
     transport_vehicle_combustion_engine_efficiency:
       title: Combustion engine vehicles
@@ -510,7 +510,7 @@ en:
         vehicles will become every year. For example: new cars become almost 2% more
         efficient every year. \r\n<br/><br/>\r\nSome people believe these vehicles
         will become much more efficient once competition from electric vehicles becomes
-        fiercer.\r\n<br/><br/>\r\nSee the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+        fiercer.\r\n<br/><br/>\r\nSee the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/energy/transport\">documentation
         on GitHub</a> for detailed information on the numbers and sources used."
     transport_ships_efficiency:
       title: Ships
@@ -538,5 +538,5 @@ en:
         vehicles are a rather novel technology, there is still quite some room for
         improvement. The electric engine is very efficient already, but the hydrogen
         fuel cell stack (the part that generates electricity) can perform better.\r\n<br/><br/>\r\nSee
-        the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/transport\">documentation
+        the <a href=\"https://github.com/quintel/etdataset-public/tree/master/nodes_source_analyses/energy/transport\">documentation
         on GitHub</a> for detailed information on the numbers and sources used."


### PR DESCRIPTION
Links were broken due to the addition of the molecule graph and the corresponding addition of the energy folders in ETDataset.