### PR TITLE
Hybrid heaters p2h for fertilizers industry

### DIFF
--- a/app/views/output_elements/tables/_storage_options.html.haml
+++ b/app/views/output_elements/tables/_storage_options.html.haml
@@ -80,6 +80,14 @@
       %td{:data => {:decimals => 4, :gquery => "industry_flexibility_p2h_refineries_electricity_output", :graph => :future}}
       %td{:data => {:decimals => 1, :gquery => "industry_flexibility_p2h_refineries_electricity_flhs", :graph => :future}}
     %tr
+      %th= t "output_elements.tables.flexibility.electricity_converted_to_heat_fertilizers_industry"
+      %td{:data => {:gquery => "industry_flexibility_p2h_fertilizers_electricity_capacity", :graph => :future}}
+      %td{:data => {:gquery => "industry_flexibility_p2h_fertilizers_electricity_peak_capacity", :graph => :future}}
+      %td
+      %td{:data => {:decimals => 4, :gquery => "industry_flexibility_p2h_fertilizers_electricity_input", :graph => :future}}
+      %td{:data => {:decimals => 4, :gquery => "industry_flexibility_p2h_fertilizers_electricity_output", :graph => :future}}
+      %td{:data => {:decimals => 1, :gquery => "industry_flexibility_p2h_fertilizers_electricity_flhs", :graph => :future}}
+    %tr
       %th= t "output_elements.tables.flexibility.electricity_converted_to_heat_chemicals_industry"
       %td{:data => {:gquery => "industry_flexibility_p2h_chemicals_electricity_capacity", :graph => :future}}
       %td{:data => {:gquery => "industry_flexibility_p2h_chemicals_electricity_peak_capacity", :graph => :future}}

--- a/config/interface/input_elements/demand_industry_chemical_fertilizers.yml
+++ b/config/interface/input_elements/demand_industry_chemical_fertilizers.yml
@@ -77,3 +77,10 @@
   related_node: industry_chemicals_fertilizers_burner_hydrogen
   position: 10
   slide_key: demand_industry_chemical_fertilizers
+- key: capacity_of_industry_chemicals_fertilizers_flexibility_p2h_electricity
+  step_value: 1.0
+  unit: MW
+  interface_group: hybrid_heating
+  related_node: industry_chemicals_fertilizers_flexibility_p2h_network_gas_electricity
+  position: 100
+  slide_key: demand_industry_chemical_fertilizers

--- a/config/interface/input_elements/flexibility_flexibility_power_to_heat_for_industry.yml
+++ b/config/interface/input_elements/flexibility_flexibility_power_to_heat_for_industry.yml
@@ -6,25 +6,32 @@
   related_node: industry_chemicals_refineries_flexibility_p2h_network_gas_electricity
   position: 1
   slide_key: flexibility_flexibility_power_to_heat_for_industry
+- key: wtp_of_industry_chemicals_fertilizers_flexibility_p2h_electricity
+  step_value: 0.1
+  unit: "€/MWh"
+  interface_group: willingness_to_pay
+  related_node: industry_chemicals_fertilizers_flexibility_p2h_network_gas_electricity
+  position: 2
+  slide_key: flexibility_flexibility_power_to_heat_for_industry
 - key: wtp_of_industry_chemicals_other_flexibility_p2h_electricity
   step_value: 0.1
   unit: "€/MWh"
   interface_group: willingness_to_pay
   related_node: industry_chemicals_other_flexibility_p2h_network_gas_electricity
-  position: 2
+  position: 3
   slide_key: flexibility_flexibility_power_to_heat_for_industry
 - key: wtp_of_industry_other_food_flexibility_p2h_electricity
   step_value: 0.1
   unit: "€/MWh"
   interface_group: willingness_to_pay
   related_node: industry_other_food_flexibility_p2h_network_gas_electricity
-  position: 3
+  position: 4
   slide_key: flexibility_flexibility_power_to_heat_for_industry
 - key: wtp_of_industry_other_paper_flexibility_p2h_electricity
   step_value: 0.1
   unit: "€/MWh"
   interface_group: willingness_to_pay
   related_node: industry_other_paper_flexibility_p2h_network_gas_electricity
-  position: 4
+  position: 5
   slide_key: flexibility_flexibility_power_to_heat_for_industry
   

