### PR TITLE
Fix bug where columns of energymix were overlapping

### DIFF
--- a/app/assets/stylesheets/_energy_mix.sass
+++ b/app/assets/stylesheets/_energy_mix.sass
@@ -125,7 +125,8 @@ body#energy-mix
       page-break-inside: avoid
       margin-left: 0
       width: 100%
-
+      .header, .items, .total
+        width: 350px
       .header
         color: $grey-font-color
       .legend-row


### PR DESCRIPTION
The columns of the EnergyMix infographic were overlapping:

<img width="793" alt="Before" src="https://user-images.githubusercontent.com/14875123/107348206-0469a280-6ac7-11eb-9e7e-f6d24e2961d2.png">

I fixed it to look like this:

<img width="793" alt="After" src="https://user-images.githubusercontent.com/14875123/107348271-164b4580-6ac7-11eb-883a-fcdc2d3c2806.png">

(Don't look at the exact numbers, these are two different scenarios 😉 )
