### PR TITLE
Update flexibility section locales

### DIFF
--- a/config/locales/interface/output_elements/en_flexibility.yml
+++ b/config/locales/interface/output_elements/en_flexibility.yml
@@ -85,7 +85,7 @@ en:
       short_description: ''
       description: |
         The ETM contains several flexible electricity demand technologies, which 
-        can be found in the in the <a href="/scenario/flexibility/flexibility_overview/what-is-flexibility">
+        can be found in the <a href="/scenario/flexibility/flexibility_overview/what-is-flexibility">
         Flexibility</a> section of the model. It is defined in the 
         <a href="https://docs.energytransitionmodel.com/main/flexibility/#definitions-of-flexible-and-inflexible-supply-and-demand" target=\"_blank\">
         documentation</a> which types of electricity demand are considered flexible. </br></br>

--- a/config/locales/interface/slides/en_flexibility.yml
+++ b/config/locales/interface/slides/en_flexibility.yml
@@ -146,13 +146,15 @@ en:
         time if needed (see the <a href="/scenario/flexibility/flexibility_overview/what-is-flexibility"> 
         Flexibility overview</a> for background information). </br></br>
         The ETM models three types of storage behaviour. <br /><ol><li>By default, storage behaves like any other
-        flexible technology. Each storage technology has a <i>willingness-to-pay</i> that indicates the maximum electricity price for
+        flexible technology. Each storage technology has a <i>willingness to pay</i> that indicates the maximum electricity price for
         which it is willing to charge electricity. If the electricity price in a given hour is lower than a 
-        technology's willingness-to-pay, the storage technology will charge. </br></br>
-        Similarly, each technology also has a <i>willingness-to-accept</i>, which indicates the minimum 
+        technology's willingness to pay, the storage technology will charge. </br></br>
+        Similarly, each technology also has a <i>willingness to accept</i>, which indicates the minimum 
         electricity price for which it is willing to discharge the stored electricity. This
         is similar to the concept of 'marginal costs' for flexible power plants.</li> </br>
-        <li>Optionally you can choose to activate a forecasting algorithm that tries to improve the
+        <li>Optionally you can choose to activate a 
+        <a href="https://docs.energytransitionmodel.com/main/battery-forecasting/" target=\"_blank\"> 
+        forecasting algorithm</a> that tries to improve the
         charging and discharging behaviour of storage. Rather than looking at the electricity
         price in the current hour only, the battery will look ahead in time to identify interesting moments
         for charging and discharging. It does so by looking at peaks and troughs in the 
@@ -165,7 +167,7 @@ en:
         In the slides below you can set the the installed capacity for various electricity storage technologies and 
         determine their behaviour. Note that the specific behaviour of these
         technologies is more complicated than stated in this short description. Our 
-        <a href="https://docs.energytransitionmodel.com/main/flexibility" target=\"_blank\"> documentation</a> 
+        <a href="https://docs.energytransitionmodel.com/main/electricity-storage" target=\"_blank\"> documentation</a> 
         contains more details.
     flexibility_power_storage_households_flexibility_p2p_electricity:
       title: Batteries in households
@@ -174,10 +176,10 @@ en:
         It is possible to install batteries in households. These can then be charged by electricity from the grid, 
         or by solar power if the household has solar panels installed. </br></br>
         Batteries in the ETM are flexible technologies, which 
-        means that they can choose at which moments to charge or discharge. By default, if the electricity price is lower than the willingness-to-pay of the battery in a given hour, it
-        will charge electricity in that hour. If the electricity price exceeds the willingness-to-accept, it will 
+        means that they can choose at which moments to charge or discharge. By default, if the electricity price is lower than the willingness to pay of the battery in a given hour, it
+        will charge electricity in that hour. If the electricity price exceeds the willingness to accept, it will 
         discharge the stored electricity. <br/><br/>Optionally, you can override this behaviour by switching the toggle below and use a forecasting algorithm to determine battery behaviour. In both cases the ETM respects the storage volume limits of the battery.
-        See our <a href="https://docs.energytransitionmodel.com/main/flexibility" target=\"_blank\">
+        See our <a href="https://docs.energytransitionmodel.com/main/electricity-storage" target=\"_blank\">
         documentation</a> for more information.
     flexibility_power_storage_transport_car_flexibility_p2p_electricity:
       title: Batteries in electric vehicles
