### PR TITLE
Additional outdated output element series found removed for etmodel #3517

### DIFF
--- a/config/interface/output_element_series/source_of_hot_water_in_households.yml
+++ b/config/interface/output_element_series/source_of_hot_water_in_households.yml
@@ -95,15 +95,3 @@
   dependent_on: 
   output_element_key: source_of_hot_water_in_households
   key: ambient_source_of_hot_water_in_households
-- label: geothermal
-  color: "#FF8400"
-  order_by: 9
-  group: 
-  show_at_first: 
-  is_target_line: 
-  target_line_position: 
-  gquery: geothermal_used_for_hot_water_in_households
-  is_1990: 
-  dependent_on: 
-  output_element_key: source_of_hot_water_in_households
-  key: geothermal_source_of_hot_water_in_households


### PR DESCRIPTION
The gquery geothermal_used_for_hot_water_in_households is outdated since geothermal heat has been coupled to the heat network, instead of directly to the households. This issue was already addressed in etmodel pull request #3517, but this output_element_series had not yet been deleted.

Since there is no slider that has an effect on the geothermal heat used for hot water in households, this output_element_series has been removed.