--- a/config/locales/interface/input_elements/en_demand_industry.yml
+++ b/config/locales/interface/input_elements/en_demand_industry.yml
@@ -323,6 +323,28 @@ en:
         heat, which is the kind most in demand in industry. You can specify how this
         hydrogen is produced in the <a href=\"/scenario/supply/hydrogen/hydrogen-production\">
         Supply section</a>. <br />"
+    capacity_of_industry_chemicals_fertilizers_flexibility_p2h_electricity:
+      title: Power-to-heat boiler for gas and H<sub>2</sub> heaters
+      short_description:
+      description: |
+        These power-to-heat (P2H) boilers can be installed as an add-on for
+        gas and hydrogen heaters. In hours when the willingness-to-pay of these boilers 
+        exceeds the electricity price, they will use electricity to produce heat and the
+        gas and hydrogen heaters will lower their production. You can set the 
+        willingness-to-pay of these boilers in the 
+        <a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-industry">
+        Flexibility</a> section. </br></br>
+        Note that for this slider to have an effect, capacity of either gas or hydrogen 
+        heaters needs to be installed as well. A number of charts are available to help you 
+        determine the effect of installing power-to-heat capacity: </br></br>
+        <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
+        The yearly use of electricity consumed by flexible demand technologies.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="hourly_flexibility_electricity" data-chart-location="side">
+        The hourly electricity supply and demand by flexible technologies.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="flexibility_integral_costs" data-chart-location="side">
+        The integral costs of flexible demand technologies.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="storage_options" data-chart-location="side">
+        A table overview of the use of flexible demand technologies.</a></li></ul>
     industry_useful_demand_for_chemical_other:
       title: Size
       short_description:

--- a/config/locales/interface/input_elements/en_flexibility.yml
+++ b/config/locales/interface/input_elements/en_flexibility.yml
@@ -758,6 +758,24 @@ en:
         The integral costs of flexible demand technologies.</a></li>
         <li><a href="#" class="open_chart" data-chart-key="storage_options" data-chart-location="side">
         A table overview of the use of flexible demand technologies.</a></li></ul>
+    wtp_of_industry_chemicals_fertilizers_flexibility_p2h_electricity:
+      title: Power-to-heat boiler for fertilizer industry
+      short_description:
+      description: |
+        This slider sets the maximum price power-to-heat boilers in the
+        <a href="/scenario/demand/industry/fertilizers">fertilizer industry</a>
+        are willing to pay for their electricity. Note that for this slider to have an effect,
+        capacity of these boilers and of either gas or hydrogen heaters needs to be 
+        installed in the fertilizer industry. </br></br>
+        A number of charts are available to help you determine the effect of the willingness to pay of power-to-heat: </br></br>
+        <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
+        The yearly use of electricity consumed by flexible demand technologies.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="hourly_flexibility_electricity" data-chart-location="side">
+        The hourly electricity supply and demand by flexible technologies.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="flexibility_integral_costs" data-chart-location="side">
+        The integral costs of flexible demand technologies.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="storage_options" data-chart-location="side">
+        A table overview of the use of flexible demand technologies.</a></li></ul>
     wtp_of_industry_chemicals_other_flexibility_p2h_electricity:
       title: Power-to-heat boiler for chemical industry
       short_description:

--- a/config/locales/interface/input_elements/nl_demand_industry.yml
+++ b/config/locales/interface/input_elements/nl_demand_industry.yml
@@ -340,6 +340,28 @@ nl:
         te maken, waar in de industrie veel behoefte aan is. In de <a href=\"/scenario/supply/hydrogen/hydrogen-production\">
         Aanbodsectie</a> kun je specificeren hoe de gebruikte waterstof wordt geproduceerd.
         <br />"