@@ -186,10 +188,10 @@ en:
         Electric vehicles could provide a cost-effective way of storing electricity as they contain a relatively 
         large battery. </br></br>
         Batteries in the ETM are flexible technologies, which 
-        means that they can choose at which moments to charge or discharge. By default, if the electricity price is lower than the willingness-to-pay of the battery in a given hour, it
-        will charge electricity in that hour. If the electricity price exceeds the willingness-to-accept, it will
+        means that they can choose at which moments to charge or discharge. By default, if the electricity price is lower than the willingness to pay of the battery in a given hour, it
+        will charge electricity in that hour. If the electricity price exceeds the willingness to accept, it will
         discharge the stored electricity. <br/><br/>Optionally, you can override this behaviour by switching the toggle below and use a forecasting algorithm to determine battery behaviour. In both cases the ETM respects the storage volume limits of the battery.
-        See our <a href="https://docs.energytransitionmodel.com/main/flexibility" target=\"_blank\">
+        See our <a href="https://docs.energytransitionmodel.com/main/electricity-storage" target=\"_blank\">
         documentation</a> for more information.
     flexibility_power_storage_energy_flexibility_mv_batteries_electricity:
       title: Large-scale batteries
@@ -198,10 +200,10 @@ en:
         This large-scale battery is typically connected to the medium voltage network. Although in the battery does 
         not react to congestion events, its behavior can help prevent capacity issues in the electricity network. </br></br>
         Batteries in the ETM are flexible technologies, which 
-        means that they can choose at which moments to charge or discharge. By default, if the electricity price is lower than the willingness-to-pay of the battery in a given hour, it
-        will charge electricity in that hour. If the electricity price exceeds the willingness-to-accept, it will
+        means that they can choose at which moments to charge or discharge. By default, if the electricity price is lower than the willingness to pay of the battery in a given hour, it
+        will charge electricity in that hour. If the electricity price exceeds the willingness to accept, it will
         discharge the stored electricity. <br/><br/>Optionally, you can override this behaviour by switching the toggle below and use a forecasting algorithm to determine battery behaviour. In both cases the ETM respects the storage volume limits of the battery.
-        See our <a href="https://docs.energytransitionmodel.com/main/flexibility" target=\"_blank\">
+        See our <a href="https://docs.energytransitionmodel.com/main/electricity-storage" target=\"_blank\">
         documentation</a> for more information.
     flexibility_power_storage_energy_flexibility_pumped_storage_electricity:
       title: Reservoirs
@@ -211,10 +213,10 @@ en:
         be used to pump water from the lower reservoir to a higher reservoir. Electricity is then 
         produced by releasing the stored water through a turbine. </br></br>
         Electricity storage in the ETM is a flexible technology, which
-        means that it can choose at which moments to charge or discharge. By default, if the electricity price is lower than the willingness-to-pay of the storage in a given hour, it
-        will charge electricity in that hour. If the electricity price exceeds the willingness-to-accept, it will
+        means that it can choose at which moments to charge or discharge. By default, if the electricity price is lower than the willingness to pay of the storage in a given hour, it
+        will charge electricity in that hour. If the electricity price exceeds the willingness to accept, it will
         discharge the stored electricity. <br/><br/>Optionally, you can override this behaviour by switching the toggle below and use a forecasting algorithm to determine storage behaviour. In both cases the ETM respects the storage volume limits of the storage.
-        See our <a href="https://docs.energytransitionmodel.com/main/flexibility" target=\"_blank\">
+        See our <a href="https://docs.energytransitionmodel.com/main/electricity-storage" target=\"_blank\">
         documentation</a> for more information.
     flexibility_power_storage_energy_flexibility_hv_opac_electricity:
       title: Underground pumped hydro storage
@@ -224,10 +226,10 @@ en:
         height difference between two water reservoirs, of which the lower reservoir is underground,
         to store electricity as potential energy. </br></br>
         Electricity storage in the ETM is a flexible technology, which
