### PR TITLE
Implement saved scenario deletion

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'non-stupid-digest-assets'
 gem 'http_accept_language'
 gem 'browser'
 gem 'valid_email2'
+gem 'discard'
 
 # javascript
 gem 'sprockets-rails', require: 'sprockets/railtie'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,8 @@ GEM
     deep_merge (1.2.2)
     diff-lcs (1.5.0)
     digest (3.1.0)
+    discard (1.2.1)
+      activerecord (>= 4.2, < 8)
     docile (1.4.0)
     dry-configurable (0.14.0)
       concurrent-ruby (~> 1.0)
@@ -580,6 +582,7 @@ DEPENDENCIES
   config
   dalli
   database_cleaner
+  discard
   dynamic_form
   ed25519
   factory_bot_rails (~> 4.8)

--- a/app/assets/stylesheets/_header.sass
+++ b/app/assets/stylesheets/_header.sass
@@ -222,6 +222,7 @@ header.main-header
   border-radius: 4px
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15), 0 0.5rem 1rem rgba(0,0,0, 0.1)
   display: block
+  font-size: 0.875rem
   left: 0.5em
   list-style: none
   margin: 0
@@ -264,6 +265,12 @@ header.main-header
     margin-top: 0.5rem
     padding-top: 0.5rem
 
+  li.category
+    font-size: 0.75rem
+    font-weight: 400
+    padding: 0.75rem 1rem 0.125rem
+    text-transform: uppercase
+
   .dropdown-content
     padding: 0.5rem 1rem
 
@@ -280,13 +287,15 @@ header.main-header
   padding: 0.25rem 1rem
   white-space: nowrap
   &:hover
-    background-color: #4287c4
+    background-color: #498dd3
     color: white !important
     cursor: pointer
     text-decoration: none
   &[disabled], .disabled
     opacity: 0.5
     pointer-events: none
+  &.inset
+    padding-left: 2rem
 
 button.dropdown-item
   background: none

--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -30,8 +30,34 @@ table.default
   flex: 1
 
 .scenario_wrapper
+  font-size: 0.875rem
+
+  // flash notice messages which are to be shown inside the scenario wrapper.
+  .inner-notice
+    align-items: center
+    background: #e8f7e7
+    border-radius: 4px
+    border: 1px solid #9ed79b
+    color: #32772e
+    display: flex
+    font-size: 14px
+    justify-content: center
+    margin-bottom: 0.5rem
+    padding: 0.5rem
+    > *
+      margin: 0 0.25rem
+    .dot
+      font-size: 6px
+    .message
+      margin-left: 0
+    a
+      color: #32772e
+      font-weight: 600
+      &:hover
+        color: black
+
   &#show_scenario, &#feature_scenario, &#index
-    width: $landing-width
+    width: $landing-width + 200px
     margin: 0 auto 3rem
     background: white
     border: 1px solid $landing-border-color
@@ -42,7 +68,7 @@ table.default
     border-radius: 4px
     padding: 15px 40px
 
-    .warning
+    .version-warning
       background: #f0f7ee image-url('icons/warning-information.svg') 1.5rem 1.25rem no-repeat
       background-size: 2rem
       border-left: 3px solid #79a765
@@ -82,19 +108,20 @@ table.default
             color: black
 
     h1
-      margin-bottom: 0.5em
+      margin-bottom: 0.675rem
+      font-size: 1.5rem
       sub
         line-height: 0
 
     .actions
       display: flex
+      align-items: center
       a
         text-decoration: none
-        margin: 0.5rem 0.5rem 1rem 0
         &:hover
           color: darken($link-color, 20%)
       .dot
-        margin: 1rem 0.5rem 1rem 0
+        margin: 1rem 0.5rem
         font-size: 6px
         color: $link-color
 
@@ -109,12 +136,11 @@ table.default
       border-radius: 3px
       cursor: pointer
       font-size: 1rem
-      font-weight: bold
+      font-weight: 500
       text-align: center
       text-shadow: none
       padding: 10px 15px
-      margin: 0.5rem 0.5rem 1rem 0
-      -webkit-font-smoothing: antialiased
+      margin: 0.5rem 0.5rem 0.5rem 0
       &.load
         background-color: $landing-blue
         background: linear-gradient(lighten($landing-blue, 10%), $landing-blue)
@@ -126,6 +152,7 @@ table.default
         &.dim
           background: linear-gradient(lighten($landing-blue, 25%), lighten($landing-blue, 18%))
       &.cancel, &.compare
