### PR TITLE
Overhaul chart picker

### DIFF
--- a/app/assets/javascripts/lib/models/chart_list.coffee
+++ b/app/assets/javascripts/lib/models/chart_list.coffee
@@ -298,26 +298,22 @@ class @ChartList extends Backbone.Collection
 
     # Launch the chart picker popup
     #
-    $(document).on "touchend click", "a.select_chart, a.add_chart", (e) ->
+    $(document).on "touchend click", "a.select_chart, a.add_chart", (e) =>
       e.preventDefault()
-      url = $(this).attr('href')
-      $.fancybox.open
-        autoSize: false
-        href: url
-        type: 'ajax'
-        width: 930
-        height: window.innerHeight - 100
-        padding: 0
-        afterShow: ->
-          # Pick a chart from the chart picker popup
-          #
-          $('#select_charts .select-chart').on 'touchend click', (e) =>
-            data_holder = $(e.target).closest('div.select-chart')
-            holder_id = data_holder.data('chart_holder')
-            chart_id  = data_holder.data('chart_id')
-            load_chart chart_id, holder_id, force: true
-            close_fancybox()
-            e.preventDefault()
+
+      holderId = $(e.target).closest('.chart_holder').data('holder_id')
+      isDisabled = @chart_already_on_screen
+
+      ChartListView.fetchData().then((data) ->
+        new ChartListView(data: data).render(
+          (chartId) -> load_chart(chartId, holderId, force: true),
+          (chartId) -> isDisabled(chartId)
+        )
+      )
+
+    # Prefetch chart data when hovering chart selection buttons.
+    $(document).on "mouseover", "a.select_chart, a.add_chart", (e) =>
+      ChartListView.fetchData();
 
     # Toggle chart lock
     #

--- a/app/assets/stylesheets/_chart.sass
+++ b/app/assets/stylesheets/_chart.sass
@@ -501,11 +501,79 @@ div.d3_container
 
 // ------ chart selector -----------------------------------------------------
 
-#select_charts
-  height: 100%
-  display: flex
-  flex-wrap: wrap
-  padding: 10px
+#select-charts-dialog
+  position: absolute
+  top: 0
+  right: 0
+  bottom: 0
+  left: 0
+  overflow: hidden
+  .search
+    background: #eee
+    border-bottom: 1px solid #bfbfbf
+    border-top-left-radius: 4px
+    border-top-right-radius: 4px
+    margin-bottom: -1px
+    position: relative
+    z-index: 3
+    .fa-search
+      color: #777
+      font-size: 17px
+      left: 20px
+      position: absolute
+      top: 14px
+    input
+      border-radius: 4px 4px 0 0
+      border: none
+      font-size: 16px
+      padding: 14px 20px 13px 42px
+      width: 100%
+      &:focus
+        box-shadow: none
+  .no-matches
+    border-top: 1px solid #ccc
+    color: #555
+    font-size: 16px
+    margin-top: -30px
+    padding: 150px 0 0
+    position: relative
+    text-align: center
+    z-index: 2
+    span.wrap
+      background: #eee
+      border-radius: 4px
+      padding: 10px 15px
+    button
+      background: none
+      border-radius: 5px
+      border: none
+      color: #555
+      font-size: 16px
+      margin: -2px
+      padding: 2px
+      transition: box-shadow 0.15s
+      will-change: box-shadow
+      &:hover
+        color: #222
+        cursor: pointer
+        text-decoration: underline
+      &:focus
+        box-shadow: 0 0 0 3px #cfe5f7
+        outline: none
+.chart-selection
+  bottom: 0
+  box-sizing: border-box
+  overflow-y: scroll
+  padding: 10px 20px 0
+  position: absolute
+  top: 45px
+  width: 100%
+  z-index: 1
+  .chart-list-item, .charts
+    display: flex
+    flex-wrap: wrap
+    &.group
+      width: 100%
   h1, h2
     background-color: $chart-header-background-color
     border-bottom: 1px solid #bdcbdc