-        means that it can choose at which moments to charge or discharge. By default, if the electricity price is lower than the willingness-to-pay of the storage in a given hour, it
-        will charge electricity in that hour. If the electricity price exceeds the willingness-to-accept, it will
+        means that it can choose at which moments to charge or discharge. By default, if the electricity price is lower than the willingness to pay of the storage in a given hour, it
+        will charge electricity in that hour. If the electricity price exceeds the willingness to accept, it will
         discharge the stored electricity. <br/><br/>Optionally, you can override this behaviour by switching the toggle below and use a forecasting algorithm to determine storage behaviour. In both cases the ETM respects the storage volume limits of the storage.
-        See our <a href="https://docs.energytransitionmodel.com/main/flexibility" target=\"_blank\">
+        See our <a href="https://docs.energytransitionmodel.com/main/electricity-storage" target=\"_blank\">
         documentation</a> for more information.
     flexibility_power_storage_energy_flexibility_flow_batteries_electricity:
       title: Flow batteries
@@ -237,10 +239,10 @@ en:
         cheap compared to other batteries and it can be scaled independent from the installed capacity. For flow batteries 
         you can therefore determine both the capacity and the storage volume. </br></br>
         Batteries in the ETM are flexible technologies, which 
-        means that they can choose at which moments to charge or discharge. By default, if the electricity price is lower than the willingness-to-pay of the battery in a given hour, it
-        will charge electricity in that hour. If the electricity price exceeds the willingness-to-accept, it will
+        means that they can choose at which moments to charge or discharge. By default, if the electricity price is lower than the willingness to pay of the battery in a given hour, it
+        will charge electricity in that hour. If the electricity price exceeds the willingness to accept, it will
         discharge the stored electricity. <br/><br/>Optionally, you can override this behaviour by switching the toggle below and use a forecasting algorithm to determine battery behaviour. In both cases the ETM respects the storage volume limits of the battery.
-        See our <a href="https://docs.energytransitionmodel.com/main/flexibility" target=\"_blank\">
+        See our <a href="https://docs.energytransitionmodel.com/main/electricity-storage" target=\"_blank\">
         documentation</a> for more information.
     flexibility_electricity_conversion_overview:
       title: Behaviour of conversion technologies
@@ -251,10 +253,10 @@ en:
         is considered flexible because it can be increased, reduced or shifted in time if needed (see the
         <a href="/scenario/flexibility/flexibility_overview/what-is-flexibility"> Flexibility overview </a>
         for background information). </br></br>
-        Each flexible demand technology has a <i>willingness-to-pay</i> that indicates the maximum electricity
-        price for which it is willing to consume electricity. If the electricity price in a given hour is lower than a technology's willingness-to-pay, the technology will consume electricity
+        Each flexible demand technology has a <i>willingness to pay</i> that indicates the maximum electricity
+        price for which it is willing to consume electricity. If the electricity price in a given hour is lower than a technology's willingness to pay, the technology will consume electricity
         in that hour.
-        In the slides below you can set the willingness-to-pay and installed capacity for:
+        In the slides below you can set the willingness to pay and installed capacity for:
         <ul><li><a href="/scenario/flexibility/flexibility_conversion/conversion-to-hydrogen">
         conversion to hydrogen</a></li>
         <li><a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-district-heating">
@@ -262,7 +264,7 @@ en:
         <li><a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-industry">
         conversion to heat for industry</a></li></ul></br>
         Note that the specific behaviour of these technologies is more complicated than stated in this short
-        description. Our <a href="https://docs.energytransitionmodel.com/main/flexibility" target=\"_blank\">
+        description. Our <a href="https://docs.energytransitionmodel.com/main/electricity-conversion" target=\"_blank\">
         documentation</a> contains a more detailed description.
     flexibility_flexibility_power_to_heat_for_district_heating:
       title: Conversion to heat for district heating
@@ -270,8 +272,8 @@ en:
       description: |
         Electricity can be used to produce heat through electric boilers or heat pumps, which is
         also known as power-to-heat. In the ETM, power-to-heat is a flexible demand technology, which
-        means that heat is only produced when the willingness-to-pay of power-to-heat exceeds the hourly
-        electricity price. See our <a href="https://docs.energytransitionmodel.com/main/flexibility" target=\"_blank\">
+        means that heat is only produced when the willingness to pay of power-to-heat exceeds the hourly
+        electricity price. See our <a href="https://docs.energytransitionmodel.com/main/electricity-conversion" target=\"_blank\">
         documentation</a> for more information. </br></br>
         Note that a 1 MWth power-to-heat boiler uses more electricity than a 1 MWth power-to-heat heat
         pump, even though they produce the same amount of heat per hour. The produced heat is delivered
