### PR TITLE
Fix uneven letter spacing in Firefox chart PNGs

### DIFF
--- a/app/assets/stylesheets/_chart.sass
+++ b/app/assets/stylesheets/_chart.sass
@@ -101,6 +101,10 @@ $chart-header-icon-color: #8895b2
     top: -10000px
     left: -10000px
     position: absolute
+    &.firefox-hidpi
+      // Add a class which reverts the clone to use Helvetica/Arial. As of 2021-03-01 rendering the
+      // system font to Canvas in Firefox on a HiDPI screen causes uneven letter spacing.
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif
     header
       background: none !important
       display: block

--- a/app/javascript/charts/utils/saveAsPNG.ts
+++ b/app/javascript/charts/utils/saveAsPNG.ts
@@ -13,6 +13,12 @@ const saveAsPNG = (holder: HTMLDivElement, scenarioID: number): Promise<HTMLCanv
   clone.removeAttribute('data-holder_id');
   clone.classList.add('html2canvas');
 
+  if (isHiDPI() && window.navigator.userAgent.includes('Firefox')) {
+    // Add a class which reverts the clone to use Helvetica/Arial. As of 2021-03-01 rendering the
+    // system font to Canvas in Firefox on a HiDPI screen causes uneven letter spacing.
+    clone.classList.add('firefox-hidpi');
+  }
+
   holder.parentNode.insertBefore(clone, holder.nextSibling);
 
   const promise = html2canvas(clone, {
@@ -32,6 +38,22 @@ const saveAsPNG = (holder: HTMLDivElement, scenarioID: number): Promise<HTMLCanv
   });
 
   return promise;
+};
+
+/**
+ * Detects a HiDPI display.
+ */
+const isHiDPI = () => {
+  const mediaQuery =
+    '(-webkit-min-device-pixel-ratio: 1.5),\
+            (min--moz-device-pixel-ratio: 1.5),\
+            (-o-min-device-pixel-ratio: 3/2),\
+            (min-resolution: 1.5dppx)';
+
+  if (window.devicePixelRatio > 1) return true;
+  if (window.matchMedia && window.matchMedia(mediaQuery).matches) return true;
+
+  return false;
 };
 
 /**


### PR DESCRIPTION
The letter spacing is uneven when using the system font in Firefox on a HiDPI screen. For that (rather rare) combination, fall back to Helvetica / Arial which doesn't have the problem.

Letter spacing issues seem to be somewhat common with html2canvas and there are several issues already open, so I don't think I'll send this upstream to them.

Closes #3630