### PR TITLE
Clarify investment costs in node details

### DIFF
--- a/app/assets/javascripts/lib/views/input_element_view.js
+++ b/app/assets/javascripts/lib/views/input_element_view.js
@@ -234,7 +234,13 @@
 
     return groups.map(function (group) {
       var attrs = Object.entries(group[1]).map(function (entry) {
-        return $.extend({ name: I18n.t('node_details.attributes.' + entry[0]) }, entry[1]);
+        return $.extend(
+          {
+            name: I18n.t('node_details.attributes.' + entry[0]),
+            description: I18n.t('node_details.descriptions.' + entry[0], { defaultValue: false }),
+          },
+          entry[1]
+        );
       });
 
       return [group[0], attrs];

--- a/app/assets/stylesheets/_node_popup.sass
+++ b/app/assets/stylesheets/_node_popup.sass
@@ -13,6 +13,7 @@ div.popup_node_details
     td, th
       border-bottom: 1px solid #eee
       padding: 0.375rem
+      vertical-align: top
       &:first-child
         width: 55%
     tr:last-child td
@@ -26,6 +27,18 @@ div.popup_node_details
         color: #333
         font-size: 1rem
         font-weight: 500
+
+  details
+    summary
+      cursor: pointer
+      &:hover
+        text-decoration: underline
+    .attribute-description
+      color: #777
+      font-size: 0.75rem
+      line-height: 1rem
+      padding-top: 3px
+      width: 90%
 
   a.download
     background: image-url('icons/xlsx.svg') no-repeat

--- a/app/views/nodes/_node_details.html
+++ b/app/views/nodes/_node_details.html
@@ -11,7 +11,16 @@
 
           <% _.each(group[1], function(data, attr) { %>
             <tr>
-              <td><%= data.name %></td>
+              <td>
+                <% if(data.description) { %>
+                  <details>
+                    <summary><%= data.name %></summary>
+                    <div class="attribute-description"><%= data.description %></div>
+                  </details>
+                <% } else { %>
+                  <%= data.name %>
+                <% } %>
+              </td>
               <td><%= Metric.node_detail_format(data.future, data.unit) %></td>
             </tr>
           <% }) %>

--- a/config/locales/en_node_details.yml
+++ b/config/locales/en_node_details.yml
@@ -57,13 +57,13 @@ en:
       wood_pellets_input_conversion: Wood pellets input conversion
     descriptions:
       total_investment_over_lifetime_per_mw_electricity: |
-        Includes initial invstment with any applicable installation, CCS, storage, and
+        Includes initial investment with any applicable installation, CCS, storage, and
         decommissioning costs.
       total_investment_over_lifetime_per_mw_typical_input_capacity: |
-        Includes initial invstment with any applicable installation, CCS, storage, and
+        Includes initial investment with any applicable installation, CCS, storage, and
         decommissioning costs.
       total_investment_over_lifetime_per_plant: |
-        Includes initial invstment with any applicable installation, CCS, storage, and
+        Includes initial investment with any applicable installation, CCS, storage, and
         decommissioning costs.
     download_analysis: Download source data
     groups:

--- a/config/locales/en_node_details.yml
+++ b/config/locales/en_node_details.yml
@@ -40,9 +40,9 @@ en:
       total_installed_input_capacity: Total installed input capacity
       total_installed_storage_capacity: Total installed storage capacity
       total_installed_transport_capacity: Total installed transport capacity
-      total_investment_over_lifetime_per_mw_electricity: Initial investment
-      total_investment_over_lifetime_per_mw_typical_input_capacity: Initial investment
-      total_investment_over_lifetime_per_plant: Initial investment
+      total_investment_over_lifetime_per_mw_electricity: Investment over lifetime
+      total_investment_over_lifetime_per_mw_typical_input_capacity: Investment over lifetime
+      total_investment_over_lifetime_per_plant: Investment over lifetime
       total_storage_capacity: Total installed storage volume
       typical_input_capacity: Capacity per unit
       typical_input_capacity_co2_capture: Capture capacity per unit
@@ -55,6 +55,16 @@ en:
       coal_input_conversion: Coal input conversion
       torrefied_biomass_pellets_input_conversion: Torrefied biomass pellets input conversion
       wood_pellets_input_conversion: Wood pellets input conversion
+    descriptions:
+      total_investment_over_lifetime_per_mw_electricity: |
+        Includes initial invstment with any applicable installation, CCS, storage, and
+        decommissioning costs.
+      total_investment_over_lifetime_per_mw_typical_input_capacity: |
+        Includes initial invstment with any applicable installation, CCS, storage, and
+        decommissioning costs.
+      total_investment_over_lifetime_per_plant: |
+        Includes initial invstment with any applicable installation, CCS, storage, and
+        decommissioning costs.
     download_analysis: Download source data
     groups:
       cost: Costs

--- a/config/locales/nl_node_details.yml
+++ b/config/locales/nl_node_details.yml
@@ -42,9 +42,9 @@ nl:
       total_installed_input_capacity: Opgesteld input vermogen
       total_installed_storage_capacity: Opgestelde opslagcapaciteit
       total_installed_transport_capacity: Opgestelde transportcapaciteit
-      total_investment_over_lifetime_per_mw_electricity: Investeringskosten
-      total_investment_over_lifetime_per_mw_typical_input_capacity: Investeringskosten
-      total_investment_over_lifetime_per_plant: Investeringskosten
+      total_investment_over_lifetime_per_mw_electricity: Investment over lifetime
+      total_investment_over_lifetime_per_mw_typical_input_capacity: Investment over lifetime
+      total_investment_over_lifetime_per_plant: Investment over lifetime
       total_storage_capacity: Opgesteld opslagvolume
       typical_input_capacity: Capaciteit per installatie
       typical_input_capacity_co2_capture: Afvangcapaciteit per installatie
@@ -55,6 +55,16 @@ nl:
       variable_operation_and_maintenance_costs_per_full_load_hour: Variabele exploitatie- en onderhoudskosten (O&M)
       wacc: Kapitaalskosten (WACC)
       wood_pellets_input_conversion: Inputconversie vaste biomassa
+    descriptions:
+      total_investment_over_lifetime_per_mw_electricity: |
+        Includes initial invstment with any applicable installation, CCS, storage, and
+        decommissioning costs.
+      total_investment_over_lifetime_per_mw_typical_input_capacity: |
+        Includes initial invstment with any applicable installation, CCS, storage, and
+        decommissioning costs.
+      total_investment_over_lifetime_per_plant: |
+        Includes initial invstment with any applicable installation, CCS, storage, and
+        decommissioning costs.
     download_analysis: Download brondata
     groups:
       cost: Kosten

--- a/config/locales/nl_node_details.yml
+++ b/config/locales/nl_node_details.yml
@@ -42,9 +42,9 @@ nl:
       total_installed_input_capacity: Opgesteld input vermogen
       total_installed_storage_capacity: Opgestelde opslagcapaciteit
       total_installed_transport_capacity: Opgestelde transportcapaciteit
-      total_investment_over_lifetime_per_mw_electricity: Investment over lifetime
-      total_investment_over_lifetime_per_mw_typical_input_capacity: Investment over lifetime
-      total_investment_over_lifetime_per_plant: Investment over lifetime
+      total_investment_over_lifetime_per_mw_electricity: Investering gedurende de levensduur
+      total_investment_over_lifetime_per_mw_typical_input_capacity: Investering gedurende de levensduur
+      total_investment_over_lifetime_per_plant: Investering gedurende de levensduur
       total_storage_capacity: Opgesteld opslagvolume
       typical_input_capacity: Capaciteit per installatie
       typical_input_capacity_co2_capture: Afvangcapaciteit per installatie
@@ -57,14 +57,11 @@ nl:
       wood_pellets_input_conversion: Inputconversie vaste biomassa
     descriptions:
       total_investment_over_lifetime_per_mw_electricity: |
-        Includes initial invstment with any applicable installation, CCS, storage, and
-        decommissioning costs.
+        Omvat de initiële investering plus de kosten voor installatie, CCS, opslag en ontmanteling (indien van toepassing)
       total_investment_over_lifetime_per_mw_typical_input_capacity: |
-        Includes initial invstment with any applicable installation, CCS, storage, and
-        decommissioning costs.
+        Omvat de initiële investering plus de kosten voor installatie, CCS, opslag en ontmanteling (indien van toepassing)
       total_investment_over_lifetime_per_plant: |
-        Includes initial invstment with any applicable installation, CCS, storage, and
-        decommissioning costs.
+        Omvat de initiële investering plus de kosten voor installatie, CCS, opslag en ontmanteling (indien van toepassing)
     download_analysis: Download brondata
     groups:
       cost: Kosten


### PR DESCRIPTION
Makes a few small changes to the technical and financial properties table:

* Rephrases "Initial investment" as "Investment over lifetime" when using the `total_investment_over_lifetime` node attribute, to clarify that the row contains not just the initial investment, but also other costs such as installation and decommissioning.

* Adds a toggleable description of the investment costs. Descriptions may be added to any attribute using the "node_attributes.descriptions" locale namespace.

A couple of translations are needed, please and thank you:

* ["Investment over lifetime" title](https://github.com/quintel/etmodel/blob/434333e22dc0ec9ffe8d2a0f12bfcf7c47e88873/config/locales/nl_node_details.yml#L45-L47) (repeated 3 times)
* [Attribute description](https://github.com/quintel/etmodel/blob/434333e22dc0ec9ffe8d2a0f12bfcf7c47e88873/config/locales/nl_node_details.yml#L59-L67) (repeated 3 times)

Closes #3727