@@ -283,9 +285,9 @@ en:
       description: |
         Gas and hydrogen burners in industry can be turned into hybrid heaters by fitting
         them with an electric boiler. In the ETM, this power-to-heat boiler is a flexible demand
-        technology, which means that when the willingness-to-pay exceeds the hourly electricity
+        technology, which means that when the willingness to pay exceeds the hourly electricity
         price, the power-to-heat boilers will produce the required heat instead of the gas or
-        hydrogen burners. See our <a href="https://docs.energytransitionmodel.com/main/flexibility" target=\"_blank\">
+        hydrogen burners. See our <a href="https://docs.energytransitionmodel.com/main/electricity-conversion" target=\"_blank\">
         documentation</a> for more information. </br></br>
         Because it is a hybrid heating option it requires capacity of both power-to-heat
         boilers and gas or hydrogen burners to be installed for it to have an effect.
@@ -300,8 +302,8 @@ en:
       description: |
         Electricity can be used to produce hydrogen through the electrolysis of water, which is also
         known as power-to-gas. In the ETM, power-to-gas is a flexible demand technology, which means that
-        hydrogen is only produced when the willingness-to-pay of power-to-gas exceeds the hourly electricity
-        price. See our <a href="https://docs.energytransitionmodel.com/main/flexibility" target=\"_blank\">
+        hydrogen is only produced when the willingness to pay of power-to-gas exceeds the hourly electricity
+        price. See our <a href="https://docs.energytransitionmodel.com/main/electricity-conversion" target=\"_blank\">
         documentation</a> for more information. </br></br>
         The produced hydrogen will be fed into the central hydrogen network. In the
         <a href="/scenario/supply/hydrogen/hydrogen-production"> hydrogen production</a> section you can

--- a/config/locales/interface/slides/nl_flexibility.yml
+++ b/config/locales/interface/slides/nl_flexibility.yml
@@ -127,8 +127,8 @@ nl:
         kan worden vergroot, verlaagd, of worden verplaatst in de tijd (zie voor achtergrondinformatie 
         het <a href="/scenario/flexibility/flexibility_overview/what-is-flexibility"> Overzicht van
         flexibiliteit</a>). </br></br>
-        Het ETM modelleert drie soorten batterijgedrag.<br /><ol><li>
-        Standaard gedraagt een batterij zich net als andere flexibele technologieën.
+        Het ETM modelleert drie soorten opslaggedrag.<br /><ol><li>
+        Standaard gedraagt een opslagtechnologie zich net als andere flexibele technologieën.
         Elke opslagtechnologie heeft een <i>willingness-to-pay</i> die de maximale prijs aangeeft
         waarvoor de technologie bereid is om op te laden. Als de
         elektriciteitsprijs in een bepaald uur lager is dan de willingness-to-pay van de technologie, 
@@ -136,7 +136,9 @@ nl:
         Elke technologie heeft ook <i>willingness-to-accept</i>, die aangeeft wat de minimale prijs 
         is waarvoor het bereid is de opgeslagen elektriciteit te ontladen. Dit is vergelijkbaar
         met het begrip 'marginale kosten' bij regelbare centrales.</li> </br>
-        <li>Daarnaast biedt het ETM een optie om een prognose-algoritme te gebruiken om het gedrag van batterijen te verbeteren.
+        <li>Daarnaast biedt het ETM een optie om een 
+        <a href="https://docs.energytransitionmodel.com/main/battery-forecasting/" target=\"_blank\"> 
+        prognose-algoritme</a> te gebruiken om het gedrag van opslagtechnologieën te verbeteren.
         In plaats van alleen te kijken naar de elektriciteitsprijs in één uur, kijkt het algoritme
         vooruit in de tijd en probeert het interessante momenten om te laden en ontladen te identificeren.
         Dit gebeurt door naar de pieken en dalen in de 
@@ -146,10 +148,10 @@ nl:
         elektriciteit op als de productie van de aangesloten hernieuwbare energiebron de capaciteit van 
         de netwerkaansluiting overschrijdt. De elektriciteit wordt ontladen zodra de productie onder deze 
         capaciteit zakt. Het opslagsysteem zelf heeft verder geen interactie met de rest van het elektriciteitssysteem. </li></ol><br/>
