### PR TITLE
Rename / remove old Noardeast Fryslan municipalities

### DIFF
--- a/db/migrate/20201211131435_remove_old_noardeast_fryslan_municipalities.rb
+++ b/db/migrate/20201211131435_remove_old_noardeast_fryslan_municipalities.rb
@@ -1,0 +1,16 @@
+class RemoveOldNoardeastFryslanMunicipalities < ActiveRecord::Migration[5.2]
+  OLD_NAMES = %w[
+  	GM0058_dongeradeel
+  	GM0079_kollumerland_en_nieuwkruisland
+  	GM1722_ferwerderadiel
+  ].freeze
+
+  def up
+    MultiYearChart.where(area_code: OLD_NAMES).update_all(area_code: "GM1970_noardeast_fryslan")
+    SavedScenario.where(area_code: OLD_NAMES).update_all(area_code: "GM1970_noardeast_fryslan")
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_20_083121) do
+ActiveRecord::Schema.define(version: 2020_12_11_131435) do
 
   create_table "area_dependencies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "dependent_on"


### PR DESCRIPTION
Counterpart to https://github.com/quintel/etengine/pull/1145. Renames the area code of saved scenarios and transition path charts for three Noardeast Fryslan datasets.