### PR TITLE
Add missing sub headers of input sliders that set capacity

### DIFF
--- a/config/interface/slides/buildings.yml
+++ b/config/interface/slides/buildings.yml
@@ -15,7 +15,7 @@
   alt_output_element_key: effect_of_insulation_in_buildings
   output_element_key: use_of_final_demand_in_buildings
 - image: building_heating_uncapped.gif
-  general_sub_header: of_demand
+  general_sub_header: of_heat_demand
   key: demand_buildings_heating
   position: 3
   sidebar_item_key: buildings

--- a/config/interface/slides/buildings.yml
+++ b/config/interface/slides/buildings.yml
@@ -15,7 +15,7 @@
   alt_output_element_key: effect_of_insulation_in_buildings
   output_element_key: use_of_final_demand_in_buildings
 - image: building_heating_uncapped.gif
-  general_sub_header: share
+  general_sub_header: of_demand
   key: demand_buildings_heating
   position: 3
   sidebar_item_key: buildings

--- a/config/interface/slides/electricity.yml
+++ b/config/interface/slides/electricity.yml
@@ -11,12 +11,14 @@
   sidebar_item_key: electricity
   alt_output_element_key: source_of_electricity_production
   output_element_key: source_of_electricity_production
-- key: supply_electricity_oil_plants
+- general_sub_header: electricity_output
+  key: supply_electricity_oil_plants
   position: 3
   sidebar_item_key: electricity
   alt_output_element_key: source_of_electricity_production
   output_element_key: source_of_electricity_production
-- key: supply_electricity_nuclear_plant
+- general_sub_header: electricity_output
+  key: supply_electricity_nuclear_plant
   position: 4
   sidebar_item_key: electricity
   alt_output_element_key: source_of_electricity_production

--- a/config/interface/slides/electricity_renewable.yml
+++ b/config/interface/slides/electricity_renewable.yml
@@ -1,20 +1,24 @@
 ---
-- key: supply_electricity_renewable_wind_turbines
+- general_sub_header: electricity_output
+  key: supply_electricity_renewable_wind_turbines
   position: 1
   sidebar_item_key: electricity_renewable
   alt_output_element_key: source_of_electricity_production
   output_element_key: source_of_electricity_production
-- key: supply_electricity_renewable_hydro_electric
+- general_sub_header: electricity_output
+  key: supply_electricity_renewable_hydro_electric
   position: 3
   sidebar_item_key: electricity_renewable
   alt_output_element_key: source_of_electricity_production
   output_element_key: source_of_electricity_production
-- key: supply_electricity_renewable_geothermal
+- general_sub_header: electricity_output
+  key: supply_electricity_renewable_geothermal
   position: 7
   sidebar_item_key: electricity_renewable
   alt_output_element_key: source_of_electricity_production
   output_element_key: source_of_electricity_production
-- key: supply_electricity_renewable_solar_power
+- general_sub_header: electricity_output
+  key: supply_electricity_renewable_solar_power
   position: 2
   sidebar_item_key: electricity_renewable
   alt_output_element_key: source_of_electricity_production
@@ -25,11 +29,13 @@
   sidebar_item_key: electricity_renewable
   alt_output_element_key: source_of_electricity_production
   output_element_key: source_of_electricity_production
-- key: supply_electricity_renewable_hydrogen_plants
+- general_sub_header: electricity_output
+  key: supply_electricity_renewable_hydrogen_plants
   position: 6
   sidebar_item_key: electricity_renewable
   output_element_key: source_of_electricity_production
-- key: supply_electricity_renewable_biomass_plants
+- general_sub_header: electricity_output
+  key: supply_electricity_renewable_biomass_plants
   position: 4
   sidebar_item_key: electricity_renewable
   output_element_key: source_of_electricity_production

--- a/config/interface/slides/flexibility_conversion.yml
+++ b/config/interface/slides/flexibility_conversion.yml
@@ -1,5 +1,6 @@
 ---