+    capacity_of_industry_chemicals_fertilizers_flexibility_p2h_electricity:
+      title: Power-to-heat boiler voor H<sub>2</sub> en gasketels
+      short_description:
+      description: |
+        Deze power-to-heat (P2H) boilers worden geïnstalleerd als een add-on bij 
+        bestaande gas- en waterstofketels. In uren wanneer de betalingsbereidheid van 
+        deze boilers hoger is dan de elektriciteitsprijs, gebruiken ze elektriciteit om 
+        warmte te produceren en reduceren de gas- en waterstofketels hun productie. Je 
+        kunt de betalingsbereidheid van deze boilers instellen in de 
+        <a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-industry">
+        Flexibiliteit</a> sectie. </br></br>
+        Let op dat deze slider alleen effect heeft als er ook vermogen van gas- of waterstofketels 
+        geïnstalleerd is. Er zijn een aantal grafieken beschikbaar om je te helpen bepalen wat het effect 
+        van power-to-heat boilers is: </br></br>
+        <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
+        De jaarlijkse inzet van elektriciteit geconsumeerd door flexible vraagtechnologieën.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="hourly_flexibility_electricity" data-chart-location="side">
+        De uurlijkse elektriciteitsvraag en -aanbod van flexibele technologieën.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="flexibility_integral_costs" data-chart-location="side">
+        De integrale kosten van flexible vraag.technnologieën</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="storage_options" data-chart-location="side">
+        Een overzicht van de inzet van flexibele vraagtechnologieën in tabelvorm.</a></li></ul>
     industry_useful_demand_for_chemical_other:
       title: Grootte
       short_description:

--- a/config/locales/interface/input_elements/nl_flexibility.yml
+++ b/config/locales/interface/input_elements/nl_flexibility.yml
@@ -795,10 +795,28 @@ nl:
       title: Power-to-heat boiler voor raffinaderijen
       short_description:
       description: |
-        Dit schuifje bepaalt wat de maximale prijs is die power-to-heat bilers in 
+        Dit schuifje bepaalt wat de maximale prijs is die power-to-heat boilers in 
         <a href="/scenario/demand/industry/refineries">raffinaderijen</a> willen betalen
         voor elektriciteit. Let op dat deze slider alleen effect heeft als er ook vermogen voor deze boilers en 
         gas- of waterstofketels in raffinaderijen geïnstalleerd is. </br></br>
+        Er zijn een aantal grafieken beschikbaar om je te helpen bepalen wat het effect 
+        van de willingness-to-pay van power-to-heat is: </br></br>
+        <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
+        De jaarlijkse inzet van elektriciteit geconsumeerd door flexible vraagtechnologieën.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="hourly_flexibility_electricity" data-chart-location="side">
+        De uurlijkse elektriciteitsvraag en -aanbod van flexibele technologieën.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="flexibility_integral_costs" data-chart-location="side">
+        De integrale kosten van flexible vraagtechnnologieën</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="storage_options" data-chart-location="side">
+        Een overzicht van de inzet van flexibele vraagtechnologieën in tabelvorm.</a></li></ul>
+    wtp_of_industry_chemicals_fertilizers_flexibility_p2h_electricity:
+      title: Power-to-heat boiler voor kunstmestindustrie
+      short_description:
+      description: |
+        Dit schuifje bepaalt wat de maximale prijs is die power-to-heat boilers in de
+        <a href="/scenario/demand/industry/fertilizers">kunstmestindustrie</a> willen betalen
+        voor elektriciteit. Let op dat deze slider alleen effect heeft als er ook vermogen voor deze boilers en 
+        gas- of waterstofketels in de kunstmestindustrie geïnstalleerd is. </br></br>
         Er zijn een aantal grafieken beschikbaar om je te helpen bepalen wat het effect 
         van de willingness-to-pay van power-to-heat is: </br></br>
         <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
@@ -813,7 +831,7 @@ nl:
       title: Power-to-heat boiler voor chemische industrie
       short_description:
       description: |
-        Dit schuifje bepaalt wat de maximale prijs is die power-to-heat bilers in de
+        Dit schuifje bepaalt wat de maximale prijs is die power-to-heat boilers in de
         <a href="/scenario/demand/industry/chemicals">chemische industrie</a> willen betalen
         voor elektriciteit. Let op dat deze slider alleen effect heeft als er ook vermogen voor deze boilers en 
         gas- of waterstofketels in de chemische industrie geïnstalleerd is. </br></br>
@@ -831,7 +849,7 @@ nl:
       title: Power-to-heat boiler voor voedingsmiddelenindustrie
       short_description:
       description: |
-        Dit schuifje bepaalt wat de maximale prijs is die power-to-heat bilers in de
+        Dit schuifje bepaalt wat de maximale prijs is die power-to-heat boilers in de
         <a href="/scenario/demand/industry/chemicals">voedingsmiddelenindustrie</a> willen betalen
         voor elektriciteit. Let op dat deze slider alleen effect heeft als er ook vermogen voor deze boilers en 
         gas- of waterstofketels in de voedingsmiddelenindustrie geïnstalleerd is. </br></br>