@@ -515,38 +583,51 @@ div.d3_container
     font-size: 18px
     font-weight: 600
     line-height: 1
-    margin: 10px -10px 10px
-    padding-left: 10px
+    margin: -10px -20px 10px
     padding: 13px 20px 12px
+    position: relative
     width: 100%
+    z-index: 2
   h2
-    background: linear-gradient(lighten($chart-header-background-color, 5%), transparent)
+    background: none
     border: none
     border-top: 1px solid $chart-header-background-color
     color: #333
     font-size: 1rem
-    padding: 20px 20px 5px
-  h1 + h2
-    border-top: none
-    margin-top: -10px
-  h1:first-child
-    border-top-left-radius: 4px
-    margin-top: -10px
-  .select-chart
+    padding: 20px 0 0
+    position: relative
+    margin: -11px 0 10px
+    z-index: 1
+    &.empty
+      padding: 0
+  .charts
+    // Wrapper which contains multiple charts.
+    padding-bottom: 20px
+    margin: 0 -10px
+    width: 100%
+    width: calc(100% + 20px)
+  .chart
     align-items: center
+    border-radius: 4px
+    box-sizing: border-box
     cursor: pointer
     display: flex
+    flex-wrap: nowrap
     height: 50px
+    overflow: hidden
     padding: 10px
-    width: 33%
-    box-sizing: border-box
-    border-radius: 4px
-    will-change: background-color
     transition: background-color 0.15s
+    width: 33.3%
+    will-change: background-color
     &:hover, &:focus
       background-color: lighten($chart-header-background-color, 3%)
     &:active
       background-color: darken($chart-header-background-color, 1%)
+    &.disabled
+      opacity: 0.25
+      &:hover, &:focus, &:active
+        cursor: default
+        background-color: transparent
     img
       border-radius: 3px
     .chart-name

--- a/app/controllers/output_elements_controller.rb
+++ b/app/controllers/output_elements_controller.rb
@@ -29,8 +29,12 @@ class OutputElementsController < ApplicationController
   def index
     # id of the element the chart will be placed in
     @chart_holder = params[:holder]
-
     @groups = OutputElement.select_by_group
+
+    respond_to do |wants|
+      wants.html {}
+      wants.json { render(json: GroupedOutputElementPresenter.new(@groups)) }
+    end
   end
 
   def zoom

