### PR TITLE
Add `subheader_image_dependent_on_country` attribute to slides

### DIFF
--- a/app/models/slide.rb
+++ b/app/models/slide.rb
@@ -114,4 +114,15 @@ class Slide < YModel::Base
   def visible_with_inputs?
     !removed_from_interface? && sliders.any?
   end
+
+  def subheader_image_available?
+    return false if subheader_image.blank?
+    return true if subheader_image_dependent_on_country.blank?
+
+    country = subheader_image_dependent_on_country
+    country = [country, 'nl2019'] if country == 'nl'
+
+    country.include?(Current.setting.area_code) ||
+      country.include?(Current.setting.area.top_level_area.area)
+  end
 end

--- a/app/views/scenarios/_slide.html.haml
+++ b/app/views/scenarios/_slide.html.haml
@@ -16,7 +16,7 @@
       - unless slide.general_sub_header.blank?
         .sub_header{ :id => "sub_header_#{slide.key}" }
           %span.sub_header_arrow= t("subheaders.#{to_yml_syntax(slide.general_sub_header)}")
-          - unless slide.subheader_image.blank?
+          - if slide.subheader_image_available?
             %img.sub_header_image{:src => "/assets/slides/#{slide.subheader_image}"}
 
       - slide.input_elements_not_belonging_to_a_group.each do |input_element|

--- a/config/interface/slides/households.yml
+++ b/config/interface/slides/households.yml
@@ -2,6 +2,7 @@
 - image: house_insulation.gif
   general_sub_header: heat_demand_reduction
   subheader_image: households_insulation_energy_label.png
+  subheader_image_dependent_on_country: nl
   key: demand_households_insulation
   position: 4
   sidebar_item_key: households


### PR DESCRIPTION
Makes it possible to only show subheader images for certain countries,
like Dutch home insulation labels