### PR TITLE
Export a scenario as ESDL

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,6 +19,7 @@
 //= require jquery_plugins
 //= require intro
 //= require esdl
+//= require export
 //= require flowplayer.playlist-3.0.8.min
 //= require admin
 //= require common_interface

--- a/app/assets/javascripts/esdl.js
+++ b/app/assets/javascripts/esdl.js
@@ -35,6 +35,8 @@ $(function () {
   var mondaineDrive = $('#mondaine_drive');
 
   if (mondaineDrive.length > 0) {
+    browseMondaineDrive($('form#import_esdl'));
+
     if (mondaineDrive.hasClass('disabled')) {
       mondaineDrive.find('a').on('click', false);
     } else {
@@ -44,7 +46,8 @@ $(function () {
 });
 
 // Browsing the Mondaine Drive
-$(function () {
+// selectType can be either 'file' or 'folder'
+function browseMondaineDrive(form, selectFolder = false) {
   var folders = $('.folder__true');
 
   if (folders.length > 0) {
@@ -56,7 +59,7 @@ $(function () {
   // from the server and create them in the DOM
   function expandFolder() {
     var folder = $(this);
-    swapIcon(folder.find('span'));
+    swapIcon(folder);
 
     if (folder.next('.children').length > 0) {
       folder.next().toggle(30);
@@ -87,12 +90,12 @@ $(function () {
     }
   }
 
-  // When a file is clicked (selected), add a 'selected' class, and remove the
+  // When an element is clicked (selected), add a 'selected' class, and remove the
   // 'required' property from the 'Browse my computer' input. Vice-versa
-  // when the file is de-selected.
-  function selectFile() {
+  // when the element is de-selected.
+  function selectElement() {
     var file = $(this);
-    var esdlForm = $('form#import_esdl');
+    var esdlForm = $(form);
 
     if (file.hasClass('selected')) {
       file.removeClass('selected');
@@ -118,25 +121,38 @@ $(function () {
       childNode.addClass(child['type'] + '__' + child['children']);
       childNode.data(child);
 
-      if (child['type'] == 'folder' && child['children'] == true) {
+      if (child['type'] == 'folder' && child['children']) {
         childNode.on('click', expandFolder);
-      } else if (child['type'] == 'file-esdl') {
-        childNode.on('click', selectFile);
-      } else {
+      } else if (child['type'] == 'folder' && !child['children']) {
         childNode.append(' (empty)');
+        if (selectFolder) {
+          childNode.addClass('hover-pointer');
+          childNode.on('click', selectElement);
+        }
+      } else if (child['type'] == 'file-esdl' && !selectFolder) {
+        childNode.on('click', selectElement);
       }
       childrenNode.append(childNode);
     });
 
     return childrenNode;
   }
-});
 
-// Swaps open and closed folder icons
-function swapIcon(icon) {
-  if (icon.hasClass('fa-folder')) {
-    icon.addClass('fa-folder-open').removeClass('fa-folder');
-  } else {
-    icon.addClass('fa-folder').removeClass('fa-folder-open');
+  // Swaps open and closed folder icons, and keeps track of the folder being selected if
+  // possible
+  function swapIcon(folder) {
+    var icon = folder.find('span');
+
+    if (icon.hasClass('fa-folder')) {
+      icon.addClass('fa-folder-open').removeClass('fa-folder');
+
+      if (selectFolder) {
+        $('.selected').removeClass('selected');
+        folder.addClass('selected');
+        $(form).find('input[name=mondaine_drive_path]').val(folder.data('id'));
+      }
+    } else {
+      icon.addClass('fa-folder').removeClass('fa-folder-open');
+    }
   }
 }

--- a/app/assets/javascripts/esdl.js
+++ b/app/assets/javascripts/esdl.js
@@ -61,6 +61,9 @@ function browseMondaineDrive(form, selectFolder = false) {
     var folder = $(this);
     swapIcon(folder);
 
+    // Remove any old warnings
+    $('.warning').remove();
+
     if (folder.next('.children').length > 0) {
       folder.next().toggle(30);
       // When imploding a folder, 'deselect' the 'selected' file within

--- a/app/assets/javascripts/export.js
+++ b/app/assets/javascripts/export.js
@@ -1,4 +1,4 @@
-/* globals $*/
+/* globals I18n $*/
 
 $(function () {
   var exportForm = $('form#export_esdl');
@@ -10,18 +10,49 @@ $(function () {
 
 function bindSubmitToForm(form) {
   form.find('.submit').on('click', function () {
-    form.trigger('submit');
+    if (esdlSubmitChecks(form)) {
+      form.trigger('submit');
+    }
   });
 }
 
-function setupMondaineDriveListeners() {
-  browseMondaineDrive($('form#export_esdl'), true);
+function esdlSubmitChecks(form) {
+  var mondaine_drive = $('.mondaine_drive');
 
-  bindSubmitToForm($('form#export_esdl'));
+  // If no Mondaine Drive, remove value to be sure
+  if (mondaine_drive.length == 0 || mondaine_drive.is(':hidden')) {
+    form.find('input[name=mondaine_drive_path]').val('');
+    return true;
+  }
+
+  // If we want to export to Mondaine Drive, give a warning if no folder was selected
+  if (form.find('input[name=mondaine_drive_path]').val() == '') {
+    mondaine_drive.append(
+      $('<div></div>').text(I18n.translate('export.esdl.select_folder')).addClass('warning')
+    );
+
+    return false;
+  }
+
+  return true;
+}
+
+function setupMondaineDriveListeners() {
+  var form = $('form#export_esdl');
+
+  // Setup browse functionality. See esdl.js
+  browseMondaineDrive(form, true);
+
+  bindSubmitToForm(form);
+
   // bind click to back
   $('#export_esdl .back').on('click', function () {
     $('.options').show();
     $('.mondaine_drive').hide();
+
+    // remove mondaine drive options from form
+    $('.selected').removeClass('selected');
+    form.find('input[name=mondaine_drive_path]').val('');
   });
   // unbind href to browse option
   $('.option.browse').on('click', function () {

--- a/app/assets/javascripts/export.js
+++ b/app/assets/javascripts/export.js
@@ -4,8 +4,29 @@ $(function () {
   var exportForm = $('form#export_esdl');
 
   if (exportForm.length > 0) {
-    exportForm.find('.option').on('click', function () {
-      exportForm.trigger('submit');
-    });
+    bindSubmitToForm(exportForm);
   }
 });
+
+function bindSubmitToForm(form) {
+  form.find('.submit').on('click', function () {
+    form.trigger('submit');
+  });
+}
+
+function setupMondaineDriveListeners() {
+  browseMondaineDrive($('form#export_esdl'), true);
+
+  bindSubmitToForm($('form#export_esdl'));
+  // bind click to back
+  $('#export_esdl .back').on('click', function () {
+    $('.options').show();
+    $('.mondaine_drive').hide();
+  });
+  // unbind href to browse option
+  $('.option.browse').on('click', function () {
+    $('.options').hide();
+    $('.mondaine_drive').show();
+    return false;
+  });
+}

--- a/app/assets/javascripts/export.js
+++ b/app/assets/javascripts/export.js
@@ -27,9 +27,11 @@ function esdlSubmitChecks(form) {
 
   // If we want to export to Mondaine Drive, give a warning if no folder was selected
   if (form.find('input[name=mondaine_drive_path]').val() == '') {
-    mondaine_drive.append(
-      $('<div></div>').text(I18n.translate('export.esdl.select_folder')).addClass('warning')
-    );
+    if ($('.warning').length == 0) {
+      mondaine_drive.append(
+        $('<div></div>').text(I18n.translate('export.esdl.select_folder')).addClass('warning')
+      );
+    }
 
     return false;
   }

--- a/app/assets/javascripts/export.js
+++ b/app/assets/javascripts/export.js
@@ -1,0 +1,11 @@
+/* globals $*/
+
+$(function () {
+  var exportForm = $('form#export_esdl');
+
+  if (exportForm.length > 0) {
+    exportForm.find('.option').on('click', function () {
+      exportForm.trigger('submit');
+    });
+  }
+});

--- a/app/assets/stylesheets/_export.sass
+++ b/app/assets/stylesheets/_export.sass
@@ -1,0 +1,34 @@
+#export
+  margin: 0 auto
+  width: $landing-width
+  text-align: center
+
+  .exportbox
+    // text-align: left
+    background-color: #fff
+    border: 1px solid $landing-border-color
+    border-bottom-color: darken($landing-border-color, 5%)
+    border-top-color: $landing-gold
+    border-top-width: 2px
+    box-shadow: 0 3px 5px rgba(50, 71, 93, 0.06), 0 1px 3px rgba(0, 0, 0, 0.04)
+    border-radius: 4px
+    padding: 15px 40px
+    margin-top: 30px
+
+    .option
+      text-align: left
+      border: 0.25px solid #aaa
+      border-radius: 15px
+      padding: 3px 10px
+      margin: 20px auto
+      width: 350px
+      cursor: pointer
+      display: block
+      color: #333
+      box-shadow: inset 0 0 3px 1px rgba(0, 0, 0, 0.1)
+      span
+        float: right
+        font-weight: bolder
+        font-size: 15pt
+      &:hover
+        text-decoration: none

--- a/app/assets/stylesheets/_export.sass
+++ b/app/assets/stylesheets/_export.sass
@@ -4,7 +4,6 @@
   text-align: center
 
   .exportbox
-    // text-align: left
     background-color: #fff
     border: 1px solid $landing-border-color
     border-bottom-color: darken($landing-border-color, 5%)
@@ -15,20 +14,60 @@
     padding: 15px 40px
     margin-top: 30px
 
+    .bar
+      border-top: 1px solid #aaa
+      margin: 0 auto
+      padding-bottom: 0.875rem
+
+    a:hover
+      text-decoration: none !important
     .option
       text-align: left
       border: 0.25px solid #aaa
       border-radius: 15px
-      padding: 3px 10px
+      padding: 4px 15px
       margin: 20px auto
       width: 350px
       cursor: pointer
       display: block
       color: #333
-      box-shadow: inset 0 0 3px 1px rgba(0, 0, 0, 0.1)
+      // box-shadow: inset 0 0 3px 1px rgba(0, 0, 0, 0.1)
+      background: #fff
       span
         float: right
-        font-weight: bolder
+        // font-weight: bold
         font-size: 15pt
+        // border-left: 0.25px solid #aaa
+        padding-left: 11px
+      &:hover, &:active
+        background: $landing-blue
+        border-color: $landing-blue
+        color: #fff
+        // span
+        //   color: $link-color
+      // &:active
+      //   background: #eee
+
+  #export_esdl
+    h3
+      text-align: left
+      margin-left: 75px
+    .back
+      color: $link-color
+      text-align: right
+      margin: 0 75px -35px 0
       &:hover
-        text-decoration: none
+        text-decoration: underline
+        cursor: pointer
+    .browsing, .filename
+      width: 400px
+      margin: 10px auto
+    .filename
+      padding: 10px
+      display: flex
+      justify-content: space-between
+      input[type="text"]
+        width: 250px
+      // .button
+      //   width: 50px
+

--- a/app/assets/stylesheets/_export.sass
+++ b/app/assets/stylesheets/_export.sass
@@ -31,27 +31,26 @@
       cursor: pointer
       display: block
       color: #333
-      // box-shadow: inset 0 0 3px 1px rgba(0, 0, 0, 0.1)
       background: #fff
       span
         float: right
-        // font-weight: bold
         font-size: 15pt
-        // border-left: 0.25px solid #aaa
         padding-left: 11px
       &:hover, &:active
         background: $landing-blue
         border-color: $landing-blue
         color: #fff
-        // span
-        //   color: $link-color
-      // &:active
-      //   background: #eee
 
   #export_esdl
     h3
       text-align: left
       margin-left: 75px
+    .mondaine_drive
+      padding: 0 0 30px
+      &.with_space
+        padding-top: 30px
+    .login_to_drive
+      margin: 65px auto 20px
     .back
       color: $link-color
       text-align: right
@@ -61,13 +60,38 @@
         cursor: pointer
     .browsing, .filename
       width: 400px
-      margin: 10px auto
+      margin: 20px auto
+    .browsing
+      margin-top: 25px
     .filename
+      width: 420px
       padding: 10px
       display: flex
       justify-content: space-between
       input[type="text"]
         width: 250px
-      // .button
-      //   width: 50px
-
+      .button
+        width: 90px
+        background: $landing-blue
+        color: white
+        cursor: pointer
+        border-radius: 13px
+        &:hover
+          background: lighten($landing-blue, 10%)
+    .warning
+      color: #fff
+      background-color: $landing-gold
+      width: max-content
+      border-radius: 2px
+      padding: 3px 8px
+      position: relative
+      top: -88px
+      left: 56px
+      box-shadow: 0 3px 5px rgba(50, 71, 93, 0.06), 0 1px 3px rgba(0, 0, 0, 0.04)
+      &:before
+        border: 7px solid transparent
+        border-bottom-color: $landing-gold
+        content: ''
+        position: absolute
+        top: -13.5px
+        left: 27px

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -41,3 +41,4 @@
 @import esdl
 @import region-flags
 @import survey
+@import export

--- a/app/assets/stylesheets/esdl.sass
+++ b/app/assets/stylesheets/esdl.sass
@@ -42,24 +42,6 @@
     margin-top: 30px
     border-top-color: $landing-gold
 
-    .dot
-      font-size: 6px
-      color: $link-color
-      margin: 0 6px
-      vertical-align: middle
-
-    .button.login
-      background: linear-gradient(lighten($landing-gold, 10%), $landing-gold)
-      width: 250px
-      font-size: 0.875rem
-      padding: 8px 4px
-      margin-bottom: 20px
-      &:hover
-        text-decoration: none !important
-        background: linear-gradient(lighten($landing-gold, 15%), lighten($landing-gold, 10%))
-      &:active
-        background: linear-gradient(darken($landing-gold, 1%), darken($landing-gold, 10%))
-
     &.disabled
       position: relative
       color: #ddd
@@ -178,3 +160,24 @@
       margin-left: -7px
       &:hover
         color: revert
+
+  #mondaine_drive, .mondaine_drive
+    .dot
+      font-size: 6px
+      color: $link-color
+      margin: 0 6px
+      vertical-align: middle
+
+    .button.login
+      background: linear-gradient(lighten($landing-gold, 10%), $landing-gold)
+      width: 250px
+      font-size: 0.875rem
+      font-weight: bold
+      padding: 8px 4px
+      margin-bottom: 20px
+      color: white
+      &:hover
+        text-decoration: none !important
+        background: linear-gradient(lighten($landing-gold, 15%), lighten($landing-gold, 10%))
+      &:active
+        background: linear-gradient(darken($landing-gold, 1%), darken($landing-gold, 10%))

--- a/app/assets/stylesheets/esdl.sass
+++ b/app/assets/stylesheets/esdl.sass
@@ -60,36 +60,6 @@
       &:active
         background: linear-gradient(darken($landing-gold, 1%), darken($landing-gold, 10%))
 
-    .browsing
-      padding: 10px
-      border-radius: 4px
-      border: 1px solid $landing-border-color
-      margin-bottom: 30px
-      .children
-        padding-left: 20px
-        span
-          padding-right: 5px
-      .folder
-        &__false
-          color: #aaa
-        &__true
-          cursor: pointer
-          &:hover
-            color: $link-color
-      .file-esdl__false
-        padding-bottom: 0.5px
-        &:hover
-          cursor: pointer
-          color: $link-color
-        &.selected
-          cursor: pointer
-          color: #fff
-          background-color: $link-color
-          border-radius: 10px
-          width: max-content
-          padding: 0 7px 0.5px 7px
-          margin-left: -7px
-
     &.disabled
       position: relative
       color: #ddd
@@ -171,3 +141,40 @@
       background: linear-gradient(lighten($landing-green, 14%), lighten($landing-green, 7%))
     &:active
       background: linear-gradient(darken($landing-green, 1%), darken($landing-green, 7%))
+
+#esdl, #export_esdl
+  .browsing
+    text-align: left
+    padding: 10px
+    border-radius: 4px
+    border: 1px solid $landing-border-color
+    margin-bottom: 30px
+    .children
+      padding-left: 20px
+      span
+        padding-right: 5px
+    .folder
+      &__false
+        color: #aaa
+      &__true
+        cursor: pointer
+        &:hover
+          color: $link-color
+    .file-esdl__false
+      padding-bottom: 0.5px
+      &:hover
+        cursor: pointer
+        color: $link-color
+    .hover-pointer:hover
+      cursor: pointer
+      color: $link-color
+    .selected
+      cursor: pointer
+      color: #fff
+      background-color: $link-color
+      border-radius: 10px
+      width: max-content
+      padding: 0 7px 0.5px 7px
+      margin-left: -7px
+      &:hover
+        color: revert

--- a/app/controllers/esdl_suite_controller.rb
+++ b/app/controllers/esdl_suite_controller.rb
@@ -17,7 +17,7 @@ class EsdlSuiteController < ApplicationController
   def redirect
     esdl_suite_service.authenticate(params[:code], stored_nonce, current_user)
 
-    redirect_to import_esdl_path
+    redirect_to previous_esdl_action
   end
 
   # Browse the Mondaine Drive with an EsdlSuiteId
@@ -59,7 +59,12 @@ class EsdlSuiteController < ApplicationController
     session.delete(:esdl_nonce)
   end
 
+  # If last location of esdl action was not stored, return to root
+  def previous_esdl_action
+    session[:return_to] or root_path
+  end
+
   def require_esdl_suite_id
-    redirect_to import_esdl_path if current_user.esdl_suite_id.blank?
+    redirect_to previous_esdl_action if current_user.esdl_suite_id.blank?
   end
 end

--- a/app/controllers/export_scenario_controller.rb
+++ b/app/controllers/export_scenario_controller.rb
@@ -21,7 +21,7 @@ class ExportScenarioController < ApplicationController
       # Upload to Mondaine Drive
       upload_result = UploadToEsdlSuite.call(esdl_id, mondaine_drive_upload_path, result.value)
       if upload_result.successful?
-        redirect_to export_scenario_path, notice: 'File was successfully uploaded'
+        redirect_to export_scenario_path, notice: t('export.esdl.success')
       else
         redirect_to export_scenario_path, notice: upload_result.errors.join(', ')
       end

--- a/app/controllers/export_scenario_controller.rb
+++ b/app/controllers/export_scenario_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# we can add all the csv stuff here as well (?) can only do this if the scenario was saved??
+class ExportScenarioController < ApplicationController
+  before_action :set_scenario
+  before_action :ensure_export_enabled
+
+  def index; end
+
+  def esdl
+    result = ExportEsdlScenario.call(@scenario.id)
+
+    if result.successful?
+      send_data(result.value, filename: "etm_scenario_#{@scenario.id}.esdl")
+      # or to M-Drive - need another service for that: UploadToEsdlSuite
+    else
+      redirect_to export_scenario_path, notice: result.errors.join(', ')
+    end
+  end
+
+  private
+
+  def set_scenario
+    @scenario ||= Api::Scenario.find(params[:id])
+  rescue ActiveResource::ResourceNotFound
+    render_not_found('scenario')
+  end
+
+  def ensure_export_enabled
+    render_not_found unless @scenario.esdl_exportable
+  end
+end

--- a/app/controllers/import_esdl_controller.rb
+++ b/app/controllers/import_esdl_controller.rb
@@ -17,12 +17,13 @@ class ImportEsdlController < ApplicationController
   def create
     redirect_to import_esdl_path and return if esdl_file.blank?
 
-    result = CreateEsdlScenario.call(esdl_file)
+    # TODO: Should set filename as scenario title?
+    result = CreateEsdlScenario.call(esdl_file, @filename)
 
     if result.failure?
       redirect_to import_esdl_path, notice: result.errors.join(', ')
     else
-      redirect_to load_scenario_path(id: result.value['scenario_id'])
+      redirect_to load_scenario_path(id: result.value)
     end
   end
 
@@ -36,12 +37,15 @@ class ImportEsdlController < ApplicationController
     @esdl_id ||= current_user&.esdl_suite_id
   end
 
+  # TODO: This @filename stuff is very ugly
   def esdl_file
     @esdl_file ||=
       if params[:mondaine_drive_path].present?
+        @filename = params[:mondaine_drive_path].split('/').last
         result = FetchFromEsdlSuite.call(esdl_id, params[:mondaine_drive_path])
         result.successful? ? result.value : ''
       elsif params[:esdl_file].present?
+        @filename = params[:esdl_file].original_filename
         params[:esdl_file].read
       else
         ''

--- a/app/controllers/import_esdl_controller.rb
+++ b/app/controllers/import_esdl_controller.rb
@@ -4,6 +4,7 @@
 # specified ESDL file. The service returns the scenario_id when (fully) succesful.
 class ImportEsdlController < ApplicationController
   before_action :ensure_esdl_enabled
+  before_action :store_location, only: :index
 
   def index
     return unless esdl_id

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -133,6 +133,10 @@ module ApplicationHelper
     Current.setting.active_saved_scenario_id.present?
   end
 
+  def export_scenario_enabled?
+    Current.setting.esdl_exportable
+  end
+
   def back_url_or_root
     controller.request.env['HTTP_REFERER'].present? ? url_for(:back) : root_url
   end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -28,6 +28,7 @@ class Setting
       end_year:                 2050,
       use_fce:                  false,
       use_merit_order:          true,
+      esdl_exportable:          false,
       locked_charts:            [],
       last_etm_page:            nil,
       preset_scenario_id:       nil,
@@ -54,6 +55,7 @@ class Setting
     new(
       preset_scenario_id: scenario.id,
       use_fce: scenario.use_fce,
+      esdl_exportable: scenario.esdl_exportable,
       end_year: scenario.end_year,
       area_code: scenario.area_code,
       active_saved_scenario_id: active_saved_scenario[:id],

--- a/app/services/create_esdl_scenario.rb
+++ b/app/services/create_esdl_scenario.rb
@@ -50,6 +50,6 @@ class CreateEsdlScenario
   end
 
   def api_url
-    APP_CONFIG[:esdl_api_url] + 'ImportESDL/'
+    APP_CONFIG[:esdl_api_url] + 'create_scenario/'
   end
 end

--- a/app/services/create_esdl_scenario.rb
+++ b/app/services/create_esdl_scenario.rb
@@ -33,7 +33,7 @@ class CreateEsdlScenario
 
   def handle_response(response)
     if response.ok?
-      ServiceResult.success(response)
+      ServiceResult.success(response['scenario_id'])
     elsif response.code == 404
       ServiceResult.failure(['This ESDL file cannot be converted into a scenario'])
     elsif response.code == 422

--- a/app/services/create_esdl_scenario.rb
+++ b/app/services/create_esdl_scenario.rb
@@ -6,8 +6,9 @@
 class CreateEsdlScenario
   include Service
 
-  def initialize(esdl_file)
+  def initialize(esdl_file, filename)
     @esdl_file = esdl_file
+    @filename = filename
   end
 
   def call
@@ -22,7 +23,11 @@ class CreateEsdlScenario
     HTTParty.public_send(
       :post,
       api_url,
-      { body: { energysystem: @esdl_file, environment: environment } }
+      { body: {
+        energy_system: @esdl_file,
+        energy_system_title: @filename,
+        environment: environment
+      } }
     )
   end
 
@@ -45,6 +50,6 @@ class CreateEsdlScenario
   end
 
   def api_url
-    APP_CONFIG[:esdl_api_url]
+    APP_CONFIG[:esdl_api_url] + 'ImportESDL/'
   end
 end

--- a/app/services/export_esdl_scenario.rb
+++ b/app/services/export_esdl_scenario.rb
@@ -46,6 +46,6 @@ class ExportEsdlScenario
   end
 
   def api_url
-    APP_CONFIG[:esdl_api_url] + 'ExportESDL/'
+    APP_CONFIG[:esdl_api_url] + 'export_esdl/'
   end
 end

--- a/app/services/export_esdl_scenario.rb
+++ b/app/services/export_esdl_scenario.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Service to retrieve a scenarios esdl file, updated with user values
+#
+# Calls the api at the etm_esdl app. The app will fetch the edsl file that is attached to the
+# scenario; the file will be updated with ETE scenario values and returned in JSON when successful.
+# If the ESDL file cannot be found, the app returns a 404, and when certain aspects of the file are
+# not (yet) supported a 422.
+class ExportEsdlScenario
+  include Service
+
+  def initialize(ete_scenario)
+    @ete_scenario = ete_scenario
+  end
+
+  def call
+    handle_response(send_request)
+  end
+
+  private
+
+  def send_request
+    HTTParty.public_send(
+      :post,
+      api_url,
+      { body: { session_id: @ete_scenario, environment: environment } }
+    )
+  end
+
+  def handle_response(response)
+    if response.ok?
+      ServiceResult.success(response.parsed_response['energy_system'])
+    elsif response.code == 404
+      ServiceResult.failure(['This scenario cannot be converted back to ESDL'])
+    elsif response.code == 422
+      # ESDL file has correct format but could not be created into a scenario
+      ServiceResult.failure('Exporting scenario failed: ' + response['message'])
+    else
+      # Malformed request or internal error of etm-esdl app
+      ServiceResult.failure(['Something went wrong'])
+    end
+  end
+
+  def environment
+    Rails.env.production? ? 'pro' : 'beta'
+  end
+
+  def api_url
+    APP_CONFIG[:esdl_api_url] + 'ExportESDL/'
+  end
+end

--- a/app/services/upload_to_esdl_suite.rb
+++ b/app/services/upload_to_esdl_suite.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Upload an ESDL file to the Mondaine Drive using an EsdlSuiteId
+class UploadToEsdlSuite < EsdlSuiteService
+  # Uploads a .esdl file to the Mondaine Drive
+  #
+  # esdl_suite_id - An EsdlSuiteId with which we can communicate with the Drive on the users behalf
+  # path          - The path on the Drive to where the desired file should be stored, e.g.
+  #                 '/Projects/Mondaine/myfile.esdl'
+  # file          - The file that needs to be uploaded in xml format
+  #
+  # Returns a ServiceResult
+  def call(esdl_suite_id, path, file)
+    return ServiceResult.failure unless esdl_suite_id.try_viable
+
+    encoded_path = CGI.escape(path).gsub('+', '%20')
+    handle_upload_response(HTTParty.put(
+      'https://drive.esdl.hesi.energy/store/resource/' + encoded_path,
+      headers: headers_for(esdl_suite_id).merge({ 'Content-type' => 'application/xml' }),
+      body: file
+    ))
+  end
+
+  private
+
+  def handle_upload_response(response)
+    if response.success?
+      ServiceResult.success(response.body)
+    else
+      ServiceResult.failure(['Something went wrong'])
+    end
+  end
+end

--- a/app/views/export_scenario/_mondaine_drive.html.haml
+++ b/app/views/export_scenario/_mondaine_drive.html.haml
@@ -1,0 +1,14 @@
+.mondaine_drive
+  .back
+    ← back
+  - if esdl_tree
+    %h3= t('esdl.mondaine_drive.browse')
+    = render partial: 'import_esdl/browse', locals: { esdl_tree: esdl_tree }
+    .filename
+      = label :filename, 'File name:'
+      = text_field_tag :filename, 'my_etm_scenario.esdl'
+      .button.submit
+        Export
+  - else
+    %h3 LOGIN
+    = render partial: 'import_esdl/login_to_drive'

--- a/app/views/export_scenario/_mondaine_drive.html.haml
+++ b/app/views/export_scenario/_mondaine_drive.html.haml
@@ -1,14 +1,12 @@
-.mondaine_drive
-  .back
-    ← back
+.mondaine_drive{class: "#{esdl_tree ? 'with_space' : ''}"}
+  .back= "← #{t('export.back')}"
+
   - if esdl_tree
     %h3= t('esdl.mondaine_drive.browse')
     = render partial: 'import_esdl/browse', locals: { esdl_tree: esdl_tree }
     .filename
-      = label :filename, 'File name:'
+      = label :filename, "#{t('export.filename')}:"
       = text_field_tag :filename, 'my_etm_scenario.esdl'
-      .button.submit
-        Export
+      .button.submit= t('export.export')
   - else
-    %h3 LOGIN
     = render partial: 'import_esdl/login_to_drive'

--- a/app/views/export_scenario/index.html.haml
+++ b/app/views/export_scenario/index.html.haml
@@ -1,3 +1,5 @@
+- content_for(:page_title) { "Export scenario - #{t('meta.name')}" }
+
 .background_wrapper
   #export
     %h1 Export your scenario
@@ -6,14 +8,14 @@
 
     .exportbox
       %h2 Export as ESDL
+      .bar
       = form_with url: export_esdl_scenario_path, id: 'export_esdl' do |f|
-        .option
-          To my computer
-          %span →
-      -# .option
-      -#   To my Mondaine Drive
-      -#   %span →
-
-      -# = form_with url: scenario_export_esdl_path, id: 'export_esdl' do |f|
-      -#   = f.hidden_field :scenario_id, value: @scenario_id
-      -#   = f.submit "Export →", class: 'button'
+        = f.hidden_field :mondaine_drive_path, value: ''
+        .options
+          .option.submit
+            To my computer
+            %span →
+          = link_to export_mondaine_drive_scenario_path, :remote => true do
+            .option.browse
+              To my Mondaine Drive
+              %span →

--- a/app/views/export_scenario/index.html.haml
+++ b/app/views/export_scenario/index.html.haml
@@ -2,20 +2,20 @@
 
 .background_wrapper
   #export
-    %h1 Export your scenario
+    %h1= t('export.title')
 
-    %p Export the settings of your scenario to another format. The sliders you set will be read and reinterpreted into the file-type of your choosing. Right now you can only export your scenario as ESDL.
+    %p= t('export.intro')
 
     .exportbox
-      %h2 Export as ESDL
+      %h2= t('export.esdl.title')
       .bar
       = form_with url: export_esdl_scenario_path, id: 'export_esdl' do |f|
         = f.hidden_field :mondaine_drive_path, value: ''
         .options
           .option.submit
-            To my computer
+            = t('export.esdl.to_computer')
             %span →
           = link_to export_mondaine_drive_scenario_path, :remote => true do
             .option.browse
-              To my Mondaine Drive
+              = t('export.esdl.to_drive')
               %span →

--- a/app/views/export_scenario/index.html.haml
+++ b/app/views/export_scenario/index.html.haml
@@ -1,0 +1,19 @@
+.background_wrapper
+  #export
+    %h1 Export your scenario
+
+    %p Export the settings of your scenario to another format. The sliders you set will be read and reinterpreted into the file-type of your choosing. Right now you can only export your scenario as ESDL.
+
+    .exportbox
+      %h2 Export as ESDL
+      = form_with url: export_esdl_scenario_path, id: 'export_esdl' do |f|
+        .option
+          To my computer
+          %span →
+      -# .option
+      -#   To my Mondaine Drive
+      -#   %span →
+
+      -# = form_with url: scenario_export_esdl_path, id: 'export_esdl' do |f|
+      -#   = f.hidden_field :scenario_id, value: @scenario_id
+      -#   = f.submit "Export →", class: 'button'

--- a/app/views/export_scenario/mondaine_drive.js.erb
+++ b/app/views/export_scenario/mondaine_drive.js.erb
@@ -1,0 +1,3 @@
+$('.options').hide();
+$("form#export_esdl").append('<%= escape_javascript(render partial: 'mondaine_drive', locals: { esdl_tree: @esdl_tree }) %>');
+$(document).ready(setupMondaineDriveListeners);

--- a/app/views/import_esdl/_browse.html.haml
+++ b/app/views/import_esdl/_browse.html.haml
@@ -1,7 +1,5 @@
-%h2= t('esdl.mondaine_drive.browse')
-
 .browsing
-  - @esdl_tree.each do |item|
+  - esdl_tree.each do |item|
     .base
       %div{class: "#{item['type']}__#{item['children']}", data: item}
         %span.fa{ class: "fa-#{item['type']}"}

--- a/app/views/import_esdl/_login_to_drive.html.haml
+++ b/app/views/import_esdl/_login_to_drive.html.haml
@@ -1,0 +1,8 @@
+.login_to_drive
+  %a.button.login{href: esdl_suite_login_path}
+    = t('esdl.mondaine_drive.sign_in')
+%a{href: 'https://www.mondaine-suite.nl/library/', target:'_blank'}
+  = t('esdl.mondaine_drive.about')
+.dot{ class: 'fa fa-circle' }
+%a{href: 'https://www.mondaine-suite.nl/contact/', target:'_blank'}
+  = t('esdl.mondaine_drive.sign_up')

--- a/app/views/import_esdl/index.html.haml
+++ b/app/views/import_esdl/index.html.haml
@@ -12,17 +12,11 @@
           %h2.please_log_in= t('esdl.please_log_in')
 
         - if @esdl_tree
-          = render partial: 'browse'
+          %h2= t('esdl.mondaine_drive.browse')
+          = render partial: 'browse', locals: { esdl_tree: @esdl_tree }
         - else
-          .login_to_drive
-            %h2= t('esdl.mondaine_drive.use')
-            %a.button.login{href: esdl_suite_login_path}
-              = t('esdl.mondaine_drive.sign_in')
-          %a{href: 'https://www.mondaine-suite.nl/library/', target:'_blank'}
-            = t('esdl.mondaine_drive.about')
-          .dot{ class: 'fa fa-circle' }
-          %a{href: 'https://www.mondaine-suite.nl/contact/', target:'_blank'}
-            = t('esdl.mondaine_drive.sign_up')
+          %h2= t('esdl.mondaine_drive.use')
+          = render partial: 'login_to_drive'
 
       %h2= t('esdl.or')
 

--- a/app/views/layouts/etm/_scenario_nav.html.haml
+++ b/app/views/layouts/etm/_scenario_nav.html.haml
@@ -42,6 +42,10 @@
         %li
           %a.dropdown-item{ href: scenario_reset_path, data: { confirm: t('header.reset_scenario_confirm') } }
             = t("header.reset_scenario")
+        - if export_scenario_enabled?
+          %li
+            %a.dropdown-item{ href: export_scenario_path(Current.setting.api_session_id) }
+              = t('header.export_scenario')
 
         - if current_user&.admin?
           %li.sep-above

--- a/config/i18n-js.yml
+++ b/config/i18n-js.yml
@@ -42,3 +42,4 @@ translations:
       - '*.node_details.*'
       - '*.chart_picker.*'
       - '*.survey.*'
+      - '*.export.esdl.*'

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -62,6 +62,7 @@ en:
     save_scenario: "Save scenario"
     save_scenario_as: "Save scenario as"
     saved: "Saved"
+    export_scenario: "Export scenario"
     scenario_report: "Scenario report"
     settings: "Settings"
     sign_in: "Log in"

--- a/config/locales/en_export.yml
+++ b/config/locales/en_export.yml
@@ -1,0 +1,16 @@
+en:
+  export:
+    title: Export your scenario
+    intro: |
+      Export the settings of your scenario to another format. The sliders you
+      set will be read and reinterpreted into the file-type of your choosing.
+      Right now you can only export your scenario as ESDL.
+    esdl:
+      title: Export as ESDL
+      to_computer: To my computer
+      to_drive: To my Mondaine Drive
+      select_folder: Please select a destination folder
+      success: File was successfully uploaded!
+    filename: File name
+    export: Export
+    back: back

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -62,6 +62,7 @@ nl:
     save_scenario: "Scenario opslaan"
     save_scenario_as: "Scenario opslaan als"
     saved: "Opgeslagen"
+    export_scenario: "Scenario exporteren"
     settings: "Opties"
     scenario_report: "Scenarioverslag"
     sign_in: "Inloggen"

--- a/config/locales/nl_export.yml
+++ b/config/locales/nl_export.yml
@@ -1,0 +1,17 @@
+nl:
+  export:
+    title: Exporteer je scenario
+    intro: |
+      Op deze pagina kan je je scenario exporteren naar een ander
+      (bestands)formaat. De schuifjes die je hebt gezet in je scenario worden
+      geherinterpreteerd naar het dorr jou gekozen bestandstype. Op dit moment
+      wordt alleen ESDL ondersteund als geldig export type.
+    esdl:
+      title: Exporteer als ESDL bestand
+      to_computer: Naar mijn computer
+      to_drive: Naar mijn Mondaine Drive
+      select_folder: Selecteer een map om naar te exporteren
+      success: Je bestand is succesvol geupload naar de Drive!
+    filename: Naam
+    export: Exporteer
+    back: terug

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,8 +64,9 @@ Rails.application.routes.draw do
       # legacy name for the energy mix
       get 'factsheet', to: redirect('scenarios/%{id}/energy_mix')
 
-      get  'export' => 'export_scenario#index'
-      post 'export/esdl' => 'export_scenario#esdl'
+      get  'export'                => 'export_scenario#index'
+      post 'export/esdl'           => 'export_scenario#esdl'
+      get  'export/mondaine_drive' => 'export_scenario#mondaine_drive'
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,9 @@ Rails.application.routes.draw do
       get 'energy_mix' => 'energy_mix#show'
       # legacy name for the energy mix
       get 'factsheet', to: redirect('scenarios/%{id}/energy_mix')
+
+      get  'export' => 'export_scenario#index'
+      post 'export/esdl' => 'export_scenario#esdl'
     end
   end
 

--- a/spec/services/export_esdl_scenario_spec.rb
+++ b/spec/services/export_esdl_scenario_spec.rb
@@ -12,7 +12,7 @@ describe ExportEsdlScenario, type: :service do
     allow(HTTParty)
       .to receive(:post)
       .with(
-        APP_CONFIG[:esdl_api_url] + 'ExportESDL/',
+        APP_CONFIG[:esdl_api_url] + 'export_esdl/',
         { body: { session_id: ete_scenario, environment: 'beta' } }
       ).and_return(ServicesHelper::StubResponse.new(code, response_body))
   end

--- a/spec/services/export_esdl_scenario_spec.rb
+++ b/spec/services/export_esdl_scenario_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ExportEsdlScenario, type: :service do
+  subject { described_class.call(ete_scenario) }
+
+  let(:ete_scenario) { 123_45 }
+  let(:updated_file) { 'updated_file' }
+
+  def stub_response(code, response_body)
+    allow(HTTParty)
+      .to receive(:post)
+      .with(
+        APP_CONFIG[:esdl_api_url] + 'ExportESDL/',
+        { body: { session_id: ete_scenario, environment: 'beta' } }
+      ).and_return(ServicesHelper::StubResponse.new(code, response_body))
+  end
+  # with valid esdl
+  context 'with valid scenario_id and esdl' do
+    before { stub_response(200, { 'energy_system' => updated_file }) }
+
+    it { is_expected.to be_a(ServiceResult) }
+
+    it 'contains an updated esdl file' do
+      expect(subject.value).to eq(updated_file)
+    end
+  end
+
+  context 'with unsupported esdl' do
+    before { stub_response(422, { 'message' => 'Solar pv not supported' }) }
+
+    it { is_expected.to be_a(ServiceResult) }
+
+    it { is_expected.to be_failure }
+  end
+
+  context 'when attached esdl could not be found' do
+    before { stub_response(404, { 'message' => 'ESDL or scenario could not be found' }) }
+
+    it { is_expected.to be_a(ServiceResult) }
+
+    it { is_expected.to be_failure }
+  end
+end

--- a/spec/support/mocks/ete_scenario.rb
+++ b/spec/support/mocks/ete_scenario.rb
@@ -19,6 +19,7 @@ def ete_scenario_mock
   allow(mock).to receive(:use_fce).and_return(nil)
   allow(mock).to receive(:scaling).and_return(nil)
   allow(mock).to receive(:protected?).and_return(false)
+  allow(mock).to receive(:esdl_exportable).and_return(false)
   allow(mock).to receive(:user_values)  do
     double('user_values', attributes: { foo: :bar })
   end


### PR DESCRIPTION
Next to importing, we can now also export a scenario as ESDL.

I created a new page on scenarios called export (`<etm>/scenarios/<id>/export`) which is currently only available for ESDL scenarios, but has the possibility to open up to other export types (csv maybe?).

For ESDL-started scenarios a new items appears in the scenario actions:

<img width="621" alt="Screenshot 2021-02-19 at 16 54 47" src="https://user-images.githubusercontent.com/14875123/108529513-d4937980-72d4-11eb-9f25-d97246710f57.png">

Users are led to the export page, where they can pick to either directly download the export, or to upload the export to their Mondaine Drive.

<img width="1229" alt="Screenshot 2021-02-19 at 16 38 59" src="https://user-images.githubusercontent.com/14875123/108529751-158b8e00-72d5-11eb-8ea4-49d3e26a8134.png">
<img width="1228" alt="Screenshot 2021-02-19 at 17 09 26" src="https://user-images.githubusercontent.com/14875123/108529873-3e138800-72d5-11eb-90ba-235698344a0d.png">

Closes #3566, #3567, #3568, #3535

Has accompanied PR's on quintel/etengine#1156 and quintel/etm-esdl#13

Any changes/feedback are welcome 😄 
