### PR TITLE
Add link to terms and privacy policy on sign up page

### DIFF
--- a/app/assets/stylesheets/form_only.sass
+++ b/app/assets/stylesheets/form_only.sass
@@ -316,15 +316,16 @@ body
       margin: 5px 25px -13px 0
 
     .input.user_allow_news
-      margin: 15px 0 10px 0 !important
+      margin: 0px 0 15px 0 !important
       width: 675px !important
 
       input
-        margin: 0 5px 0 0
+        margin: -1px 5px 0 0
+        height: 14px
+        width: 14px
 
       label
         display: inline-block
-        font-size: 12px
         font-weight: normal
         padding-top: 6px
         width: auto
@@ -353,6 +354,9 @@ body
     a:hover
       color: #222
       text-decoration: none
+
+  .terms
+    font-size: 0.75rem
 
 // Small typography tweaks for the NL signup page.
 

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -36,15 +36,21 @@
         = f.input :password, required: true
         = f.input :password_confirmation, required: true
 
+      .row
+        - if MailchimpService.configured?
+          = f.input :allow_news
+
     .section.highlight
       .row
         = f.input :company_school
         = f.input :teacher_email
 
-    - if MailchimpService.configured?
-      = f.input :allow_news
-
     .section
+      %p.terms
+        = t('sign_up.agree_to_terms',
+            privacy_policy: link_to('Privacy Policy', privacy_url),
+            terms_of_service: link_to('Terms of Service', terms_of_service_url)).html_safe
+
       = f.button :submit, I18n.t('simple_form.labels.user.submit'), class: 'primary'
 
 .return-to-model

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -48,8 +48,8 @@
     .section
       %p.terms
         = t('sign_up.agree_to_terms',
-            privacy_policy: link_to('Privacy Policy', privacy_url),
-            terms_of_service: link_to('Terms of Service', terms_of_service_url)).html_safe
+            privacy_policy: link_to(t('sign_up.privacy_policy'), privacy_url),
+            terms_of_service: link_to(t('sign_up.terms_of_service'), terms_of_service_url)).html_safe
 
       = f.button :submit, I18n.t('simple_form.labels.user.submit'), class: 'primary'
 

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -366,6 +366,12 @@ en:
     im_a_student:     "I'm a student"
     im_a_teacher:     "I'm a teacher"
 
+    agree_to_terms: |
+      By signing up, you agree to the %{terms_of_service} and %{privacy_policy} of the Energy
+      Transition Model.
+    terms_of_service: Terms of Service
+    privacy_policy: Privacy Policy
+
   pico:
     ready: ready
 

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -374,10 +374,10 @@ nl:
     optional:         "Optioneel"
 
     agree_to_terms: |
-      By signing up, you agree to the %{terms_of_service} and %{privacy_policy} of the Energy
-      Transition Model.
-    terms_of_service: Terms of Service
-    privacy_policy: Privacy Policy
+      Door een account aan te maken, ga je akkoord met de %{terms_of_service} en %{privacy_policy} 
+      van het Energietransitiemodel.
+    terms_of_service: Gebruiksvoorwaarden
+    privacy_policy: Privacyverklaring
 
   pico:
     ready: gereed

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -373,6 +373,12 @@ nl:
     im_a_teacher:     "Ik ben een docent"
     optional:         "Optioneel"
 
+    agree_to_terms: |
+      By signing up, you agree to the %{terms_of_service} and %{privacy_policy} of the Energy
+      Transition Model.
+    terms_of_service: Terms of Service
+    privacy_policy: Privacy Policy
+
   pico:
     ready: gereed
 


### PR DESCRIPTION
This adds links to our terms and privacy policy on the sign-up page.

Would you mind adding [a few translations](https://github.com/quintel/etmodel/blob/edf148e05f6a6b017250e62f7f079572376d0463/config/locales/nl_etm.yml#L376-L380) prior to merging? Please and thank you!

![Screenshot 2021-03-08 at 11 40 33](https://user-images.githubusercontent.com/4383/110316844-3527f380-8003-11eb-959c-2eddf1b51160.png)
