### PR TITLE
Remove broken investment table from report

### DIFF
--- a/config/interface/slides/data_export.yml
+++ b/config/interface/slides/data_export.yml
@@ -11,7 +11,7 @@
 - key: data_export_production
   position: 3
   sidebar_item_key: data_export
-  output_element_key: investment_table
+  output_element_key: breakdown_of_total_costs
 - key: data_export_energy_flows
   position: 1
   sidebar_item_key: data_export

--- a/config/reports/main.en.liquid
+++ b/config/reports/main.en.liquid
@@ -222,8 +222,7 @@
   </p>
   <p>
     Finally, appendix A lists all the sliders that were changed from their default value.
-    Appendix B gives a detailed overview of all investment costs.
-    Appendix C provides background information about the Energy Transition Model.
+    Appendix B provides background information about the Energy Transition Model.
   </p>
 
   <h1 class="banner">Energy use and production</h1>
@@ -609,11 +608,6 @@
 
   </ul>
 
-  <p>
-    For a complete list of investment costs per technology see
-    <a href="#appendix-b-investment-costs">Appendix B</a>.
-  </p>
-
   <h2>Area needed for wind</h2>
 
   <p>
@@ -769,22 +763,7 @@
     </p>
   {% endif %}
 
-  <h1 class="banner">Appendix B: Investment costs</h1>
-
-  <p>
-    The following (total) investments must be done to realise your scenario:
-  </p>
-
-
-  {% chart investment_table %}
-    This table shows an overview of the investment cost of heat and electricity producing
-    technologies. The investment costs are shown for both the start scenario ({{ settings.start_year }})
-    and for the future year. In both cases a 'green-field' approach is taken: no previously installed
-    technologies are assumed. The last column shows the difference between the investment costs
-    of the two scenarios.
-  {% endchart %}
-
-  <h1 class="banner">Appendix C: About The Energy Transition Model</h1>
+  <h1 class="banner">Appendix B: About The Energy Transition Model</h1>
 
     <h2>Introduction</h2>
 

--- a/config/reports/main.nl.liquid
+++ b/config/reports/main.nl.liquid
@@ -891,17 +891,7 @@
     </p>
   {% endif %}
 
-  <h2>Appendix B: Investeringen </h2>
-
-  {% chart investment_table %}
-    Deze tabel geeft een overzicht van de totale investeringen.
-  {% endchart %}
-
-  {% chart additional_infrastructure_investments %}
-    Deze tabel geeft een overzicht van de totale investeringen in de elektriciteitsnetten.
-  {% endchart %}
-
-  <h2>Appendix C: Over het Energietransitiemodel</h2>
+  <h2>Appendix B: Over het Energietransitiemodel</h2>
 
     <h3>Inleiding</h3>
 

--- a/config/reports/regional.en.liquid
+++ b/config/reports/regional.en.liquid
@@ -222,8 +222,7 @@
   </p>
   <p>
     Finally, appendix A lists all the sliders that were changed from their default value.
-    Appendix B gives a detailed overview of all investment costs.
-    Appendix C provides background information about the Energy Transition Model.
+    Appendix B provides background information about the Energy Transition Model.
   </p>
 
   <h1 class="banner">Energy use and production</h1>
@@ -610,11 +609,6 @@
 
   </ul>
 
-  <p>
-    For a complete list of investment costs per technology see
-    <a href="#appendix-b-investment-costs">Appendix B</a>.
-  </p>
-
   <h2>Area needed for wind</h2>
 
   <p>
@@ -769,22 +763,7 @@
     </p>
   {% endif %}
 
-  <h1 class="banner">Appendix B: Investment costs</h1>
-
-  <p>
-    The following (total) investments must be done to realise your scenario:
-  </p>
-
-
-  {% chart investment_table %}
-    This table shows an overview of the investment cost of heat and electricity producing
-    technologies. The investment costs are shown for both the start scenario ({{ settings.start_year }})
-    and for the future year. In both cases a 'green-field' approach is taken: no previously installed
-    technologies are assumed. The last column shows the difference between the investment costs
-    of the two scenarios.
-  {% endchart %}
-
-  <h1 class="banner">Appendix C: About The Energy Transition Model</h1>
+  <h1 class="banner">Appendix B: About The Energy Transition Model</h1>
 
     <h2>Introduction</h2>
 

--- a/config/reports/regional.nl.liquid
+++ b/config/reports/regional.nl.liquid
@@ -441,17 +441,7 @@
     </p>
   {% endif %}
 
-  <h2>Appendix B: Investeringen </h2>
-
-  {% chart investment_table %}
-    Deze tabel geeft een overzicht van de totale investeringen.
-  {% endchart %}
-
-  {% chart additional_infrastructure_investments %}
-    Deze tabel geeft een overzicht van de totale investeringen in de elektriciteitsnetten.
-  {% endchart %}
-
-    <h2>Appendix C: Over het Energietransitiemodel</h2>
+    <h2>Appendix B: Over het Energietransitiemodel</h2>
 
       <h3>Inleiding</h3>
 


### PR DESCRIPTION
A user got in touch yesterday to notify us that charts were not loading in the scenario report. This is caused by an old chart – the investment table – using gqueries that no longer exist in ETSource:

```
0: "Gquery industry_steel_blastfurnace_captured_co2_present_in_investment_cost_table does not exist"
1: "Gquery industry_steel_blastfurnace_captured_co2_future_in_investment_cost_table does not exist"
2: "Gquery industry_steel_blastfurnace_captured_co2_delta_in_investment_cost_table does not exist"
3: "Gquery industry_steel_electricfurnace_captured_co2_present_in_investment_cost_table does not exist"
4: "Gquery industry_steel_electricfurnace_captured_co2_future_in_investment_cost_table does not exist"
5: "Gquery industry_steel_electricfurnace_captured_co2_delta_in_investment_cost_table does not exist"
6: "Gquery industry_steel_hisarna_captured_co2_present_in_investment_cost_table does not exist"
7: "Gquery industry_steel_hisarna_captured_co2_future_in_investment_cost_table does not exist"
8: "Gquery industry_steel_hisarna_captured_co2_delta_in_investment_cost_table does not exist"
```

The table isn't available in the main ETM front-end. I'm not sure of the best way to fix this. Either someone more familiar than I with the steel sector can figure out if we can update the table, or we can remove the investment table from the report entirely. This PR does the latter.

@mabijkerk I'm assigning to you since you recently set the table to be hidden in the main interface (unfortunately the scenario report doesn't respect this), but feel free to reassign the PR as you see fit.

/cc @marliekeverweij 