-- key: flexibility_flexibility_power_to_gas
+- general_sub_header: electricity_input
+  key: flexibility_flexibility_power_to_gas
   position: 1
   sidebar_item_key: flexibility_conversion
   alt_output_element_key: use_of_excess_electricity

--- a/config/interface/slides/flexibility_storage.yml
+++ b/config/interface/slides/flexibility_storage.yml
@@ -1,5 +1,6 @@
 ---
-- key: flexibility_flexibility_power_storage
+- general_sub_header: electricity_input
+  key: flexibility_flexibility_power_storage
   position: 1
   sidebar_item_key: flexibility_storage
   alt_output_element_key: energy_storage

--- a/config/interface/slides/households.yml
+++ b/config/interface/slides/households.yml
@@ -24,8 +24,7 @@
   alt_output_element_key: use_of_final_electricity_demand_in_households
   output_element_key: use_of_final_electricity_demand_in_households
 - image: house_heating.gif
-  general_sub_header: share
-  group_sub_header: share
+  general_sub_header: of_houses
   key: demand_households_heating
   position: 5
   sidebar_item_key: households

--- a/config/interface/slides/households.yml
+++ b/config/interface/slides/households.yml
@@ -24,6 +24,7 @@
   alt_output_element_key: use_of_final_electricity_demand_in_households
   output_element_key: use_of_final_electricity_demand_in_households
 - image: house_heating.gif
+  general_sub_header: share
   group_sub_header: share
   key: demand_households_heating
   position: 5

--- a/config/interface/slides/hydrogen.yml
+++ b/config/interface/slides/hydrogen.yml
@@ -1,10 +1,12 @@
 ---
-- key: supply_hydrogen_production
+- general_sub_header: input_capacity
+  key: supply_hydrogen_production
   position: 1
   sidebar_item_key: hydrogen
   alt_output_element_key: hydrogen_production
   output_element_key: mekko_of_hydrogen_network
-- key: supply_hydrogen_transport
+- general_sub_header: share
+  key: supply_hydrogen_transport
   position: 3
   sidebar_item_key: hydrogen
   output_element_key: mekko_of_hydrogen_network

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -155,7 +155,9 @@ en:
     hybrid_heating: "MW"
     heat_demand_reduction: "heat demand reduction"
     electricity_output: "electricity output"
+    electricity_input: "electricity input"
     heat_output: "heat output"
+    input_capacity: "input capacity"
 
 
 

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -159,7 +159,7 @@ en:
     heat_output: "heat output"
     input_capacity: "input capacity"
     of_houses: "% of residences"
-    of_demand: "% of demand"
+    of_heat_demand: "% of heat demand"
 
 
 

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -158,6 +158,8 @@ en:
     electricity_input: "electricity input"
     heat_output: "heat output"
     input_capacity: "input capacity"
+    of_houses: "% of residences"
+    of_demand: "% of demand"
 
 
 

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -159,6 +159,8 @@ nl:
     electricity_input: "elektriciteit-input"
     heat_output: "warmte-output"
     input_capacity: "input vermogen"
+    of_houses: "% van huizen"
+    of_demand: "% van vraag"
 
   #------------ Output Serie Labels ------------- #
   scenario:

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -155,8 +155,10 @@ nl:
     efficiency: "%/jaar"
     hybrid_heating: "MW"
     heat_demand_reduction: "warmtevraagreductie"
-    electricity_output: "elektrisch vermogen"
+    electricity_output: "elektriciteit-output"
+    electricity_input: "elektriciteit-input"
     heat_output: "warmte-output"
+    input_capacity: "input vermogen"
 
   #------------ Output Serie Labels ------------- #
   scenario:

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -160,7 +160,7 @@ nl:
     heat_output: "warmte-output"
     input_capacity: "input vermogen"
     of_houses: "% van huizen"
-    of_demand: "% van vraag"
+    of_heat_demand: "% van warmtevraag"
 
   #------------ Output Serie Labels ------------- #
   scenario:


### PR DESCRIPTION
For a number of input sliders no sub header was specified (see #3619). This could lead to confusion about whether the sliders sets the input or the output capacity. For input sliders that set capacity these sub headers have been added.