--- a/app/javascript/packs/app.ts
+++ b/app/javascript/packs/app.ts
@@ -61,6 +61,13 @@ window.MeritTransformator = {
 import DateSelect from '../charts/HourlyBase/DateSelect';
 window.D3ChartDateSelect = DateSelect;
 
+// Other Backbone classes
+// ----------------------
+
+import ChartListView from '../views/ChartListView';
+
+window.ChartListView = ChartListView;
+
 // Extensions to legacy classes
 // ----------------------------
 

--- a/app/javascript/views/ChartListView.js
+++ b/app/javascript/views/ChartListView.js
@@ -1,0 +1,355 @@
+/* globals $ Backbone I18n */
+
+/**
+ * Given data for a list item, the onSelectChart and isElementDisabled callbacks (see
+ * ChartListView#render) returns the element as a ListItem.
+ */
+const createElement = (el, onSelectChart, isElementDisabled) => {
+  switch (el.type) {
+    case 'group':
+    case 'subgroup':
+      return new GroupListItem({ isElementDisabled, onSelectChart, ...el });
+    default:
+      return new ChartListItem({ isElementDisabled, onSelectChart, ...el });
+  }
+};
+
+/**
+ * Given an array of elements, the onSelectChart and isElementDisabled callbacks (see
+ * ChartListView#render) returns an array of the elements transformed to ListItems.
+ */
+const createElements = (elements = [], onSelectChart, isElementDisabled) => {
+  return elements.map((el) => createElement(el, onSelectChart, isElementDisabled));
+};
+
+class ListItem extends Backbone.View {
+  /**
+   * CSS display value when the element is visible.
+   */
+  display = 'flex';
+
+  get className() {
+    return 'chart-list-item';
+  }
+
+  constructor(options) {
+    super(options);
+
+    this.children = createElements(
+      options.elements,
+      this.options.onSelectChart,
+      this.options.isElementDisabled
+    );
+
+    // Create search text which omits any HTML.
+    const stripEl = document.createElement('DIV');
+    stripEl.innerHTML = this.options.name;
+    this.searchText = stripEl.textContent.toLowerCase();
+  }
+
+  /**
+   * Searches the item for the provided text. The element will be visible if the text matches,
+   * invisible if not.
+   *
+   * Returns true if the text matched, false otherwise.
+   */
+  performSearch(text) {
+    if (text.length === 0 || this.searchText.includes(text)) {
+      this.show(true);
+      return true;
+    }
+
+    // If the item doesn't match, test the children. If any of those match
+    let childShown = false;
+
+    this.children.forEach((el) => (childShown = el.performSearch(text) || childShown));
+
+    if (childShown) {
+      this.show();
+      return true;
+    }
+
+    this.hide();
+    return false;
+  }
+
+  /**
+   * Shows the element but does not show children unless showChildren is true.
+   */
+  show(showChildren) {
+    this.el.style.display = this.display;
+
+    if (showChildren) {
+      for (const child of this.children) {
+        child.show(true);
+      }
+    }
+  }
+
+  /**
+   * Hides the element and children.
+   */
+  hide() {
+    this.el.style.display = 'none';
+  }
+}
+
+class ChartListItem extends ListItem {
+  events = { click: 'onClick' };
+
+  get className() {
+    return 'chart-list-item chart';
+  }
+
+  render() {
+    super.render();
+
+    this.delegateEvents(this.events);
+
+    // We know the HTML provided is safe to use.
+    this.$el.append(
+      $('<img width="50" height="30" alt="" />').attr('src', this.options.image_url),
+      $('<span class="chart-name" />').html(this.options.name)
+    );
+
+    this.options.isElementDisabled(this.options.key);
+
+    if (this.options.isElementDisabled(this.options.key)) {
+      this.$el.addClass('disabled');
+    }
+
+    return this.el;
+  }
+
+  onClick(event) {
+    event.preventDefault();
+
+    if (!this.options.isElementDisabled(this.options.key)) {
+      this.options.onSelectChart(this.options.key);
+    }
+  }
+}
+
+/**
+ * Represents a group or sub-group header and child elements.
+ */
+class GroupListItem extends ListItem {
+  /**
+   * The tag used to wrap the item name or content (except any child elements).
+   */
+  innerTagName() {
+    return this.options.type === 'group' ? 'H1' : 'H2';
+  }
+
+  get className() {
+    return 'chart-list-item group';
+  }
+
+  // Renders the group name and any child elements.
+  render() {
+    this.delegateEvents(this.events);
+
+    const innerEl = document.createElement(this.innerTagName());
+    innerEl.textContent = this.options.name;
+
+    this.el.append(innerEl);
+
+    if (!this.options.key) {
+      innerEl.classList.add('empty');
+    }
+
+    let childrenContainer = this.el;
+
+    if (this.children && !this.children[0].options.type) {
+      // Wrap charts inside an extra div to allow use to fine-tune the margins.
+      childrenContainer = document.createElement('DIV');
+      childrenContainer.classList.add('charts');
+      this.el.append(childrenContainer);
+    }
+
+    for (const child of this.children) {
+      childrenContainer.append(child.render());
+    }
+
+    return this.el;
+  }
+}
+
+/**
+ * Renders the search form.
+ */
+class SearchView extends Backbone.View {
+  get events() {
+    return {
+      'input input': 'onInput',
+      'keyup input': 'onKeyUp',
+    };
+  }
+
+  get className() {
+    return 'search';
+  }
+
+  render() {
+    this.inputEl = $('<input name="q" type="search" />').attr(
+      'placeholder',
+      `${I18n.t('chart_picker.search_for_a_chart')}...`
+    )[0];
+
+    this.el.append($('<span class="fa fa-search" />')[0], this.inputEl);
+
+    return this.el;
+  }
+
+  onInput(event) {
+    this.options.onInput?.(event.target.value.trim());
+  }
+
+  onKeyUp(event) {
+    if (event.key == 'Escape') {
+      event.preventDefault();
+      this.options.onEscape?.();
+    }
+  }
+
+  reset() {
+    this.inputEl.value = '';
+  }
+
+  focus() {
+    this.inputEl.focus();
+  }
+}
+
+/**
+ * Shown when the search text provided by the user has no matching charts.
+ */
+class NoMatchesView extends Backbone.View {
+  get events() {
+    return { 'click button': 'onReset' };
+  }
+
+  get className() {
+    return 'no-matches';
+  }
+
+  render() {
+    this.$el.append(
+      $('<span class="wrap" />').append(
+        I18n.t('chart_picker.no_matches'),
+        ' &ndash; ',
+        $('<button />').text(I18n.t('chart_picker.reset_search'))
+      )
+    );
+
+    return this.el;
+  }
+
+  onReset() {
+    this.options.onReset?.();
+  }
+
+  show() {
+    this.el.style.display = 'block';
+  }
+
+  hide() {
+    this.el.style.display = 'none';
+  }
+}
+
+export default class ChartListView extends Backbone.View {
+  /**
+   * Fetches the data from the API, returning a jQuery.Deferred which yields the data. Repeat calls
+   * return the same Deferred and don't hit the API again.
+   */
+  static fetchData() {
+    this.fetchDeferred ||= $.getJSON('/output_elements');
+    return this.fetchDeferred;
+  }
+
+  /**
+   * Renders the ChartListView inside a FancyBox popup.
+   *
+   * @param {function} onSelectChart
+   *   A callback function which is fired when the user selects a chart. Yields the chart key.
+   * @param {function} isElementDisabled
+   *   A function called for each element with the element key. The function should return true or
+   *   false indicating whether the element is disabled. This only affects list elements which
+   *   represent charts, not groups.
+   */
+  render(onSelectChart, isElementDisabled) {
+    // Called whenever the user selects a chart.
+    const onSelect = (chartId) => {
+      $.fancybox.close();
+      onSelectChart && onSelectChart(chartId);
+    };
+
+    isElementDisabled ||= () => false;
+
+    this.elements = createElements(this.options.data, onSelect, isElementDisabled);
+
+    this.selectChartsEl = $('<div class="chart-selection" />');
+
+    this.noMatches = new NoMatchesView({ onReset: this.reset });
+    this.noMatches.hide();
+
+    this.searchView = new SearchView({
+      onEscape: () => $.fancybox.close(),
+      onInput: (text) => this.performSearch(text),
+    });
+
+    this.el.append(this.searchView.render());
+
+    for (const element of this.elements) {
+      this.selectChartsEl.append(element.render());
+    }
+
+    this.el.append(this.selectChartsEl[0]);
+    this.el.append(this.noMatches.render());
+
+    $.fancybox.open({
+      autoSize: false,
+      type: 'ajax',
+      content: '<div id="select-charts-dialog"></div>',
+      width: 930,
+      height: window.innerHeight - 100,
+      padding: 0,
+    });
+
+    document.querySelector('#select-charts-dialog').innerHTML = '';
+    document.querySelector('#select-charts-dialog').append(this.el);
+
+    this.searchView.focus();
+
+    return this.el;
+  }
+
+  /**
+   * Performs a search recursively through all elements and their children. Those which match the
+   * search term will be visible, those that don't will be hidden.
+   */
+  performSearch(text) {
+    let anyMatches = false;
+
+    this.elements.forEach(
+      (el) => (anyMatches = el.performSearch(text.toLowerCase().trim()) || anyMatches)
+    );
+
+    if (anyMatches) {
+      this.noMatches.hide();
+    } else {
+      this.noMatches.show();
+    }
+  }
+
+  /**
+   * Empties the search field and shows all elements.
+   */
+  reset = () => {
+    this.searchView?.reset();
+    this.searchView?.focus();
+    this.noMatches?.hide();
+    this.elements.forEach((el) => el.show(true));
+  };
+}

--- a/app/javascript/views/ChartListView.js
+++ b/app/javascript/views/ChartListView.js
@@ -190,7 +190,7 @@ class GroupListItem extends ListItem {
     this.delegateEvents(this.events);
 
     const innerEl = document.createElement(this.innerTagName());
-    innerEl.textContent = this.options.name;
+    innerEl.innerHTML = this.options.name;
 
     this.el.append(innerEl);
 

--- a/app/models/grouped_output_element_presenter.rb
+++ b/app/models/grouped_output_element_presenter.rb
@@ -34,7 +34,9 @@ class GroupedOutputElementPresenter
   # are output elements.
   def group_as_json(name, elements)
     {
-      elements: elements.map { |element| output_element_as_json(element) },
+      elements: elements
+        .map { |element| output_element_as_json(element) }
+        .sort_by { |el| el[:name] },
       key: name&.downcase&.presence
     }
   end

--- a/app/models/grouped_output_element_presenter.rb
+++ b/app/models/grouped_output_element_presenter.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Given output elements already grouped (by OutputElement.select_by_group), creates a JSON
+# representation of the hierarchy of the elements, and minimal information about each.
+class GroupedOutputElementPresenter
+  def initialize(grouped_elements)
+    @grouped_elements = grouped_elements
+    @view_context = ActionController::Base.new.view_context
+  end
+
+  def as_json(*)
+    @grouped_elements.map do |key, value|
+      group_name = I18n.t("chart_group.#{key.downcase}")
+
+      # Grouped charts come in two forms: either an array - in which case this is a top-level group
+      # with charts belonging to it without any subgroups - or an Hash of subgroup keys and the
+      # charts belonging to them.
+      if value.is_a?(Array)
+        group_as_json(key, value).merge(type: :group, name: group_name)
+      elsif value.is_a?(Hash)
+        {
+          elements: subgroups_as_json(value),
+          key: key&.downcase&.presence,
+          name: group_name,
+          type: :group
+        }
+      end
+    end
+  end
+
+  private
+
+  # Internal: Creates the JSON representation of a group (or subgroup) for which all the elements
+  # are output elements.
+  def group_as_json(name, elements)
+    {
+      elements: elements.map { |element| output_element_as_json(element) },
+      key: name&.downcase&.presence
+    }
+  end
+
+  # Internal: Receives an array of subgroups and creates the JSON for each group and its output
+  # elements
+  def subgroups_as_json(groups)
+    groups.map do |name, elements|
+      group_as_json(name, elements).merge(
+        name: name && I18n.t("chart_sub_group.#{name.downcase}"),
+        type: :subgroup
+      )
+    end
+  end
+
+  # Internal: Creates the JSON representation of a single output element.
+  def output_element_as_json(element)
+    element.as_json(
+      only: %w[key output_element_type_name]
+    ).merge(
+      name: I18n.t("output_elements.#{element.key}.title"),
+      image_url: @view_context.image_url("output_elements/#{element.icon}")
+    )
+  end
+end

--- a/app/models/output_element.rb
+++ b/app/models/output_element.rb
@@ -119,7 +119,7 @@ class OutputElement < YModel::Base
   def self.select_by_group
     Hash[whitelisted.group_by(&:group).each.map do |group, elements|
       if elements.map(&:sub_group).compact.any?
-        elements = elements.group_by(&:sub_group)
+        elements = elements.group_by { |e| e.sub_group.presence }
       end
 
       [group, elements]

--- a/config/i18n-js.yml
+++ b/config/i18n-js.yml
@@ -40,3 +40,4 @@ translations:
       - '*.toast.*'
       - '*.scenario_nav.*'
       - '*.node_details.*'
+      - '*.chart_picker.*'

--- a/config/interface/output_elements/demand.yml
+++ b/config/interface/output_elements/demand.yml
@@ -3,7 +3,7 @@
   unit: "%"
   percentage: true
   group: Demand
-  sub_group: ''
+  sub_group: overview
   show_point_label: true
   growth_chart: false
   key: final_energy_demand_per_sector_percentage

--- a/config/interface/output_elements/demand_overview.yml
+++ b/config/interface/output_elements/demand_overview.yml
@@ -3,7 +3,7 @@
   unit: PJ
   percentage: false
   group: Demand
-  sub_group: Overview
+  sub_group: overview
   show_point_label: false
   growth_chart: false
   key: final_demand_mekko_mece

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -27,6 +27,11 @@ en:
   nevermind: "Never mind"
   cancel: "Cancel"
 
+  chart_picker:
+    no_matches: No matches
+    reset_search: Reset search
+    search_for_a_chart: Search for a chart
+
   header:
     about_qi: "About Quintel Intelligence"
     add_chart: "See more charts"

--- a/config/locales/interface/output_elements/labels_groups/nl_groups.yml
+++ b/config/locales/interface/output_elements/labels_groups/nl_groups.yml
@@ -21,5 +21,6 @@ nl:
     households: "Huishoudens"
     overview: "Overzicht"
     buildings: "Gebouwen"
+    other: "Overig"
     hydrogen: "Waterstof"
     network_gas: "Netwerkgas"

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -28,9 +28,9 @@ nl:
   cancel: "Annuleren"
 
   chart_picker:
-    no_matches: Geen overeenkomsten
-    reset_search: Reset zeoken
-    search_for_a_chart: Zoek naar een grafieken
+    no_matches: Geen resultaten
+    reset_search: Verwijder zoekopdracht
+    search_for_a_chart: Zoek naar een grafiek
 
   header:
     about_qi: "Over Quintel Intelligence"

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -27,6 +27,11 @@ nl:
   nevermind: "Niet gebruiken"
   cancel: "Annuleren"
 
+  chart_picker:
+    no_matches: Geen overeenkomsten
+    reset_search: Reset zeoken
+    search_for_a_chart: Zoek naar een grafieken
+
   header:
     about_qi: "Over Quintel Intelligence"
     add_chart: "Meer grafieken bekijken"
@@ -120,8 +125,8 @@ nl:
     name: "Laatste updates"
     title: Het ETM is geüpdatet!
     description:
-      Het is nu mogelijk om CO2 afvang, opslag en hergebruik toe te voegen aan je scenario om zo 
-      emissies te verlagen. Het koppelen van andere modellen is door deze update makkelijker en 
+      Het is nu mogelijk om CO2 afvang, opslag en hergebruik toe te voegen aan je scenario om zo
+      emissies te verlagen. Het koppelen van andere modellen is door deze update makkelijker en
       met de nieuwe toolbar kun je eenvoudig je scenario opslaan.
 
   # ----------- Dashbord titles ----------- #


### PR DESCRIPTION
* The list is now generated by a couple of Backbone views with JSON data returned from the ETModel API.
  * The list of output elements is fetched as soon as the user hovers the chart picker buttons, which means it appears faster than before. The list is also cached, and so appears instantly when re-opened.

* A search field has been added allowing users to quickly find the chart they want.
  * Fuzzy matching is supported: searching for "el prod" shows the "Electricity production", "CO2 emissions of electricity production", and "Electricity production per hour" charts.
  * Matching is also performed against group and sub-group names: searching for "flex" shows all charts in the "Flexibility" group.
 
* Charts which are already loaded will be greyed out and not selectable, to prevent the same chart being selected multiple times.

@marliekeverweij You requested this more than two years ago, so it's been a long time coming! It would benefit from [a double-check of the translations](https://github.com/quintel/etmodel/blob/9536cfb87669bc6fb2094081f1f8138d87793d2f/config/locales/nl_etm.yml#L30-L33) before merging.

![101484495-a1864e80-3951-11eb-895f-ec9c46becebd](https://user-images.githubusercontent.com/4383/104184211-03335000-540b-11eb-9c68-d44d86d49c41.gif)

Closes #2837.