@@ -849,7 +867,7 @@ nl:
       title: Power-to-heat boiler voor papierindustrie
       short_description:
       description: |
-        Dit schuifje bepaalt wat de maximale prijs is die power-to-heat bilers in de
+        Dit schuifje bepaalt wat de maximale prijs is die power-to-heat boilers in de
         <a href="/scenario/demand/industry/chemicals">papierindustrie</a> willen betalen
         voor elektriciteit. Let op dat deze slider alleen effect heeft als er ook vermogen voor deze boilers en 
         gas- of waterstofketels in de papierindustrie geïnstalleerd is. </br></br>

--- a/config/locales/interface/output_elements/labels_groups/en_tables.yml
+++ b/config/locales/interface/output_elements/labels_groups/en_tables.yml
@@ -150,6 +150,7 @@ en:
         electricity_converted_to_hydrogen: "Conversion to hydrogen"
         electricity_converted_to_heat_industry: "Conversion to heat for industry"
         electricity_converted_to_heat_refineries_industry: "Conversion to heat for industry (refineries)"
+        electricity_converted_to_heat_fertilizers_industry: "Conversion to heat for industry (fertilizers)"
         electricity_converted_to_heat_chemicals_industry: "Conversion to heat for industry (chemicals)"
         electricity_converted_to_heat_food_industry: "Conversion to heat for industry (food)"
         electricity_converted_to_heat_paper_industry: "Conversion to heat for industry (paper)"

--- a/config/locales/interface/output_elements/labels_groups/nl_tables.yml
+++ b/config/locales/interface/output_elements/labels_groups/nl_tables.yml
@@ -153,6 +153,7 @@ nl:
         electricity_converted_to_hydrogen: "Conversie naar waterstof"
         electricity_converted_to_heat_industry: "Conversie naar warmte voor industrie"
         electricity_converted_to_heat_refineries_industry: "Conversie naar warmte voor industrie (raffinaderijen)"
+        electricity_converted_to_heat_fertilizers_industry: "Conversie naar warmte voor industrie (kunstmest)"
         electricity_converted_to_heat_chemicals_industry: "Conversie naar warmte voor industry (chemie)"
         electricity_converted_to_heat_food_industry: "Conversie naar warmte voor industry (voedsel)"
         electricity_converted_to_heat_paper_industry: "Conversie naar warmte voor industry (papier)"

--- a/config/locales/interface/slides/en_flexibility.yml
+++ b/config/locales/interface/slides/en_flexibility.yml
@@ -291,6 +291,7 @@ en:
         boilers and gas or hydrogen burners to be installed for it to have an effect.
         You can set the installed capacity in these industry sub sectors:
         <ul><li><a href="/scenario/demand/industry/refineries">refineries</a></li>
+        <li><a href="/scenario/demand/industry/fertilizers">fertilizer industry</a></li>
         <li><a href="/scenario/demand/industry/chemicals">chemical industry</a></li>
         <li><a href="/scenario/demand/industry/food">food industry</a></li>
         <li><a href="/scenario/demand/industry/paper">paper industry</a></li></ul>

--- a/config/locales/interface/slides/nl_flexibility.yml
+++ b/config/locales/interface/slides/nl_flexibility.yml
@@ -303,6 +303,7 @@ nl:
         vermogen van de power-to-heat boilers als van de gas- of waterstofketels geïnstalleerd is.
         Je kunt het geïnstalleerde vermogen bepalen voor deze subsectoren van de industrie:
         <ul><li><a href="/scenario/demand/industry/refineries">raffinaderijen</a></li>
+        <li><a href="/scenario/demand/industry/fertilizers">kunstmestindustrie</a></li>
         <li><a href="/scenario/demand/industry/chemicals">chemische industrie</a></li>
         <li><a href="/scenario/demand/industry/food">voedingsmiddelenindustrie</a></li>
         <li><a href="/scenario/demand/industry/paper">papierindustrie</a></li></ul>


### PR DESCRIPTION
This PR adds front-end for p2h hybrid heaters in the fertilizer industry.

Corresponding ETSource PR: https://github.com/quintel/etsource/pull/2636.