### PR TITLE
Improve messaging when uploading invalid CSV files

### DIFF
--- a/config/locales/en_custom_curves.yml
+++ b/config/locales/en_custom_curves.yml
@@ -22,6 +22,7 @@ en:
       file_too_large: Curve must not be larger than 1MB
       illegal_value: Curve must only contain numeric values
       not_a_curve: Curve must be a CSV file containing 8760 numeric values, one for each hour in a typical year
+      too_many_columns: Curve must contain only a single numeric value on each line; multiple values separated by commas are not permitted
       wrong_length: Curve must have 8760 numeric values, one for each hour in a typical year
     groups:
       heat_production: "Supply: Heat"

--- a/config/locales/nl_custom_curves.yml
+++ b/config/locales/nl_custom_curves.yml
@@ -22,6 +22,7 @@ nl:
       file_too_large: Profiel mag niet meer dan 1MB groot zijn
       illegal_value: Profiel mag alleen numerieke waarden bevatten
       not_a_curve: Profiel moet een CSV-bestand zijn met 8760 getallen (één getal voor elk uur in een jaar)
+      too_many_columns: Curve must contain only a single numeric value on each line; multiple values separated by commas are not permitted
       wrong_length: Profiel moet 8760 getallen bevatten (één getal voor elk uur in een jaar)
     groups:
       heat_production: "Aanbod: Warmte"

--- a/config/locales/nl_custom_curves.yml
+++ b/config/locales/nl_custom_curves.yml
@@ -22,7 +22,7 @@ nl:
       file_too_large: Profiel mag niet meer dan 1MB groot zijn
       illegal_value: Profiel mag alleen numerieke waarden bevatten
       not_a_curve: Profiel moet een CSV-bestand zijn met 8760 getallen (één getal voor elk uur in een jaar)
-      too_many_columns: Curve must contain only a single numeric value on each line; multiple values separated by commas are not permitted
+      too_many_columns: Profiel mag per regel maar één getal bevatten; meerdere getallen gescheiden door een komma zijn niet toegestaan.
       wrong_length: Profiel moet 8760 getallen bevatten (één getal voor elk uur in een jaar)
     groups:
       heat_production: "Aanbod: Warmte"


### PR DESCRIPTION
Adds a better message when the visitor uploads a CSV curve containing multiple columns separated by a comma. This issue was [originally reported on Basecamp](https://3.basecamp.com/3797409/buckets/12512661/todos/3419365857#__recording_3423173259).

The new message [needs a Dutch translation](https://github.com/quintel/etmodel/blob/f42cb8019cbe1a2c9350a8c8389479f9410fd49f/config/locales/nl_custom_curves.yml#L25) please.

Goes with https://github.com/quintel/etengine/pull/1154