### PR TITLE
Scale slider steps when min and max range is small

### DIFF
--- a/app/assets/javascripts/lib/models/input_element.coffee
+++ b/app/assets/javascripts/lib/models/input_element.coffee
@@ -90,6 +90,22 @@ class @InputElement extends Backbone.Model
     if @get('key') == 'settings_enable_merit_order'
       App.update_merit_order_checkbox()
 
+  # Returns the step value of the input, except in cases where the step would
+  # be too small to be meaningful (e.g. in small datasets), in which case the
+  # step will be scaled down to ensure roughly 100 steps between the min and
+  # max values.
+  smartStep: ->
+    if @smartStepValue
+      return @smartStepValue
+
+    step = @get('step_value')
+    delta = @get('max_value') - @get('min_value')
+
+    while (step * 20) > delta
+      step /= 10
+
+    @smartStepValue = step
+
 class @InputElementList extends Backbone.Collection
   model: InputElement
 

--- a/app/assets/javascripts/lib/views/input_element_view.js
+++ b/app/assets/javascripts/lib/views/input_element_view.js
@@ -84,7 +84,7 @@
     var conversions = [],
       modelConvs = model.conversions(),
       mPrecision = floatPrecision(
-        model.get('step_value'),
+        model.smartStep(),
         model.get('max_value') - model.get('min_value')
       ),
       customDefault = false,
@@ -354,7 +354,7 @@
      * Creates the HTML elements used to display the slider.
      */
     render: function() {
-      var quinnStep = this.model.get('step_value');
+      var quinnStep = this.model.smartStep();
 
       if (this.model.get('share_group')) {
         // Inputs in groups may have rounding errors (etmodel#1023) if
@@ -649,9 +649,9 @@
       }
 
       if (isIncreasing) {
-        this.quinn.setTentativeValue(initialValue + this.model.get('step_value'));
+        this.quinn.setTentativeValue(initialValue + this.model.smartStep());
       } else {
-        this.quinn.setTentativeValue(initialValue - this.model.get('step_value'));
+        this.quinn.setTentativeValue(initialValue + this.model.smartStep());
       }
 
       initialValue = this.quinn.model.value;


### PR DESCRIPTION
In small datasets, the range between the minimum and maximum values of a slider may be too small for the step to be meaningful. For example, the population slider with a step of 100k is useless in a dataset with only 50k people.

This change automatically scales the step value of a slider, dividing by ten until there are at least 20 "steps" between the minimum and maximum slider value. This should keep the step value in small datasets meaningful, without making it _too_ small.

Ref #3500
