### PR TITLE
Grey out dashboard items based on their dependent_on attribute

### DIFF
--- a/app/assets/javascripts/lib/models/dashboard_item.coffee
+++ b/app/assets/javascripts/lib/models/dashboard_item.coffee
@@ -38,10 +38,12 @@ class DashboardItem extends Backbone.Model
     })
 
   # All dashboard items show the value of the gquery they've been assigned.
-  # But there's one exception...
+  # But there's two exceptions...
   result: ->
     if @get('key') == 'profitability'
       MeritOrder.dashboardValue(@gquery.get('future'))
+    else if @get('dependent_on') == 'has_merit_order' && not App.settings.merit_order_enabled()
+      'unavailable'
     else
       @get('result')
 

--- a/app/assets/javascripts/lib/views/dashboard_item_view.coffee
+++ b/app/assets/javascripts/lib/views/dashboard_item_view.coffee
@@ -12,9 +12,14 @@ class @DashboardItemView extends Backbone.View
     key = @model.get 'key'
     if key == 'total_energy_cost' || key == 'costs_fte'
       @render_costs_label()
+
     formatted_value = @format_result()
-    $('strong', @dom_id).empty().append(formatted_value)
-    @updateArrows()
+    if formatted_value == 'unavailable'
+      @render_unavailable()
+    else
+      @element.removeClass('unavailable')
+      $('strong', @dom_id).empty().append(formatted_value)
+      @updateArrows()
     this
 
   # different behaviour unfortunately
@@ -32,6 +37,12 @@ class @DashboardItemView extends Backbone.View
     ].join('/')
 
     @update_subheader "(#{ unit })"
+
+  # An item can be unvailable when it's dependent on e.g. Merit being enabled
+  render_unavailable: () =>
+    $('strong', @dom_id).empty().append(I18n.t('units.unavailable'))
+    @cleanArrows()
+    @element.addClass('unavailable')
 
   update_header: (title) =>
     $('.header', @dom_id).html(title)
@@ -58,6 +69,7 @@ class @DashboardItemView extends Backbone.View
     result = @model.result()
     key    = @model.get('key')
     return '' if @model.error()
+    return 'unavailable' if result == 'unavailable'
 
     out = switch key
       when 'total_energy_cost'

--- a/app/assets/stylesheets/_dashboard.sass
+++ b/app/assets/stylesheets/_dashboard.sass
@@ -21,6 +21,10 @@
       width: 14%
       position: relative
 
+      &.unavailable
+        .header, strong
+          color: #999
+
       .arrow
         position: absolute
         right: 5px

--- a/app/models/dashboard_item.rb
+++ b/app/models/dashboard_item.rb
@@ -107,12 +107,12 @@ class DashboardItem < YModel::Base
   # INSTANCE METHODS ---------------------------------------------------------
 
   # Creates a JSON representation of the DashboardItem. Contains only the id,
-  # key and Gquery key.
+  # key, Gquery key and the dependencies.
   #
   # @return [Hash{String => Object}]
   #
   def as_json(*)
-    %w[key gquery_key].to_h { |k| [k, send(k)] }
+    %w[key gquery_key dependent_on].index_with { |k| send(k) }
   end
 
   def description

--- a/config/interface/dashboard_items.yml
+++ b/config/interface/dashboard_items.yml
@@ -75,7 +75,7 @@
   position: 6
   disabled: false
   output_element_key: merit_order_hourly_supply
-  dependent_on: ''
+  dependent_on: has_merit_order
 - key: total_number_of_excess_events
   gquery_key: dashboard_total_number_of_excess_events
   group: summary

--- a/config/locales/en_units.yml
+++ b/config/locales/en_units.yml
@@ -88,3 +88,4 @@ en:
       thousands: "km<sup>3</sup>"
       millions: "Mm<sup>3</sup>"
       billions: "Bm<sup>3</sup>"
+    unavailable: n.a.

--- a/config/locales/nl_units.yml
+++ b/config/locales/nl_units.yml
@@ -97,3 +97,4 @@ nl:
       thousands: "km<sup>3</sup>"
       millions: "Mm<sup>3</sup>"
       billions: "Bm<sup>3</sup>"
+    unavailable: n.v.t.


### PR DESCRIPTION
Also, set the `blackout_hours` `DashboardItem` to be dependent on Merit being enabled.

<img width="707" alt="Screenshot 2021-04-08 at 11 18 03" src="https://user-images.githubusercontent.com/14875123/114001343-2465da00-985c-11eb-89bc-f112e3dc84d5.png">




Closes #3593