-        In de onderstaande slides het geïnstalleerde vermogen voor verschillende opslagtechnologieën instellen
+        In de onderstaande slides kun je het geïnstalleerde vermogen voor verschillende opslagtechnologieën instellen
         en het gedrag bepalen. Let op dat het
         daadwerkelijke gedrag van deze technologieën gecompliceerder is dan toegelicht in deze korte 
-        beschrijving. De <a href="https://docs.energytransitionmodel.com/main/flexibility" target=\"_blank\">
+        beschrijving. De <a href="https://docs.energytransitionmodel.com/main/electricity-storage" target=\"_blank\">
         documentatie</a> bevat een meer gedetailleerde beschrijving.
     flexibility_power_storage_households_flexibility_p2p_electricity:
       title: Batterijen in huishoudens
@@ -161,7 +163,7 @@ nl:
         in een bepaald uur lager is dan de willingness-to-pay, gaat de batterij in dat uur opladen. Wanneer
         de elektriciteitsprijs groter is dan de willingness-to-accept, zal de opslagen elektriciteit worden 
         ontladen.
-        <br/><br/>Optioneel kun je ervoor kiezen dit gedrag te overschrijven en in plaats daarvan het gedrag te laten bepalen door een prognose-algoritme. Dit kan door de toggle hieronder op 'aan' te zetten. In beide gevallen houdt het ETM rekening met het opslagvolume van de batterij. Zie onze <a href="https://docs.energytransitionmodel.com/main/flexibility" target=\"_blank\">
+        <br/><br/>Optioneel kun je ervoor kiezen dit gedrag te overschrijven en in plaats daarvan het gedrag te laten bepalen door een prognose-algoritme. Dit kan door de toggle hieronder op 'aan' te zetten. In beide gevallen houdt het ETM rekening met het opslagvolume van de batterij. Zie onze <a href="https://docs.energytransitionmodel.com/main/electricity-storage" target=\"_blank\">
         documentatie</a> voor meer informatie.
     flexibility_power_storage_wind_turbine_inland:
       title: Windmolens met opslagsystemen
@@ -193,7 +195,7 @@ nl:
         in een bepaald uur lager is dan de willingness-to-pay, gaat de batterij in dat uur opladen. Wanneer
         de elektriciteitsprijs groter is dan de willingness-to-accept, zal de opslagen elektriciteit worden
         ontladen.
-        <br/><br/>Optioneel kun je ervoor kiezen dit gedrag te overschrijven en in plaats daarvan het gedrag te laten bepalen door een prognose-algoritme. Dit kan door de toggle hieronder op 'aan' te zetten. In beide gevallen houdt het ETM rekening met het opslagvolume van de batterij. Zie onze <a href="https://docs.energytransitionmodel.com/main/flexibility" target=\"_blank\">
+        <br/><br/>Optioneel kun je ervoor kiezen dit gedrag te overschrijven en in plaats daarvan het gedrag te laten bepalen door een prognose-algoritme. Dit kan door de toggle hieronder op 'aan' te zetten. In beide gevallen houdt het ETM rekening met het opslagvolume van de batterij. Zie onze <a href="https://docs.energytransitionmodel.com/main/electricity-storage" target=\"_blank\">
         documentatie</a> voor meer informatie.
     flexibility_power_storage_energy_flexibility_mv_batteries_electricity:
       title: Grootschalige batterijopslag
@@ -206,7 +208,7 @@ nl:
         in een bepaald uur lager is dan de willingness-to-pay, gaat de batterij in dat uur opladen. Wanneer
         de elektriciteitsprijs groter is dan de willingness-to-accept, zal de opslagen elektriciteit worden
         ontladen.
-        <br/><br/>Optioneel kun je ervoor kiezen dit gedrag te overschrijven en in plaats daarvan het gedrag te laten bepalen door een prognose-algoritme. Dit kan door de toggle hieronder op 'aan' te zetten. In beide gevallen houdt het ETM rekening met het opslagvolume van de batterij. Zie onze <a href="https://docs.energytransitionmodel.com/main/flexibility" target=\"_blank\">
+        <br/><br/>Optioneel kun je ervoor kiezen dit gedrag te overschrijven en in plaats daarvan het gedrag te laten bepalen door een prognose-algoritme. Dit kan door de toggle hieronder op 'aan' te zetten. In beide gevallen houdt het ETM rekening met het opslagvolume van de batterij. Zie onze <a href="https://docs.energytransitionmodel.com/main/electricity-storage" target=\"_blank\">
         documentatie</a> voor meer informatie.
     flexibility_power_storage_energy_flexibility_pumped_storage_electricity:
       title: Stuwmeren
