### PR TITLE
Adding a more robust query to the co2 emissions of transport

### DIFF
--- a/config/interface/output_element_series/emissions_transport.yml
+++ b/config/interface/output_element_series/emissions_transport.yml
@@ -6,7 +6,7 @@
   show_at_first:
   is_target_line: false
   target_line_position:
-  gquery: co2_sheet_transport_total_co2_emissions_energetic
+  gquery: primary_co2_of_transport
   is_1990: false
   dependent_on:
   output_element_key: emissions_transport


### PR DESCRIPTION
Vans were not included in the previous query