### PR TITLE
Hide remaining households hot water geothermal node

### DIFF
--- a/config/interface/output_element_series/source_of_heat_used_in_households.yml
+++ b/config/interface/output_element_series/source_of_heat_used_in_households.yml
@@ -95,18 +95,6 @@
   dependent_on: 
   output_element_key: source_of_heat_used_in_households
   key: ambient_heating_source_of_heat_used_in_households
-- label: geothermal_heating
-  color: "#FF8400"
-  order_by: 9
-  group: ''
-  show_at_first: false
-  is_target_line: false
-  target_line_position: ''
-  gquery: geothermal_used_for_heating_in_households
-  is_1990: false
-  dependent_on: _always_hidden
-  output_element_key: source_of_heat_used_in_households
-  key: geothermal_heating_source_of_heat_used_in_households
 - label: heat_network_hot_water
   color: "#bc1616"
   order_by: 1
@@ -203,18 +191,6 @@
   dependent_on: 
   output_element_key: source_of_heat_used_in_households
   key: ambient_hot_water_source_of_heat_used_in_households
-- label: ambient_hot_water
-  color: "#f7b671"
-  order_by: 9
-  group: ''
-  show_at_first: false
-  is_target_line: false
-  target_line_position: ''
-  gquery: geothermal_used_for_hot_water_in_households
-  is_1990: false
-  dependent_on: _always_hidden
-  output_element_key: source_of_heat_used_in_households
-  key: geothermal_hot_water_source_of_heat_used_in_households
 - label: hydrogen_heating
   color: "#87CEEB"
   order_by: 10

--- a/config/interface/output_element_series/source_of_heat_used_in_households.yml
+++ b/config/interface/output_element_series/source_of_heat_used_in_households.yml
@@ -212,7 +212,7 @@
   target_line_position: ''
   gquery: geothermal_used_for_hot_water_in_households
   is_1990: false
-  dependent_on: 
+  dependent_on: _always_hidden
   output_element_key: source_of_heat_used_in_households
   key: geothermal_hot_water_source_of_heat_used_in_households
 - label: hydrogen_heating


### PR DESCRIPTION
The table _Final demand heating and hot water_ in residences showed a duplicate entry for _Ambient heat (for hot water)_ as shown in the screenshot below. This entry was not affected by any of the sliders in the relevant section of the model. Further inspection showed that it represented the gquery _geothermal_used_for_hot_water_in_households_. The other geothermal gquery in output_element_series was set to always hidden so I've updated this gquery to match it.

![Screenshot 2020-12-14 at 09 37 57](https://user-images.githubusercontent.com/67338510/102058626-0fb68f80-3df0-11eb-8a3c-592ede9311a3.png)


