### PR TITLE
Definition of residual load was reversed and is now updated

### DIFF
--- a/config/locales/interface/output_elements/en_flexibility.yml
+++ b/config/locales/interface/output_elements/en_flexibility.yml
@@ -147,7 +147,7 @@ en:
       description: |
         This chart shows the imbalance in the total volume of inflexible supply and the total volume of 
         baseload demand for electricity, gas, hydrogen and heat per month. The imbalance is calculated 
-        by subtracting the baseload demand from the inflexible supply, and is also known as the "residual 
+        by subtracting the inflexible supply from the baseload demand, and is also known as the "residual 
         load". Negative values mean "surpluses" of energy and positive values "shortages". <br/><br/>
         More information about flexibility can be found in our
         <a href="https://docs.energytransitionmodel.com/main/flexibility/">documentation</a>.
@@ -155,8 +155,8 @@ en:
       title: Imbalance ("residual load") per hour
       description: |
         This chart shows the hourly imbalance in inflexible supply and baseload demand for electricity, 
-        gas, hydrogen and heat. The imbalance is calculated by subtracting the baseload demand from 
-        the inflexible supply, and is also known as the "residual load". Negative values mean "surpluses" 
+        gas, hydrogen and heat. The imbalance is calculated by subtracting the inflexible supply from 
+        the baseload demand, and is also known as the "residual load". Negative values mean "surpluses" 
         of energy and positive values "shortages". <br/><br/>
         More information about flexibility can be found in our
         <a href="https://docs.energytransitionmodel.com/main/flexibility/">documentation</a>.

--- a/config/locales/interface/output_elements/nl_flexibility.yml
+++ b/config/locales/interface/output_elements/nl_flexibility.yml
@@ -125,8 +125,8 @@ nl:
       title: Onbalans in maandelijkse volumes van vraag en aanbod
       description: |
         Deze grafiek laat de onbalans in het totale volume van basislastvraag en het totale volume van inflexibel
-        aanbod zien voor elektriciteit, gas, waterstof en warmte per maand. De onbalans is berekend door de 
-        basislastvraag af te trekken van het inflexibele aanbod, dit heet de "residual load". Negatieve waarden 
+        aanbod zien voor elektriciteit, gas, waterstof en warmte per maand. De onbalans is berekend door het 
+        inflexibele aanbod af te trekken van de basislastvraag, dit heet de "residual load". Negatieve waarden 
         betekenen "overschotten" aan energie en positieve waarden "tekorten". </br></br>
         Meer informatie over flexibiliteit is te vinden in onze
         <a href="https://docs.energytransitionmodel.com/main/flexibility/">documentatie</a>.
@@ -134,7 +134,7 @@ nl:
       title: Onbalans ("residual load") per uur
       description: |
         Deze grafiek laat de onbalans in basislastvraag en inflexibel aanbod zien voor elektriciteit, gas, waterstof 
-        en warmte per uur. De onbalans is berekend door de basislastvraag af te trekken van het inflexibele aanbod, 
+        en warmte per uur. De onbalans is berekend door het inflexibele aanbod af te trekken van de basislastvraag, 
         dit heet de "residual load". Negatieve waarden betekenen "overschotten" aan energie en positieve waarden 
         "tekorten". </br></br>
         Meer informatie over flexibiliteit is te vinden in onze

--- a/config/locales/interface/slides/en_flexibility.yml
+++ b/config/locales/interface/slides/en_flexibility.yml
@@ -277,7 +277,7 @@ en:
         This chart shows the monthly imbalance between supply and demand <i>volumes</i> for electricity, gas,
         hydrogen and heat. This gives you insight into the balance of your energy system throughout the year: in which 
         months does an imbalance occur? Which carriers are not in balance? Are these shortages or surpluses of energy? </br></br>
-        The imbalance is calculated by subtracting the baseload demand from the inflexible supply, 
+        The imbalance is calculated by subtracting the inflexible supply from the baseload demand, 
         this is called the "residual load". Negative values mean "surpluses" of energy and positive 
         values "shortages". More information about the definitions of inflexible supply and baseload 
         demand can be found in our <a href="https://docs.energytransitionmodel.com/main/flexibility#definitions-of-inflexible-supply-and-baseload-demand">

--- a/config/locales/interface/slides/nl_flexibility.yml
+++ b/config/locales/interface/slides/nl_flexibility.yml
@@ -334,7 +334,7 @@ nl:
         elektriciteit, gas, waterstof en warmte. Dit geeft je inzicht in de balans van je energiesysteem 
         door het jaar heen: welke dragers zijn niet in balans? In welke maanden is er een onbalans? Zijn 
         dit overschotten of tekorten van energie? <br/><br/>
-        De onbalans is berekend door de basislastvraag af te trekken van het inflexibele aanbod, dit heet 
+        De onbalans is berekend door het inflexibele aanbod af te trekken van de basislastvraag, dit heet 
         de "residual load". Negatieve waarden betekenen "overschotten" aan energie en positieve waarden 
         "tekorten". Op onze <a href="https://docs.energytransitionmodel.com/main/flexibility#definitions-of-inflexible-supply-and-baseload-demand">documentatie</a> 
         is meer informatie te vinden over de definities van basislastvraag en inflexibel aanbod. <br/><br/>


### PR DESCRIPTION
The current definition of residual load in the flexibility overview and corresponding charts of the model is described as follows: 'The imbalance is calculated by subtracting the baseload demand from the inflexible supply, this is called the "residual load".'

The actual definition should be the reverse: 'The imbalance is calculated by subtracting the inflexible supply from the baseload demand, this is called the "residual load".'

The following elements have been updated accordingly for both the EN and NL locales:

- slide of monthly imbalance
- chart description of monthly imbalance
- chart description of hourly imbalance