### PR TITLE
Add description of NACE J to Central ICT locales

### DIFF
--- a/config/locales/interface/input_elements/en_demand_industry.yml
+++ b/config/locales/interface/input_elements/en_demand_industry.yml
@@ -204,8 +204,10 @@ en:
     industry_useful_demand_for_other_ict:
       title: Size
       short_description:
-      description: Here you can indicate the total size of the central ICT industry
-        in the future.
+      description: |
+        Here you can indicate the total size of the central ICT industry in the future.
+        The demand for the start year of your scenario is set as the demand from the 
+        economic sector "Information and communication" (NACE J).
     industry_useful_demand_for_other_ict_efficiency:
       title: Efficiency improvement
       short_description:

--- a/config/locales/interface/input_elements/nl_demand_industry.yml
+++ b/config/locales/interface/input_elements/nl_demand_industry.yml
@@ -214,8 +214,10 @@ nl:
     industry_useful_demand_for_other_ict:
       title: Grootte
       short_description: 
-      description: Geef hier aan hoe de ICT-industrie in de toekomst zal groeien of
-        krimpen.
+      description: |
+        Geef hier aan hoe de ICT-industrie in de toekomst zal groeien of krimpen.
+        Voor het startjaar van je scenario is de vraag gelijk aan de vraag in de
+        economische sector "Informatie en communicatie" (SBI J).
     industry_useful_demand_for_other_ict_efficiency:
       title: Efficiëntieverbetering
       short_description: 


### PR DESCRIPTION
The description of sliders for the size of the Central ICT have been updated.
They now include a reference to the economic sector NACE J for `en` locales and SBI J for `nl` locales.
This is done for https://github.com/quintel/etdataset/issues/883 and should be merged with the nl 2019 dataset.