### PR TITLE
Leave more space for the legend in bezier type charts

### DIFF
--- a/app/javascript/charts/Bezier.js
+++ b/app/javascript/charts/Bezier.js
@@ -17,7 +17,7 @@ class Bezier extends D3Chart {
     top: 20,
     bottom: 20,
     left: 0,
-    right: 30,
+    right: 35,
   };
 
   canRenderAsTable() {


### PR DESCRIPTION
I increased the right margin of bezier charts by 5, leaving some comfortable space for the legend (see #3640 for preview)

Closes #3640 