@@ -219,7 +221,7 @@ nl:
         in een bepaald uur lager is dan de willingness-to-pay, gaat de opslag in dat uur opladen. Wanneer
         de elektriciteitsprijs groter is dan de willingness-to-accept, zal de opslagen elektriciteit worden
         ontladen.
-        <br/><br/>Optioneel kun je ervoor kiezen dit gedrag te overschrijven en in plaats daarvan het gedrag te laten bepalen door een prognose-algoritme. Dit kan door de toggle hieronder op 'aan' te zetten. In beide gevallen houdt het ETM rekening met het opslagvolume van de opslag. Zie onze <a href="https://docs.energytransitionmodel.com/main/flexibility" target=\"_blank\">
+        <br/><br/>Optioneel kun je ervoor kiezen dit gedrag te overschrijven en in plaats daarvan het gedrag te laten bepalen door een prognose-algoritme. Dit kan door de toggle hieronder op 'aan' te zetten. In beide gevallen houdt het ETM rekening met het opslagvolume van de opslag. Zie onze <a href="https://docs.energytransitionmodel.com/main/electricity-storage" target=\"_blank\">
         documentatie</a> voor meer informatie.
     flexibility_power_storage_energy_flexibility_hv_opac_electricity:
       title: OPAC
@@ -232,7 +234,7 @@ nl:
         in een bepaald uur lager is dan de willingness-to-pay, gaat de opslag in dat uur opladen. Wanneer
         de elektriciteitsprijs groter is dan de willingness-to-accept, zal de opslagen elektriciteit worden
         ontladen.
-        <br/><br/>Optioneel kun je ervoor kiezen dit gedrag te overschrijven en in plaats daarvan het gedrag te laten bepalen door een prognose-algoritme. Dit kan door de toggle hieronder op 'aan' te zetten. In beide gevallen houdt het ETM rekening met het opslagvolume van de opslag. Zie onze <a href="https://docs.energytransitionmodel.com/main/flexibility" target=\"_blank\">
+        <br/><br/>Optioneel kun je ervoor kiezen dit gedrag te overschrijven en in plaats daarvan het gedrag te laten bepalen door een prognose-algoritme. Dit kan door de toggle hieronder op 'aan' te zetten. In beide gevallen houdt het ETM rekening met het opslagvolume van de opslag. Zie onze <a href="https://docs.energytransitionmodel.com/main/electricity-storage" target=\"_blank\">
         documentatie</a> voor meer informatie.
     flexibility_power_storage_energy_flexibility_flow_batteries_electricity:
       title: Flowbatterijen
@@ -246,7 +248,7 @@ nl:
         in een bepaald uur lager is dan de willingness-to-pay, gaat de batterij in dat uur opladen. Wanneer
         de elektriciteitsprijs groter is dan de willingness-to-accept, zal de opslagen elektriciteit worden
         ontladen.
-        <br/><br/>Optioneel kun je ervoor kiezen dit gedrag te overschrijven en in plaats daarvan het gedrag te laten bepalen door een prognose-algoritme. Dit kan door de toggle hieronder op 'aan' te zetten. In beide gevallen houdt het ETM rekening met het opslagvolume van de batterij. Zie onze <a href="https://docs.energytransitionmodel.com/main/flexibility" target=\"_blank\">
+        <br/><br/>Optioneel kun je ervoor kiezen dit gedrag te overschrijven en in plaats daarvan het gedrag te laten bepalen door een prognose-algoritme. Dit kan door de toggle hieronder op 'aan' te zetten. In beide gevallen houdt het ETM rekening met het opslagvolume van de batterij. Zie onze <a href="https://docs.energytransitionmodel.com/main/electricity-storage" target=\"_blank\">
         documentatie</a> voor meer informatie.
     flexibility_electricity_conversion_overview:
       title: Gedrag van conversietechnologieën