+        color: black
         &:hover
           color: lighten(black, 15%)
           background: linear-gradient(lighten(#eee, 9%), lighten(#eee, 2%))
@@ -147,6 +174,14 @@ table.default
         padding: 5px 8px
         -webkit-font-smoothing: auto
 
+  .edit_featured_scenario .actions
+    a, input
+      margin-top: 0
+      margin-bottom: 0
+      line-height: 1
+    & > * + *
+      margin-left: 0.5rem
+
   &#index
     .vertical-bar
       width: 0
@@ -155,56 +190,155 @@ table.default
       display: inline-block
       margin: 0 0.5rem 0 0
       vertical-align: middle
-    a
-      color: #3c8ee1
 
-    table
-      width: 100%
-      margin: 10px 0
-      td
-        border: none
-        padding: 8px 10px
-        &.box
-          padding-left: 0
-          padding-right: 0
-          input
-            margin: 0
-      input
-        height: 16px
-        width: 16px
+    .save-wrapper
+      align-items: center
+      display: flex
+      margin: 0 20px 0 auto
+      .save
+        margin: 0
+        font-size: 14px
+    .empty-state
+      text-align: center
+      padding: 2rem 8rem
+      h4
+        font-size: 18px
+        font-weight: 500
+        margin: 0
+      p
+        color: $landing-grey
+        font-size: 14px
+        margin: 0.75rem 0 0
       a
-        display: block
-        text-decoration: none
-        cursor: pointer
-        .title
-          font-weight: bold
-          font-size: 1rem
-          display: inline-block
-          width: 100%
-        .info
-          color: black
-        .author
-          color: $landing-grey
-        .featured
-          color: #e2ac49
-        &:hover .title
-          color: darken($landing-blue, 25%)
-          text-decoration: underline
-      .unavailable
-        .info
-          color: $error-red
+        padding: 0.5rem
+        margin: -0.5rem
 
-      #scenario_paginator td
-        border: none
-        a
-          border-top: 1px solid #ddd
-          color: #56b351
-          font-size: 1rem
-          font-weight: bold
-          padding-top: 1rem
+    .trash-notice
+      align-items: center
+      color: $landing-grey
+      display: flex
+      font-size: 14px
+      justify-content: center
+      padding: 0.5rem 0
+      svg
+        margin-right: 0.25rem
+
+    .pagination
+      align-items: center
+      display: flex
+      font-size: 16px
+      justify-content: center
+      margin: 0 0 0.5rem
+
+      a
+        border-radius: 4px
+        padding: 0.375rem 0.5rem
+        &:hover
+          background: lighten($landing-grey, 42%)
+          text-decoration: none
+        &:active
+          background: lighten($landing-grey, 35%)
+          color: darken($landing-grey, 15%)
+
+      .current
+        font-weight: 600
+        padding: 0.375rem 0.5rem
+
+    .scenario-row
+      display: flex
+      margin: 0 -1rem
+      &:hover
+        border-radius: 4px
+        .buttons
+          opacity: 1
+          pointer-events: initial
+      &.discarded .buttons
+        // buttons are always visible for discarded scenarios.
+        opacity: 1
+        pointer-events: initial
+      a.title, .check input
+        // title link and checkbox are clickable for the entire container.
+        &::after
+          position: absolute
+          top: 0
+          right: 0
+          bottom: 0
+          left: 0
+          z-index: 1
+          content: ""
+      .check, .scenario-info, .buttons
+        padding: 0.5rem
+      & > :first-child
+        padding-left: 1rem
+      & > :last-child
+        padding-left: 1rem
+      .check
+        position: relative
+        input
+          height: 16px
+          margin: 0
+          width: 16px
+      .scenario-info
+        flex: 1
+        position: relative
+        a.title:hover
+          text-decoration: underline
+      .buttons
+        align-items: center
+        pointer-events: none
+        opacity: 0
+        transition: opacity 0.15s ease-in-out
+        .discard
+          align-items: center
+          background: lighten($landing-grey, 42%)
+          border-radius: 4px
+          color: $landing-grey
+          display: flex
+          height: 24px
+          justify-content: center
+          padding: 0.375rem
+          transition: all 0.15s ease-in-out
+          width: 24px
           &:hover
-            color: darken(#56b351, 20%)
-            text-decoration: underline
+            background: lighten($landing-grey, 35%)
+          &:active
+            background: lighten($landing-grey, 28%)
+            color: darken($landing-grey, 15%)
+        .destroy
+          color: $error-red
+      .title
+        font-weight: 600
+        font-size: 1rem
+        display: inline-block
+        width: 100%
+      .info, .author, .last-updated
+        font-size: 0.8125rem
+      .info
+        color: black
+      .author, .last-updated
+        color: $landing-grey
+      .featured
+        color: #e2ac49
+        position: relative
+        z-index: 2
+    .unavailable .scenario-info
+      opacity: 0.3
+      .info
+        color: $error-red
+
+    #scenario_paginator
+      border: none
+      a
+        border-top: 1px solid #ddd
+        color: #56b351
+        display: inline-block
+        font-size: 1rem
+        font-weight: bold
+        padding-top: 1rem
+        margin: 1rem 0
+        &:hover
+          color: darken(#56b351, 20%)
+          text-decoration: underline
 
   &#show_scenario
     .title
@@ -231,14 +365,33 @@ table.default
 
     ul.details
       display: flex
-      padding-left: 0
       margin-top: 0
-      li
+      padding-left: 0
+      & > li
         list-style: none
         padding-right: 8px
-        color: #999
+        color: #888
         strong
           color: initial
+          font-weight: 600
+      .area-flag
+        vertical-align: middle
+        margin-top: -4px
+      #scenario-location button
+        background: none
+        border: 0
+        color: inherit
+        cursor: pointer
+        font-size: inherit
+        margin: -0.5rem
+        padding: 0.5rem
+        svg
+          vertical-align: middle
+          margin-top: -3px
+        &:hover
+          color: #444
+        .fa
+          margin-left: 0.25rem
 
     .bar
       border-top: 1px solid #eee
@@ -358,8 +511,8 @@ table.default
         font-weight: normal
       .button.save
         background: linear-gradient(#de8283, #bd5252)
+        color: white
         &:hover
-          color: white
           background: linear-gradient(lighten(#de8283, 4%), lighten(#bd5252, 4%))
         &:active
           background: linear-gradient(darken(#de8283, 5%), darken(#bd5252, 5%))
@@ -376,6 +529,54 @@ table.default
           margin-top: 0 !important
         *:last-child
           margin-bottom: 0 !important
+
+  .big-tabs
+    align-items: stretch
+    background: #eef2f7
+    border-bottom: 1px solid #d2d6d9
+    display: flex
+    font-weight: 500
+    margin: -15px -40px 20px
+    .count
+      align-items: center
+      background: #ccd3db
+      background: lighten(#79828d, 31%)
+      border-radius: 99px
+      color: darken(#79828d, 15%)
+      display: inline-flex
+      font-size: 11px
+      font-weight: normal
+      height: 0.75rem
+      justify-content: center
+      margin-left: 0.25rem
+      min-width: 0.5rem
+      padding: 0.25rem 0.375rem
+      &.red
+        background-color: #e35252
+        color: white
+    .tab
+      align-items: center
+      border-right: 1px solid #d2d6d9
+      color: darken(#79828d, 15%)
+      display: flex
+      font-size: 16px
+      gap: 0.125rem
+      padding: 20px 40px
+      &:hover
+        color: darken(#79828d, 15%)
+        text-decoration: none
+        .name
+          text-decoration: underline
+      &.active
+        background: white
+        color: black
+        border-bottom: 1px solid white
+        margin-bottom: -1px
+        &:hover
+          color: black
+      svg
+        display: inline-block
+        margin-right: 0.125rem
 
   hr
     border: none

--- a/app/controllers/saved_scenarios_controller.rb
+++ b/app/controllers/saved_scenarios_controller.rb
@@ -134,7 +134,7 @@ class SavedScenariosController < ApplicationController
       @saved_scenario.discarded_at = Time.zone.now
       @saved_scenario.save(touch: false)
 
-      flash.notice = 'Your scenario was put in the trash'
+      flash.notice = t('scenario.trash.discarded_flash')
       flash[:undo_params] = [undiscard_saved_scenario_path(@saved_scenario), { method: :put }]
     end
 
@@ -149,7 +149,7 @@ class SavedScenariosController < ApplicationController
       @saved_scenario.discarded_at = nil
       @saved_scenario.save(touch: false)
 
-      flash.notice = 'Your scenario was restored'
+      flash.notice = t('scenario.trash.undiscarded_flash')
       flash[:undo_params] = [discard_saved_scenario_path(@saved_scenario), { method: :put }]
     end
 

--- a/app/controllers/scenarios_controller.rb
+++ b/app/controllers/scenarios_controller.rb
@@ -26,15 +26,18 @@ class ScenariosController < ApplicationController
 
   def index
     @student_ids = current_user.students.pluck(:id)
-    items = if current_user.admin?
-      SavedScenario.all.includes(:featured_scenario, :user)
-    elsif current_user.students.present?
-      SavedScenario.includes(:featured_scenario, :user)
-        .where(user_id: @student_ids + [current_user.id])
+    items = if current_user.students.present?
+      SavedScenario.where(user_id: @student_ids + [current_user.id])
     else
       current_user.saved_scenarios
     end
-    @saved_scenarios = items.order('updated_at DESC').page(params[:page]).per(50)
+
+    @saved_scenarios = items
+      .available
+      .includes(:featured_scenario, :user)
+      .order('updated_at DESC')
+      .page(params[:page])
+      .per(50)
 
     respond_to do |format|
       format.html

--- a/app/helpers/scenario_helper.rb
+++ b/app/helpers/scenario_helper.rb
@@ -149,4 +149,19 @@ module ScenarioHelper
       release_date: l(current_release_date.to_date, format: :long)
     )
   end
+
+  # Classes for the scenario row on the scenario listing.
+  def classes_for_scenario_row(saved_scenario)
+    [
+      saved_scenario.discarded? ? 'discarded' : nil,
+      saved_scenario.loadable? ? '' : 'unavailable'
+    ].compact.join(' ')
+  end
+
+  # Shows the number of scenarios in a tab. When the number is zero nothing is shown.
+  def tab_count(count, options = {})
+    return if count.zero?
+
+    tag.span(number_with_delimiter(count), class: "count #{options[:class]}".strip)
+  end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -26,7 +26,10 @@
     #wrapper
       = render "layouts/etm/header"
       #content
-        - flash_message
+        - if content_for?(:flash)
+          = yield :flash
+        - else
+          - flash_message
         = content_for?(:content) ? yield(:content) : yield
       - if content_for?(:footer)
         %footer.fixed

--- a/app/views/saved_scenarios/_flash_notice.html.haml
+++ b/app/views/saved_scenarios/_flash_notice.html.haml
@@ -1,0 +1,11 @@
+- if flash[:notice]
+  .inner-notice
+    :plain
+      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"></path>
+      </svg>
+    .message
+      = flash[:notice]
+    - if flash[:undo_params]
+      .fa.dot.fa-circle
+      = link_to 'Undo?', *flash[:undo_params]

--- a/app/views/saved_scenarios/_flash_notice.html.haml
+++ b/app/views/saved_scenarios/_flash_notice.html.haml
@@ -8,4 +8,4 @@
       = flash[:notice]
     - if flash[:undo_params]
       .fa.dot.fa-circle
-      = link_to 'Undo?', *flash[:undo_params]
+      = link_to "#{t('undo')}?", *flash[:undo_params]

--- a/app/views/saved_scenarios/_info.html.haml
+++ b/app/views/saved_scenarios/_info.html.haml
@@ -1,12 +1,47 @@
 %ul.details
   %li
-    = area_flag(scenario.area_code)
+    = area_flag_icon(scenario.area_code)
     %strong
       = t "areas.#{scenario.area_code}"
       = scenario.end_year
   %li
     = t('scenario.updated')
     = local_time(scenario.updated_at, :long)
+
+  - if owned_saved_scenario?(scenario) && action_name == 'show'
+    %li{ style: 'margin-left: auto; padding-right: 0' }
+      .dropdown#scenario-location<>
+        %button.scenario-actions#scenario-location-button{ aria: { expanded: 'false' }, data: { toggle: 'dropdown' }, type: 'button' }
+          :plain
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+              <path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd" />
+            </svg>
+          = t('settings')
+          %span.fa.fa-caret-down
+        %ul.dropdown-menu.dropdown-menu-right{ 'aria-labelledby': 'scenario-location-button', style: 'margin-top: -10px' }
+          %li
+            = link_to t("scenario.edit_text"),
+                edit_saved_scenario_path(scenario.id),
+                remote: true,
+                class: 'dropdown-item'
+          - if current_user&.admin?
+            %li
+              - if @saved_scenario.featured?
+                = link_to t('scenario.edit_featured_scenario'), saved_scenario_feature_path(@saved_scenario), class: 'dropdown-item'
+              - else
+                = link_to t('scenario.feature_scenario'), saved_scenario_feature_path(@saved_scenario), class: 'dropdown-item'
+          %li.sep-above.category
+            == #{t('move_to')}&hellip;
+          - if scenario.discarded?
+            %li
+              = link_to t('header.load_scenario'), undiscard_saved_scenario_path(@saved_scenario, backto: 'scenario'), method: :put, class: 'dropdown-item'
+          - if scenario.kept?
+            %li
+              = link_to t('trash'), discard_saved_scenario_path(@saved_scenario, backto: 'scenario'), method: :put, class: 'dropdown-item'
+
+      :javascript
+        new DropdownView({ el: $('#scenario-location') }).render()
+
 
 .bar
 

--- a/app/views/saved_scenarios/_scenario_list_tabs.html.haml
+++ b/app/views/saved_scenarios/_scenario_list_tabs.html.haml
@@ -1,0 +1,17 @@
+.big-tabs
+  %a.tab{ href: scenarios_path, class: active_tab == :my_scenarios ? 'active' : '' }
+    :plain
+      <svg style="transform: rotate(90deg);" height="24" width="24" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
+      </svg>
+    %span.name= t('header.load_scenario')
+  %a.tab{ href: discarded_saved_scenarios_path, class: active_tab == :trash ? 'active' : '' }
+    :plain
+      <svg style="margin-top: -2px" height="24" width="24" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+      </svg>
+    %span.name= t('trash')
+    = tab_count(current_user.saved_scenarios.discarded.count, class: 'red')
+  - if Current.setting.api_session_id && local_assigns[:show_save_current] != false
+    .save-wrapper
+      = link_to t("scenario.link"), new_saved_scenario_path(scenario_id: Current.setting.api_session_id), class: 'button save'

--- a/app/views/saved_scenarios/_scenario_row.html.haml
+++ b/app/views/saved_scenarios/_scenario_row.html.haml
@@ -1,0 +1,39 @@
+.scenario-row{ class: classes_for_scenario_row(scenario_row) }
+  - unless scenario_row.discarded?
+    .check
+      = check_box_tag 'scenario_ids[]', scenario_row.scenario_id, false, disabled: !scenario_row.loadable?
+  .scenario-info
+    - if scenario_row.loadable?
+      %a.title{ href:"/saved_scenarios/#{scenario_row.id}" }
+        = scenario_row.localized_title(I18n.locale)
+      %span.info
+        = t("areas.#{scenario_row.area_code}")
+        = scenario_row.end_year
+    - else
+      %span.title.unavailable
+        = scenario_row.localized_title(I18n.locale)
+      %span.info.unavailable
+        %code= scenario_row.area_code
+        (#{t('scenario.area_not_exists')})
+        = scenario_row.end_year
+    - if current_user.id != scenario_row.user_id
+      %span.author
+        = t('scenario.by')
+        = scenario_row.user&.name
+    %span.last-updated
+      •
+      = t('last_updated_ago', when: time_ago_in_words(scenario_row.updated_at))
+    - if scenario_row.featured?
+      %span.featured.tooltip{ title: t('scenario.featured_scenario')} &#9733;
+  - if current_user.id == scenario_row.user_id
+    .buttons
+      - if scenario_row.discarded?
+        = link_to t('restore'), undiscard_saved_scenario_path(scenario_row), method: :put, class: 'button compare'
+        = link_to t('delete_permanently'), saved_scenario_path(scenario_row), method: :delete, class: 'button compare destroy'
+      - else
+        = link_to discard_saved_scenario_path(scenario_row), method: :put, class: 'discard tooltip', title: t('delete') do
+          :plain
+            <svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            </svg>
+

--- a/app/views/saved_scenarios/discarded.html.haml
+++ b/app/views/saved_scenarios/discarded.html.haml
@@ -1,0 +1,28 @@
+- content_for(:page_title) { "#{t('trash')} - #{t('meta.name')}" }
+
+-# We'll render the flash in this view, so suppress doing so in the layout.
+- content_for(:flash) do
+  %span
+
+.background_wrapper#saved_scenario
+  .scenario_wrapper#index
+    = render partial: 'scenario_list_tabs', locals: { active_tab: :trash }
+    = render partial: 'flash_notice'
+
+    - if @saved_scenarios.any?
+      .trash-notice
+        :plain
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+          </svg>
+        = t('scenario.trash.notice', deleted_after: SavedScenario::AUTO_DELETES_AFTER.in_days.to_i)
+
+      = render partial: 'scenario_row', collection: @saved_scenarios
+      = paginate @saved_scenarios
+    - else
+      .empty-state
+        %h4= t('scenario.trash.empty.title')
+        %p= t('scenario.trash.empty.description', deleted_after: SavedScenario::AUTO_DELETES_AFTER.in_days.to_i)
+        %p{ style: "font-weight: 500" }
+          = link_to scenarios_path do
+            == ← #{t('scenario.trash.empty.back')}

--- a/app/views/saved_scenarios/show.html.haml
+++ b/app/views/saved_scenarios/show.html.haml
@@ -1,17 +1,20 @@
 - content_for(:page_title) { "#{@saved_scenario.title} - #{t('meta.name')}" }
 
+-# We'll render the flash in this view, so suppress doing so in the layout.
+- content_for(:flash) do
+  %span
+
 .background_wrapper#saved_scenario
   .scenario_wrapper#show_scenario
+    - if owned_saved_scenario?(@saved_scenario)
+      = render partial: 'scenario_list_tabs', locals: { active_tab: @saved_scenario.discarded? ? :trash : :my_scenarios, show_save_current: false }
+    = render partial: 'saved_scenarios/flash_notice'
 
     .scenario
       = render partial: 'scenario', locals: { saved_scenario: @saved_scenario }
 
     #edit_scenario
-
     - unless @saved_scenario.featured?
       = render partial: 'scenarios/version_warning', locals: { scenario: @saved_scenario }
 
     = render partial: 'scenarios/share_links', locals: { scenario: @saved_scenario }
-
-    %p.note
-      = t("scenario.overwritten")

--- a/app/views/scenarios/_scenarios_slice.html.haml
+++ b/app/views/scenarios/_scenarios_slice.html.haml
@@ -1,35 +1,4 @@
-- @saved_scenarios.each do |ss|
-  - if ss.loadable?
-    %tr
-      %td.box= check_box_tag 'scenario_ids[]', ss.scenario_id
-      %td
-        %a{ href:"/saved_scenarios/#{ss.id}" }
-          %span.title= ss.localized_title(I18n.locale)
-          %span.info
-            = t('areas.' + ss.area_code)
-            = ss.end_year
-          %span.author
-            = t('scenario.by')
-            = ss.user&.name
-          - if ss.featured?
-            %span.featured.tooltip{ title: t('scenario.featured_scenario')} &#9733;
+= render partial: 'saved_scenarios/scenario_row', collection: @saved_scenarios
 
-  - elsif current_user.admin?
-    %tr.unavailable
-      %td.box= check_box_tag 'scenario_ids[]', -1, false, disabled: true
-      %td
-        %a
-          %span.title
-            = ss.title
-            (#{ss.scenario_id})
-          %span.info
-            %code= ss.area_code
-            (#{t('scenario.area_not_exists')})
-          %span.author
-            = t('scenario.by')
-            = ss.user&.name
-          - if ss.featured?
-            %span.featured{ title: t('scenario.featured_scenario')} &#9733;
-%tr#scenario_paginator
-  %td
-  %td= link_to_next_page @saved_scenarios, 'More...', remote: true
+#scenario_paginator
+  = link_to_next_page @saved_scenarios, 'More...', remote: true

--- a/app/views/scenarios/_version_warning.html.haml
+++ b/app/views/scenarios/_version_warning.html.haml
@@ -1,5 +1,5 @@
 - if !ETModel::Version.prerelease? && scenario.updated_at && scenario.updated_at < ETModel::Version::DATE
-  .warning
+  .version-warning
     = previous_version_scenario_warning(scenario, ETModel::Version::DATE)
     %details
       %summary= t('scenario.warning.effect')

--- a/app/views/scenarios/index.html.haml
+++ b/app/views/scenarios/index.html.haml
@@ -1,15 +1,16 @@
 - content_for(:page_title) { "#{t('scenario.saved')} - #{t('meta.name')}" }
 
+-# We'll render the flash in this view, so suppress doing so in the layout.
+- content_for(:flash) do
+  %span
+
 .background_wrapper#saved_scenario
   .scenario_wrapper#index
+    = render partial: 'saved_scenarios/scenario_list_tabs', locals: { active_tab: :my_scenarios }
+    = render partial: 'saved_scenarios/flash_notice'
+
     = form_tag compare_scenarios_path, method: 'get' do
-      %h1= t("scenario.saved")
       = submit_tag t('scenario.compare'), class: 'button compare'
       = submit_tag t('scenario.merge'), name: 'merge', class: 'button compare'
       = submit_tag t('scenario.local_vs_global'), name: 'combine', class: 'button compare'
-      - if Current.setting.api_session_id
-        .vertical-bar
-        = link_to t("scenario.link"), new_saved_scenario_path(scenario_id: Current.setting.api_session_id), class: 'button compare save'
-      %table.default
-        %tbody
-          = render 'scenarios_slice'
+      = render 'scenarios_slice'

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -27,6 +27,13 @@ en:
   grows: "grows"
   nevermind: "Never mind"
   cancel: "Cancel"
+  last_updated_ago: "Last updated %{when} ago"
+  delete: Delete
+  delete_permanently: Delete Permanently
+  restore: Restore
+  trash: Trash
+  settings: Settings
+  move_to: Move to
 
   chart_picker:
     no_matches: No matches
@@ -243,6 +250,16 @@ en:
         %0D%0A
         I used the Energy Transition Model to create a scenario, and I would like to share it with you.%0D%0A
         Please click on the following link to view the scenario:"
+    trash:
+      notice: Scenarios in the trash will be automatically deleted after %{deleted_after} days.
+      empty:
+        title:
+          There are no scenarios in the trash
+        description:
+          Deleted scenarios are sent to the trash where you can choose to permanently
+          delete or restore them. Trashed scenarios are automatically removed after %{deleted_after}
+          days.
+        back: Back to my scenarios
   featured_scenario:
     unfeature: 'Unfeature'
     unfeature_title: 'Unfeature this scenario'

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -34,6 +34,7 @@ en:
   trash: Trash
   settings: Settings
   move_to: Move to
+  undo: Undo
 
   chart_picker:
     no_matches: No matches
@@ -252,6 +253,8 @@ en:
         Please click on the following link to view the scenario:"
     trash:
       notice: Scenarios in the trash will be automatically deleted after %{deleted_after} days.
+      discarded_flash: Your scenario was put in the trash
+      undiscarded_flash: Your scenario was restored
       empty:
         title:
           There are no scenarios in the trash

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -27,6 +27,13 @@ nl:
   grows: "groeien met"
   nevermind: "Niet gebruiken"
   cancel: "Annuleren"
+  last_updated_ago: "Laatst bijgewerkt %{when} geleden"
+  delete: Verwijderen
+  delete_permanently: Permanent verwijderen
+  restore: Herstellen
+  trash: Vuilnisbak
+  settings: Opties
+  move_to: Verhuizen naar
 
   chart_picker:
     no_matches: Geen resultaten
@@ -244,6 +251,16 @@ nl:
         %0D%0A
         Ik heb een scenario gemaakt met het Energietransitiemodel, en zou het graag met je delen.%0D%0A
         Klik op de volgende link om het te bekijken:"
+    trash:
+      notice: Scenarios in the trash will be automatically deleted after %{deleted_after} days.
+      empty:
+        title:
+          There are no scenarios in the trash
+        description:
+          Deleted scenarios are sent to the trash where you can choose to permanently
+          delete or restore them. Trashed scenarios are automatically removed after ${deleted_after}
+          days.
+        back: Back to my scenarios
   featured_scenario:
     unfeature: 'Stop met uitlichten'
     unfeature_title: 'Stop met uitlichten van dit scenario'

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -31,9 +31,9 @@ nl:
   delete: Verwijderen
   delete_permanently: Permanent verwijderen
   restore: Herstellen
-  trash: Vuilnisbak
+  trash: Prullenbak
   settings: Opties
-  move_to: Verhuizen naar
+  move_to: Verplaatsen naar
 
   chart_picker:
     no_matches: Geen resultaten
@@ -252,15 +252,15 @@ nl:
         Ik heb een scenario gemaakt met het Energietransitiemodel, en zou het graag met je delen.%0D%0A
         Klik op de volgende link om het te bekijken:"
     trash:
-      notice: Scenarios in the trash will be automatically deleted after %{deleted_after} days.
+      notice: Scenarios in de prullenbak worden na %{deleted_after} dagen automatisch verwijderd.
       empty:
         title:
-          There are no scenarios in the trash
+          De prullenbak is leeg
         description:
-          Deleted scenarios are sent to the trash where you can choose to permanently
-          delete or restore them. Trashed scenarios are automatically removed after ${deleted_after}
-          days.
-        back: Back to my scenarios
+          Wanneer je een scenario weggooit gaat deze eerst naar de prullenbak. Hier kan je ervoor
+          kiezen om een scenario te herstellen of permanent te verwijderen. Scenarios in de
+          prullenbak worden automatisch verwijderd na %{deleted_after} dagen.
+        back: Terug naar mijn scenarios
   featured_scenario:
     unfeature: 'Stop met uitlichten'
     unfeature_title: 'Stop met uitlichten van dit scenario'

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -254,8 +254,8 @@ nl:
         Klik op de volgende link om het te bekijken:"
     trash:
       notice: Scenarios in de prullenbak worden na %{deleted_after} dagen automatisch verwijderd.
-      discarded_flash: Your scenario was put in the trash
-      undiscarded_flash: Your scenario was restored
+      discarded_flash: Het scenario is verplaatst naar de prullenbak
+      undiscarded_flash: Het scenario is hersteld
       empty:
         title:
           De prullenbak is leeg

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -34,6 +34,7 @@ nl:
   trash: Prullenbak
   settings: Opties
   move_to: Verplaatsen naar
+  undo: Ongedaan maken
 
   chart_picker:
     no_matches: Geen resultaten
@@ -253,6 +254,8 @@ nl:
         Klik op de volgende link om het te bekijken:"
     trash:
       notice: Scenarios in de prullenbak worden na %{deleted_after} dagen automatisch verwijderd.
+      discarded_flash: Your scenario was put in the trash
+      undiscarded_flash: Your scenario was restored
       empty:
         title:
           De prullenbak is leeg

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,16 +70,22 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :saved_scenarios, except: %i[new destroy] do
+  resources :saved_scenarios, except: %i[new] do
     resource :feature, only: %i[show create update destroy], controller: 'featured_scenarios'
 
     member do
       get :load
+      put :discard
+      put :undiscard
 
       # get    'feature' => 'featured_scenarios#edit'
       # post   'feature' => 'featured_scenarios#create'
       # put    'feature' => 'featured_scenarios#update'
       # delete 'feature' => 'featured_scenarios#destroy'
+    end
+
+    collection do
+      get :discarded
     end
 
     get '/report/:report_name' => 'saved_scenario_reports#show'

--- a/db/migrate/20220503145118_add_discarded_at_to_saved_scenarios.rb
+++ b/db/migrate/20220503145118_add_discarded_at_to_saved_scenarios.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToSavedScenarios < ActiveRecord::Migration[7.0]
+  def change
+    add_column :saved_scenarios, :discarded_at, :datetime
+    add_index :saved_scenarios, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2021_12_15_125700) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_03_145118) do
   create_table "area_dependencies", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "dependent_on"
     t.text "description"
@@ -91,6 +91,8 @@ ActiveRecord::Schema[7.0].define(version: 2021_12_15_125700) do
     t.text "settings"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_saved_scenarios_on_discarded_at"
     t.index ["scenario_id"], name: "index_saved_scenarios_on_scenario_id"
     t.index ["user_id"], name: "index_saved_scenarios_on_user_id"
   end

--- a/lib/tasks/cron.rake
+++ b/lib/tasks/cron.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :cron do
+  # Removes scenarios which were discarded some time ago.
+  task delete_discarded_scenarios: :environment do
+    SavedScenario.destroy_old_discarded!
+  end
+end

--- a/spec/controllers/saved_scenarios_controller_spec.rb
+++ b/spec/controllers/saved_scenarios_controller_spec.rb
@@ -231,4 +231,141 @@ describe SavedScenariosController, vcr: true do
       end
     end
   end
+
+  describe 'PUT discard' do
+    before do
+      login_as(user)
+      session[:setting] = Setting.new
+    end
+
+    context 'with an owned saved scenario' do
+      before do
+        post(:discard, params: { id: user_scenario.id })
+      end
+
+      it 'redirects to the scenario listing' do
+        expect(response).to be_redirect
+      end
+
+      it 'soft-deletes the scenario' do
+        expect(user_scenario.reload).to be_discarded
+      end
+    end
+
+    context 'with an unowned saved scenario' do
+      before do
+        post(:discard, params: { id: admin_scenario.id })
+      end
+
+      it 'returns 404' do
+        expect(response).to be_not_found
+      end
+
+      it 'does not soft-delete the scenario' do
+        expect(admin_scenario.reload).not_to be_discarded
+      end
+    end
+
+    context 'with a saved scenario ID that does not exist' do
+      before do
+        post(:discard, params: { id: 99_999 })
+      end
+
+      it 'returns 404' do
+        expect(response).to be_not_found
+      end
+    end
+  end
+
+  describe 'PUT undiscard' do
+    before do
+      login_as(user)
+      session[:setting] = Setting.new
+    end
+
+    context 'with an owned saved scenario' do
+      before do
+        user_scenario.discard!
+        post(:undiscard, params: { id: user_scenario.id })
+      end
+
+      it 'redirects to the scenario listing' do
+        expect(response).to be_redirect
+      end
+
+      it 'removes the soft-deletion of the scenario' do
+        expect(user_scenario.reload).not_to be_discarded
+      end
+    end
+
+    context 'with an unowned saved scenario' do
+      before do
+        admin_scenario.discard!
+        post(:undiscard, params: { id: admin_scenario.id })
+      end
+
+      it 'returns 404' do
+        expect(response).to be_not_found
+      end
+
+      it 'does not remove the soft-deletion of the scenario' do
+        expect(admin_scenario.reload).to be_discarded
+      end
+    end
+
+    context 'with a saved scenario ID that does not exist' do
+      before do
+        post(:undiscard, params: { id: 99_999 })
+      end
+
+      it 'returns 404' do
+        expect(response).to be_not_found
+      end
+    end
+  end
+
+  describe 'DELETE destroy' do
+    before do
+      login_as(user)
+      session[:setting] = Setting.new
+    end
+
+    context 'with an owned saved scenario' do
+      before do
+        delete(:destroy, params: { id: user_scenario.id })
+      end
+
+      it 'redirects to the scenario listing' do
+        expect(response).to be_redirect
+      end
+
+      it 'destroys the scenario' do
+        expect(SavedScenario.exists?(user_scenario.id)).to be(false)
+      end
+    end
+
+    context 'with an unowned saved scenario' do
+      before do
+        delete(:destroy, params: { id: admin_scenario.id })
+      end
+
+      it 'returns 404' do
+        expect(response).to be_not_found
+      end
+
+      it 'does not destroy the scenario' do
+        expect(SavedScenario.exists?(admin_scenario.id)).to be(true)
+      end
+    end
+
+    context 'with a saved scenario ID that does not exist' do
+      before do
+        delete(:destroy, params: { id: 99_999 })
+      end
+
+      it 'returns 404' do
+        expect(response).to be_not_found
+      end
+    end
+  end
 end

--- a/spec/controllers/scenarios_controller_spec.rb
+++ b/spec/controllers/scenarios_controller_spec.rb
@@ -350,26 +350,6 @@ describe ScenariosController, vcr: true do
     # rubocop:enable RSpec/NestedGroups
   end
 
-  context 'with an admin' do
-    before do
-      login_as admin
-    end
-
-    describe '#index' do
-      subject do
-        get :index
-        response
-      end
-
-      it { is_expected.to be_successful }
-      it 'gets a list of all saved scenarios' do
-        subject
-        expect(assigns(:saved_scenarios))
-          .to include user_scenario, admin_scenario
-      end
-    end
-  end
-
   context 'with a teacher' do
     let(:student) { FactoryBot.create(:user, teacher_email: user.email) }
     let(:student_scenario) { FactoryBot.create(:saved_scenario, user: student) }


### PR DESCRIPTION
- Saved scenarios can now be deleted by users.

- When a scenario is deleted, either by clicking the "Delete" button in the scenario list, or selecting "Settings -> Move to Trash" on the scenario page, it is sent to the trash.

- Scenarios in the trash may be restored within 60 days of being placed there, after which they'll be deleted permanently.

- A user may opt to permanently delete a scenario immediately from the trash.

- Admin users will no longer see everyone's saved scenarios.

Closes #3523

### Scenario list

![Screenshot 2022-05-18 at 16 28 23](https://user-images.githubusercontent.com/4383/169082351-1a1bc548-f868-48fe-964a-e1e09824c92c.png)

![Screenshot 2022-05-18 at 16 28 55](https://user-images.githubusercontent.com/4383/169082490-14587bcb-b7b6-490f-b5ad-5afdddc45142.png)

### Trash empty state

![Screenshot 2022-05-18 at 16 31 09](https://user-images.githubusercontent.com/4383/169082455-4add972c-f1a1-4167-9a6d-7afcdd8faa2f.png)

### Non-empty trash

![Screenshot 2022-05-18 at 16 28 33](https://user-images.githubusercontent.com/4383/169082376-7485da2c-15ef-4c8c-a6f8-8b14843f5962.png)

### Saved scenario

![Screenshot 2022-05-18 at 16 34 01](https://user-images.githubusercontent.com/4383/169082876-c9a6de8c-70a1-440c-acb2-8b576527ca5a.png)

/cc @ChaelKruip 