### PR TITLE
Updates disabled merit warning

### DIFF
--- a/config/locales/en_wells.yml
+++ b/config/locales/en_wells.yml
@@ -4,8 +4,10 @@ en:
       merit: >
         <h4>Please enable merit order to view this information</h4>
         <p>
-          This chart relies on data from the time-resolved calculations, which is
-          currently disabled in your scenario. To turn it on, please select the
-          'Enable time-resolved calculations' option from the 'Settings'
-          menu at the top right of this page.
+          This chart relies on data from time-resolved calculations, which is
+          currently disabled in your scenario. To turn it on, please enable the
+          time-resolved calculations on the 
+          <a href="/scenario/supply/merit_order/merit-order">Merit Order</a> page.
+          There you can also find more information about what the merit order is 
+          and what effect it has on your scenario.
         </p>

--- a/config/locales/nl_wells.yml
+++ b/config/locales/nl_wells.yml
@@ -4,14 +4,10 @@ nl:
       merit: >
         <h4>Zet de merit order aan om deze informatie te bekijken</h4>
         <p>
-          Deze informatie is gebaseerd op doorrekening op uurbasis, die
-          momenteel niet aangezet is in jouw scenario. Selecteer
-          'Gebruik uurlijkse berekeningen' om deze aan te zetten vanuit het 'Opties' menu
-          rechts bovenaan de pagina.
+          Deze informatie is gebaseerd op doorrekeningen op uurbasis, die
+          momenteel niet zijn aangezet in jouw scenario. Schakel de uurlijkse
+          berkeningen in op de
+          <a href="/scenario/supply/merit_order/merit-order">Merit Order</a> pagina.
+          Daar kun je ook meer informatie krijgen over wat de merit order is en welk
+          effect het heeft op jouw scenario.
         </p>
-        <p>
-          Om meer te leren over de merit order en het effect die het zal hebben op
-          jouw scenario, zie de <a href="/supply/merit_order/merit-order">Merit Order</a>
-          pagina onder de sectie Kosten.
-        </p>
-


### PR DESCRIPTION
This solves #3844 by updating the warning text that is displayed in charts when merit is turned off.