### PR TITLE
Remove costs per household from the dashboard items

### DIFF
--- a/config/interface/dashboard_items.yml
+++ b/config/interface/dashboard_items.yml
@@ -34,13 +34,6 @@
   disabled: false
   output_element_key: renewability
   dependent_on: ''
-- key: household_energy_cost
-  gquery_key: dashboard_total_costs_per_household
-  group: costs
-  position:
-  disabled: false
-  output_element_key: breakdown_of_total_cost_per_household
-  dependent_on:
 - key: loss_of_load
   gquery_key: dashboard_security_of_supply
   group: summary


### PR DESCRIPTION
In the costs update, the underlying chart for the dashboard item 'costs per household' was removed. This left the question as to whether to update the chart link to another chart for this dashboard item or whether to remove the dashboard item as well.

<img width="500" alt="Screenshot 2022-06-02 at 10 36 31" src="https://user-images.githubusercontent.com/67338510/171590380-a6db97b5-a9ea-491c-8c57-2398ac13b986.png">

After a discussion with @Charlottevm and @DorinevanderVlies, we decided that the dashboard item could be removed. The main motivation being that it is not that informative and we don't expect that it is used that much.