@@ -271,7 +273,7 @@ nl:
         <li><a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-industry">
         conversie naar warmte voor industrie</a></li></ul></br>
         Let op dat het daadwerkelijke gedrag van deze technologieën gecompliceerder is dan 
-        toegelicht in deze korte beschrijving. De <a href="https://docs.energytransitionmodel.com/main/flexibility" target=\"_blank\">
+        toegelicht in deze korte beschrijving. De <a href="https://docs.energytransitionmodel.com/main/electricity-conversion" target=\"_blank\">
         documentatie</a> bevat een meer gedetailleerde beschrijving.
     flexibility_flexibility_power_to_heat_for_district_heating:
       title: Conversie naar warmte voor warmtenetten
@@ -281,7 +283,7 @@ nl:
         boilers of warmtepompen, wat ook wel power-to-heat wordt genoemd. In het ETM is power-to-heat 
         een flexibele vraagtechnologie, wat betekent dat warmte alleen geproduceerd wordt wanneer 
         de willingness-to-pay van power-to-heat hoger is dan de uurlijkse elektriciteitsprijs.
-        Zie de <a href="https://docs.energytransitionmodel.com/main/flexibility" target=\"_blank\">
+        Zie de <a href="https://docs.energytransitionmodel.com/main/electricity-conversion" target=\"_blank\">
         documentatie</a> voor meer informatie. </br></br>
         Houd er rekening mee dat 1 MWth power-to-heat boiler meer elektriciteit gebruikt dan 1 MWth
         power-to-heat warmtepomp, ondanks dat ze dezelfde hoeveelheid warmte produceren per uur. De
@@ -297,7 +299,7 @@ nl:
         vraagtechnologie, wat betekent dat, als de willingness-to-pay van power-to-heat hoger is 
         dan de uurlijkse elektriciteitsprijs, de power-to-heat boilers de benodigde warmte producere 
         in plaats van de gas- of waterstofketels. Zie de 
-        <a href="https://docs.energytransitionmodel.com/main/flexibility" target=\"_blank\">
+        <a href="https://docs.energytransitionmodel.com/main/electricity-conversion" target=\"_blank\">
         documentatie</a> voor meer informatie. </br></br>
         Omdat het een hybride technologie is, hebben deze schuifjes alleen effect als er zowel 
         vermogen van de power-to-heat boilers als van de gas- of waterstofketels geïnstalleerd is.
@@ -314,10 +316,10 @@ nl:
         van water, wat ook wel power-to-gas wordt genoemd. In het ETM is power-to-gas 
         een flexibele vraagtechnologie, wat betekent dat waterstof alleen geproduceerd wordt wanneer 
         de willingness-to-pay van power-to-gas hoger is dan de uurlijkse elektriciteitsprijs.
-        Zie de <a href="https://docs.energytransitionmodel.com/main/flexibility" target=\"_blank\">
+        Zie de <a href="https://docs.energytransitionmodel.com/main/electricity-conversion" target=\"_blank\">
         documentatie</a> voor meer informatie. </br></br>
         De geproduceerde waterstof wordt ingevoed in het centrale waterstofnetwerk. In de
-        <a href="/scenario/supply/hydrogen/hydrogen-production"> waterstof productie</a> sectie kan je 
+        <a href="/scenario/supply/hydrogen/hydrogen-production"> waterstofproductie</a> sectie kan je 
         waterstof ook door middel van andere pocessen produceren. Eventuele overschotten aan 
         waterstof worden geëxporteerd.
     flexibility_flexibility_power_to_methane:


### PR DESCRIPTION
This pull requests includes:

- Update to links to the documentation: new pages have been added for the new flexible behaviour. These are currently still on the` price-sensitive-flex` [branch](https://github.com/quintel/documentation/tree/price-sensitive-flex) of the documentation.
- Update to the overview description of storage technologies, where 'batteries' are replaced by the more general term 'electricity storage technologies'. See https://github.com/quintel/etmodel/issues/3890.
- Change EN spelling of willingness-to-pay and willingness-to-accept to willingness to pay and willingness to accept.
- Minor fixes.

@lottevanvlimmeren could you check this PR and merge it once the documentation branch is merged? If you have the time, feel free to take a critical look at the flexibility section locales in general.