### PR TITLE
Add warning to profile chart when lacking capacity

### DIFF
--- a/app/assets/javascripts/d3/solar_curtailment_curve.coffee
+++ b/app/assets/javascripts/d3/solar_curtailment_curve.coffee
@@ -12,6 +12,11 @@ D3.solar_curtailment_curve =
     refresh: ->
       super()
 
+      if _.all(@visibleData(), (s) -> _.all(s.values, (v) -> v == 0))
+        @svg.selectAll('g.no-data').style('display', 'inline')
+      else
+        @svg.selectAll('g.no-data').style('display', 'none')
+
       # Update each series tooltip and fill since the paths are re-used when a
       # new series is selected.
       @svg.selectAll('g.serie')
@@ -29,6 +34,19 @@ D3.solar_curtailment_curve =
       @svg.selectAll('g.serie').remove()
 
       super(xScale, yScale, area, line)
+
+      @svg.append('g')
+        .attr('class', 'no-data')
+        .append('text')
+        .attr('x',@width / 2)
+        .attr('y', (@height - @margins.bottom - 10) / 2)
+        .attr('text-anchor', 'middle')
+        .text(
+          I18n.t(
+            'output_elements.empty.' + this.model.get('key'),
+            { defaults: [{ scope: 'output_elements.common.empty' }] }
+          )
+        )
 
     visibleData: ->
       val = @serieSelect?.selectBox.val() || @serieSelectOptions()[0].match

--- a/app/assets/stylesheets/_chart.sass
+++ b/app/assets/stylesheets/_chart.sass
@@ -373,6 +373,9 @@ div.d3_container
       cursor: pointer
       opacity: 0.8
 
+  .no-data
+    display: none
+
   .subzero
     fill: black
     opacity: 0.05

--- a/config/locales/interface/output_elements/labels_groups/en_labels.yml
+++ b/config/locales/interface/output_elements/labels_groups/en_labels.yml
@@ -36,6 +36,7 @@ en:
       mekko_of_detailed_final_demand_in_industry_other: "There is no industry in your scenario"
       mekko_of_detailed_final_demand_in_industry_energetic_nl: "There is no industry in your scenario"
       mekko_of_detailed_final_demand_in_industry_energetic_other: "There is no industry in your scenario"
+      user_profiles: "There is no demand or supply for this technology"
     tooltips:
       add: "Add another chart"
       change: "Change Chart"

--- a/config/locales/interface/output_elements/labels_groups/nl_labels.yml
+++ b/config/locales/interface/output_elements/labels_groups/nl_labels.yml
@@ -34,6 +34,7 @@ nl:
       mekko_of_detailed_final_demand_in_industry_other: "Er is geen industrie in je scenario"
       mekko_of_detailed_final_demand_in_industry_energetic_nl: "Er is geen industrie in je scenario"
       mekko_of_detailed_final_demand_in_industry_energetic_other: "Er is geen industrie in je scenario"
+      user_profiles: "There is no demand or supply for this technology"
     tooltips:
       add: "Voeg nog een grafiek toe"
       change: "Andere grafiek"

--- a/config/locales/interface/output_elements/labels_groups/nl_labels.yml
+++ b/config/locales/interface/output_elements/labels_groups/nl_labels.yml
@@ -34,7 +34,7 @@ nl:
       mekko_of_detailed_final_demand_in_industry_other: "Er is geen industrie in je scenario"
       mekko_of_detailed_final_demand_in_industry_energetic_nl: "Er is geen industrie in je scenario"
       mekko_of_detailed_final_demand_in_industry_energetic_other: "Er is geen industrie in je scenario"
-      user_profiles: "There is no demand or supply for this technology"
+      user_profiles: "Deze technologie heeft geen energievraag of -aanbod in dit scenario"
     tooltips:
       add: "Voeg nog een grafiek toe"
       change: "Andere grafiek"


### PR DESCRIPTION
Adds a small warning message to the user profile chart whenever they select a technology whose curve is all zeros; this indicates that there was no demand, supply, or capacity installed. Based on feedback from Alexander on Basecamp.

There is one short translation required, which customises the message for this chart from the default ("There is no data for this chart") to something more meaningful. I worded the message differently from Alexander's suggestion – which was to mention the lack of capacity – since the technology *may* have capacity installed but still have no demand or supply.

![Screenshot 2021-02-01 at 16 47 05](https://user-images.githubusercontent.com/4383/106489892-28b4f600-64ad-11eb-9811-36ac3261d310.png)
