### PR TITLE
Add descriptions for capacity_profile curves

### DIFF
--- a/config/locales/en_custom_curves.yml
+++ b/config/locales/en_custom_curves.yml
@@ -11,6 +11,7 @@ en:
     on_date: "on %{date}"
     remove: Revert to default curve
     select_scenario: Select a scenario...
+    type: Curve
     upload: Upload a custom curve
     upload_from_scenario: Or from a scenario
     uploaded: uploaded
@@ -71,6 +72,7 @@ en:
     types:
       capacity_profile:
         default: Default profile
+        type: Capacity profile
         help: |
           You can use your own supply profiles by uploading a CSV file. This file should contain
           8760 rows (one for each hour per year). The sum of the profile should equal the total
@@ -79,6 +81,7 @@ en:
           used in that hour.
       price:
         default: Default price curve
+        type: Price curve
         help: |
           By default, it is assumed that the price is constant throughout the year.
           You can change this by uploading a CSV file, specifying the price of imported
@@ -95,6 +98,7 @@ en:
         imported_from: From scenario
       temperature:
         default: Default temperature curve
+        type: Temperature curve
         help: |
           You can change the temperature curve by uploading a CSV file, specifying the outdoor air temperature for
           every hour of the year. This file should contain 8760 rows (one for each hour per year)
@@ -102,7 +106,8 @@ en:
         value: "%{value}°C"
       profile:
         default: Default profile
+        type: Profile
         help: |
-          You can use your own demand profiles by uploading a CSV file. This file should contain
-          8760 rows (one for each hour per year). The unit used in the CSV file does not matter: the
-          ETM will use the shape of your profile (the relative distribution of demand over time).
+          You can use your own profiles by uploading a CSV file. This file should contain 8760 rows
+          (one for each hour per year). The unit used in the CSV file does not matter: the ETM will
+          use the shape of your profile (the relative distribution of demand over time).

--- a/config/locales/nl_custom_curves.yml
+++ b/config/locales/nl_custom_curves.yml
@@ -11,6 +11,7 @@ nl:
     on_date: "op %{date}"
     remove: Zet het standaardprofiel terug
     select_scenario: Selecteer scenario...
+    type: Curve
     upload: Een eigen profiel uploaden
     upload_from_scenario: Of gebruik een scenario
     uploaded: geüpload
@@ -71,6 +72,7 @@ nl:
     types:
       capacity_profile:
         default: Standaard profiel
+        type: Capaciteitsprofiel
         help: |
           Je kunt aanbodprofielen aanpassen door een CSV-bestand met een eigen profiel te uploaden.
           Dit bestand moet uit 8760 rijen bestaan (één voor elk uur per jaar). Het profiel optellen
@@ -78,7 +80,8 @@ nl:
           dat het profiel voor elk uur een waarde tussen de 0 en 1 bevat die aangeeft welke fractie
           van het piekvermogen in dat uur gebruikt wordt.
       price:
-        default: Standaard prijsprofiel
+        default: Standaard prijscurve
+        type: Prijsprofiel
         help: |
           Standaard wordt een constante prijs verondersteld gedurende het jaar.
           Je kunt dit aanpassen door een CSV-bestand te importeren met daarin voor elk uur
@@ -95,6 +98,7 @@ nl:
         imported_from: Vanuit scenario
       temperature:
         default: Standaard temperatuurcurve
+        type: Temperatuurcurve
         help: |
           Je kunt de temperatuurcurve aanpassen door een CSV-bestand te importeren met daarin voor elk uur
           van het jaar de temperatuur. Dit bestand moet uit 8760 rijen bestaan
@@ -102,8 +106,9 @@ nl:
         value: "%{value}°C"
       profile:
         default: Standaard profiel
+        type: Profiel
         help: |
-          Je kunt vraagprofielen aanpassen door een CSV-bestand met een eigen profiel te uploaden.
-          Dit bestand moet uit 8760 rijen bestaan (één voor elk uur per jaar). Maakt de gebruikte
+          Je kunt profielen aanpassen door een CSV-bestand met een eigen profiel te uploaden. Dit
+          bestand moet uit 8760 rijen bestaan (één voor elk uur per jaar). Maakt de gebruikte
           eenheid niet uit: het ETM gebruikt alleen de vorm van het profiel (de relatieve verdeling
           van de vraag over de tijd).

--- a/config/locales/nl_custom_curves.yml
+++ b/config/locales/nl_custom_curves.yml
@@ -75,7 +75,7 @@ nl:
         type: Capaciteitsprofiel
         help: |
           Je kunt aanbodprofielen aanpassen door een CSV-bestand met een eigen profiel te uploaden.
-          Dit bestand moet uit 8760 rijen bestaan (één voor elk uur per jaar). Het profiel optellen
+          Dit bestand moet uit 8760 rijen bestaan (één voor elk uur per jaar). Het profiel moet optellen
           tot het gewenste jaarlijkse aantal vollasturen van de productietechnologie. Dit betekent
           dat het profiel voor elk uur een waarde tussen de 0 en 1 bevat die aangeeft welke fractie
           van het piekvermogen in dat uur gebruikt wordt.


### PR DESCRIPTION
This separates the descriptions for the profile and capacity_profile curve types. Would you mind checking that I didn't butcher the Dutch texts?

I also added a `type` translation which will come in useful later.

See also:
* https://github.com/quintel/etengine/pull/1153
* https://github.com/quintel/etsource/pull/2406