### PR TITLE
Add shortage to Electricity Sankey

### DIFF
--- a/app/assets/javascripts/d3/sankey.coffee
+++ b/app/assets/javascripts/d3/sankey.coffee
@@ -16,6 +16,7 @@ D3.sankey =
           {id: 'import4',                      column: 0, label: 'import4',                color: '#b71540'},
           {id: 'import5',                      column: 0, label: 'import5',                color: '#b71540'},
           {id: 'import6',                      column: 0, label: 'import6',                color: '#b71540'},
+          {id: 'shortage',                      column: 0, label: 'hv_shortage',                color: '#DCDCDC'},
           {id: 'network',                      column: 1, label: 'network',                color: '#006266'},
           {id: 'households',                   column: 2, label: 'households',             color: '#4169E1'},
           {id: 'buildings',                    column: 2, label: 'buildings',              color: '#ADD8E6'},
@@ -47,6 +48,7 @@ D3.sankey =
           {left: 'import4',                    right: 'network',          gquery: 'import4_to_network_in_sankey', color: '#ff7f0e'},
           {left: 'import5',                    right: 'network',          gquery: 'import5_to_network_in_sankey', color: '#ff7f0e'},
           {left: 'import6',                    right: 'network',          gquery: 'import6_to_network_in_sankey', color: '#ff7f0e'},
+          {left: 'shortage',                   right: 'network',          gquery: 'shortage_to_network_in_sankey', color: '#DCDCDC'},
 
           {left: 'network',                    right: 'households',       gquery: 'network_to_households_in_sankey', color: '#1f77b4'},
           {left: 'network',                    right: 'buildings',        gquery: 'network_to_buildings_in_sankey', color: '#1f77b4'},

--- a/config/locales/interface/output_elements/labels_groups/en_labels.yml
+++ b/config/locales/interface/output_elements/labels_groups/en_labels.yml
@@ -215,6 +215,7 @@ en:
       export4: "export #4"
       export5: "export #5"
       export6: "export #6"
+      hv_shortage: "blackouts"
       dac: "direct air capture"
       power_production: "power production"
       hydrogen_production: "hydrogen production"

--- a/config/locales/interface/output_elements/labels_groups/nl_labels.yml
+++ b/config/locales/interface/output_elements/labels_groups/nl_labels.yml
@@ -210,6 +210,7 @@ nl:
       export4: "export #4"
       export5: "export #5"
       export6: "export #6"
+      hv_shortage: "stroomuitval"
       dac: "direct air capture"
       power_production: "elektriciteitsproductie"
       hydrogen_production: "waterstofproductie"


### PR DESCRIPTION
In https://github.com/quintel/etsource/pull/2644 a number of fixes have been made to the Electricity Sankey. One of these is that shortages due to blackouts have been added to the Sankey queries. This PR adds blackouts to the Sankey.