### PR TITLE
Update interconnector curve upload texts for clarity

### DIFF
--- a/config/locales/en_custom_curves.yml
+++ b/config/locales/en_custom_curves.yml
@@ -6,11 +6,11 @@ en:
     download_file: Download file
     full_load_hours: Full load hours
     interconnector_intro_html: |
-      It is assumed that the price of imported electricity and availability of import and export are
-      constant, set using the sliders above. You may override these assumptions by uploading CSV files
-      below detailing the hourly price or availability. For more information on how this works, and
-      examples of compatible CSV files, please
-      <a href=%{docs_path} target="_blank">see our documentation</a>.
+      By default, the ETM assumes that the external electricity price and availability of import and export, set with 
+      the sliders above, are constant throughout the year. You may override this assumption by uploading CSV files 
+      below containing an hourly changing price or availability. </br></br>
+      Click on the drop-down icon to change which curve you want to upload. For more information on how this 
+      works, and examples of compatible CSV files, please <a href=%{docs_path} target="_blank">see our documentation</a>.
     interface_group_title: Custom curves
     loading: Loading...
     max: Maximum
@@ -43,18 +43,18 @@ en:
       gas_import_export: "Import/export: Gases"
       weather: Weather data
     names:
-      interconnector_1_price: Interconnector 1 price
-      interconnector_2_price: Interconnector 2 price
-      interconnector_3_price: Interconnector 3 price
-      interconnector_4_price: Interconnector 4 price
-      interconnector_5_price: Interconnector 5 price
-      interconnector_6_price: Interconnector 6 price
-      interconnector_7_price: Interconnector 7 price
-      interconnector_8_price: Interconnector 8 price
-      interconnector_9_price: Interconnector 9 price
-      interconnector_10_price: Interconnector 10 price
-      interconnector_11_price: Interconnector 11 price
-      interconnector_12_price: Interconnector 12 price
+      interconnector_1_price: Interconnector 1 electricity price
+      interconnector_2_price: Interconnector 2 electricity price
+      interconnector_3_price: Interconnector 3 electricity price
+      interconnector_4_price: Interconnector 4 electricity price
+      interconnector_5_price: Interconnector 5 electricity price
+      interconnector_6_price: Interconnector 6 electricity price
+      interconnector_7_price: Interconnector 7 electricity price
+      interconnector_8_price: Interconnector 8 electricity price
+      interconnector_9_price: Interconnector 9 electricity price
+      interconnector_10_price: Interconnector 10 electricity price
+      interconnector_11_price: Interconnector 11 electricity price
+      interconnector_12_price: Interconnector 12 electricity price
       interconnector_1_import_availability: Interconnector 1 import availability
       interconnector_2_import_availability: Interconnector 2 import availability
       interconnector_3_import_availability: Interconnector 3 import availability

--- a/config/locales/interface/slides/en_flexibility.yml
+++ b/config/locales/interface/slides/en_flexibility.yml
@@ -4,81 +4,75 @@ en:
       title: Electricity interconnectors
       short_description:
       description: |
-        <p>The <strong>domestic electricity market</strong> in your scenario is
+        The <strong>domestic electricity market</strong> in your scenario is
         connected to one or more <strong>external markets</strong> via
         interconnectors. These interconnectors allow for importing and exporting
-        electricity.</p>
-
-        <p>Import occurs whenever doing so is cheaper than using domestic
+        electricity. </br></br>
+        Import occurs whenever doing so is cheaper than using domestic
         electricity generation options. Similarly, electricity is exported whenever the
         neighbouring countries are willing to pay more than the domestic
-        (production) price.</p>
-
-        <p>In the tabs below you can set the interconnector capacities of the external
-        markets your area is connected to. For each interconnector a price
-        (or hourly price curve) can be added.</p>
+        (production) price. </br></br>
+        In the tabs below you can determine the capacity of interconnectors in 
+        your scenario, as well as a number of other attributes.
     flexibility_electricity_import_export_interconnectivity:
       title: Interconnector 1
       short_description:
-      description: "The difference between supply and demand of electricity on an
-      hourly basis can be imported or exported. Many countries import and export
-      electricity with their neighboring countries through different interconnectors.
-      In the ETM it is possible to model up to six different electrical interconnectors
-      between countries. You add an interconnector by setting interconnection capacity
-      for that interconnector. If you prefer to model all interconnectors together,
-      you only set interconnector capacity for interconnector 1.
-      \r\n<br/><br/>\r\n
-      You can set the capacity per interconnector. However, not all of this capacity
-      may be available for export, for example because the neighboring country suffers
-      from electricity surpluses at the same time. It is therefore possible to limit
-      the percentage of interconnection capacity available for export. In addition to capacity,
-      it is also possible to set the corresponding CO<sub>2</sub> emissions and price.
-      The price determines the deployment order of interconnectors
-      for import and export."
+      description:
+        Many countries import and export electricity with their neighboring countries through different 
+        interconnectors. In the ETM it is possible to model up to twelve different electrical interconnectors
+        between countries. You add an interconnector by setting interconnection capacity for that 
+        interconnector. If you prefer to model all interconnectors together, you only set interconnector 
+        capacity for interconnector 1. <br/><br/>
+        You can set the capacity per interconnector. However, not all of this capacity may be available for 
+        export, for example because the neighboring country suffers from electricity surpluses at the same 
+        time. It is therefore possible to limit the percentage of interconnection capacity available for 
+        export. In addition to capacity, it is also possible to set the corresponding CO<sub>2</sub> 
+        emissions and price. The price determines the deployment order of interconnectors for import and 
+        export.
     flexibility_electricity_import_export_interconnectivity_2:
       title: "Interconnector 2"
       description: |
-        Below you can set the capacity, CO<sub>2</sub> emissions and price for electricity interconnector 2.
+        Below you can set the capacity, availability, CO<sub>2</sub> emissions, and price for electricity interconnector 2.
     flexibility_electricity_import_export_interconnectivity_3:
       title: "Interconnector 3"
       description: |
-        Below you can set the capacity, CO<sub>2</sub> emissions and price for electricity interconnector 3.
+        Below you can set the capacity, availability, CO<sub>2</sub> emissions, and price for electricity interconnector 3.
     flexibility_electricity_import_export_interconnectivity_4:
       title: "Interconnector 4"
       description: |
-        Below you can set the capacity, CO<sub>2</sub> emissions and price for electricity interconnector 4.
+        Below you can set the capacity, availability, CO<sub>2</sub> emissions, and price for electricity interconnector 4.
     flexibility_electricity_import_export_interconnectivity_5:
       title: "Interconnector 5"
       description: |
-        Below you can set the capacity, CO<sub>2</sub> emissions and price for electricity interconnector 5.
+        Below you can set the capacity, availability, CO<sub>2</sub> emissions, and price for electricity interconnector 5.
     flexibility_electricity_import_export_interconnectivity_6:
       title: "Interconnector 6"
       description: |
-        Below you can set the capacity, CO<sub>2</sub> emissions and price for electricity interconnector 6.
+        Below you can set the capacity, availability, CO<sub>2</sub> emissions, and price for electricity interconnector 6.
     flexibility_electricity_import_export_interconnectivity_7:
       title: "Interconnector 7"
       description: |
-        Below you can set the capacity, CO<sub>2</sub> emissions and price for electricity interconnector 7.
+        Below you can set the capacity, availability, CO<sub>2</sub> emissions, and price for electricity interconnector 7.
     flexibility_electricity_import_export_interconnectivity_8:
       title: "Interconnector 8"
       description: |
-        Below you can set the capacity, CO<sub>2</sub> emissions and price for electricity interconnector 8.
+        Below you can set the capacity, availability, CO<sub>2</sub> emissions, and price for electricity interconnector 8.
     flexibility_electricity_import_export_interconnectivity_9:
       title: "Interconnector 9"
       description: |
-        Below you can set the capacity, CO<sub>2</sub> emissions and price for electricity interconnector 9.
+        Below you can set the capacity, availability, CO<sub>2</sub> emissions, and price for electricity interconnector 9.
     flexibility_electricity_import_export_interconnectivity_10:
       title: "Interconnector 10"
       description: |
-        Below you can set the capacity, CO<sub>2</sub> emissions and price for electricity interconnector 10.
+        Below you can set the capacity, availability, CO<sub>2</sub> emissions, and price for electricity interconnector 10.
     flexibility_electricity_import_export_interconnectivity_11:
       title: "Interconnector 11"
       description: |
-        Below you can set the capacity, CO<sub>2</sub> emissions and price for electricity interconnector 11.
+        Below you can set the capacity, availability, CO<sub>2</sub> emissions, and price for electricity interconnector 11.
     flexibility_electricity_import_export_interconnectivity_12:
       title: "Interconnector 12"
       description: |
-        Below you can set the capacity, CO<sub>2</sub> emissions and price for electricity interconnector 12.
+        Below you can set the capacity, availability, CO<sub>2</sub> emissions, and price for electricity interconnector 12.
     flexibility_flexibility_cold_snap:
       title: Cold snap
       short_description:

--- a/config/locales/interface/slides/nl_flexibility.yml
+++ b/config/locales/interface/slides/nl_flexibility.yml
@@ -4,82 +4,79 @@ nl:
       title: Elektrische interconnectoren
       short_description:
       description: |
-        <p>De <strong>binnenlandse elektriciteitsmarkt</strong> in jouw scenario is
+        De <strong>binnenlandse elektriciteitsmarkt</strong> in jouw scenario is
         verbonden met één of meerdere <strong>externe markten</strong> via
         interconnectoren. Deze interconnectoren importeren en exporteren
-        elektriciteit.</p>
-
-        <p>Elektriciteit wordt geïmporteerd als het goedkoper is dan de binnenlandse
+        elektriciteit. </br></br>
+        Elektriciteit wordt geïmporteerd als het goedkoper is dan de binnenlandse
         productie van elektriciteit. Het omgekeerde geldt voor export: als er in een
         externe markt een hogere prijs wordt geboden dan de binnenlandse (productie)prijs
-        wordt er stroom geëxporteerd.</p>
-
-        <p>In de onderstaande tabs kun je de interconnectiecapaciteiten instellen van de
-        externe markten waar jouw gebied mee verbonden is. Voor elke interconnector kun je
-        een prijs (of uurlijkse prijscurve) opgeven.</p>
+        wordt er stroom geëxporteerd. </br></br>
+        In de onderstaande tabs kun je voor de interconnectoren in jouw scenario de 
+        capaciteit en andere attributen instellen.
     flexibility_electricity_import_export_interconnectivity:
       title: "Interconnector 1"
       short_description:
-      description: "Het verschil tussen vraag en aanbod van elektriciteit op
-        uurbasis kan worden geïmporteerd of geëxporteerd. Veel landen importeren en
+      description: |
+        Veel landen importeren en
         exporteren elektriciteit met hun buurlanden via verschillende
-        interconnectoren. In het ETM is het mogelijk om tot wel zes verschillende elektrische
+        interconnectoren. In het ETM is het mogelijk om tot wel twaalf verschillende elektrische
         interconnectoren te modelleren tussen landen. Je voegt een interconnector toe
         door interconnectiecapaciteit in te stellen voor die interconnector. Als je liever
         alle interconnectoren gezamenlijk wilt modelleren, dan stel je alleen interconnectorcapaciteit
         in voor interconnector 1.
-        \r\n<br/><br/>\r\n
+        <br/><br/>
         Per interconnector kan je de capaciteit instellen. Het is echter mogelijk dat niet al deze capaciteit
         beschikbaar is voor export, bijvoorbeeld omdat het naburige land op hetzelfde
         moment met elektriciteitsoverschotten kampt. Het is daarom mogelijk om het
         percentage van de interconnectiecapaciteit dat beschikbaar is voor export
         te beperken. Naast capaciteit is het ook mogelijk de bijbehorende CO<sub>2</sub>
         uitstoot en prijs in te stellen. De prijs bepaalt de inzetvolgorde
-        van interconnectoren voor import en export."
+        van interconnectoren voor import en export.
     flexibility_electricity_import_export_interconnectivity_2:
       title: "Interconnector 2"
       description: |
-        Hieronder kan je capaciteit, CO<sub>2</sub> uitstoot en prijs instellen voor interconnector 2.
+        Hieronder kan je capaciteit, beschikbaarheid, CO<sub>2</sub>-uitstoot en prijs instellen voor interconnector 2.
     flexibility_electricity_import_export_interconnectivity_3:
       title: "Interconnector 3"
       description: |
-        Hieronder kan je capaciteit, CO<sub>2</sub> uitstoot en prijs instellen voor interconnector 3.
+        Hieronder kan je capaciteit, beschikbaarheid, CO<sub>2</sub>-uitstoot en prijs instellen voor interconnector 3.
     flexibility_electricity_import_export_interconnectivity_4:
       title: "Interconnector 4"
       description: |
-        Hieronder kan je capaciteit, CO<sub>2</sub> uitstoot en prijs instellen voor interconnector 4.
+        Hieronder kan je capaciteit, beschikbaarheid, CO<sub>2</sub>-uitstoot en prijs instellen voor interconnector 4.
     flexibility_electricity_import_export_interconnectivity_5:
       title: "Interconnector 5"
       description: |
-        Hieronder kan je capaciteit, CO<sub>2</sub> uitstoot en prijs instellen voor interconnector 5.
+        Hieronder kan je capaciteit, beschikbaarheid, CO<sub>2</sub>-uitstoot en prijs instellen voor interconnector 5.
     flexibility_electricity_import_export_interconnectivity_6:
       title: "Interconnector 6"
       description: |
-        Hieronder kan je capaciteit, CO<sub>2</sub> uitstoot en prijs instellen voor interconnector 6.
+        Hieronder kan je capaciteit, beschikbaarheid, CO<sub>2</sub>-uitstoot en prijs instellen voor interconnector 6.
     flexibility_electricity_import_export_interconnectivity_7:
       title: "Interconnector 7"
       description: |
-        Hieronder kan je capaciteit, CO<sub>2</sub> uitstoot en prijs instellen voor interconnector 7.
+        Hieronder kan je capaciteit, beschikbaarheid, CO<sub>2</sub>-uitstoot en prijs instellen voor interconnector 7.
     flexibility_electricity_import_export_interconnectivity_8:
       title: "Interconnector 8"
       description: |
-        Hieronder kan je capaciteit, CO<sub>2</sub> uitstoot en prijs instellen voor interconnector 8.
+        Hieronder kan je capaciteit, beschikbaarheid, CO<sub>2</sub>-uitstoot en prijs instellen voor interconnector 8.
     flexibility_electricity_import_export_interconnectivity_9:
       title: "Interconnector 9"
       description: |
-        Hieronder kan je capaciteit, CO<sub>2</sub> uitstoot en prijs instellen voor interconnector 9.
+        Hieronder kan je capaciteit, beschikbaarheid, CO<sub>2</sub>-uitstoot en prijs instellen voor interconnector 9.
     flexibility_electricity_import_export_interconnectivity_10:
       title: "Interconnector 10"
       description: |
-        Hieronder kan je capaciteit, CO<sub>2</sub> uitstoot en prijs instellen voor interconnector 10.
+        Hieronder kan je capaciteit, beschikbaarheid, CO<sub>2</sub>-uitstoot en prijs instellen voor interconnector 10.
     flexibility_electricity_import_export_interconnectivity_11:
       title: "Interconnector 11"
       description: |
-        Hieronder kan je capaciteit, CO<sub>2</sub> uitstoot en prijs instellen voor interconnector 11.
+        Hieronder kan je capaciteit, beschikbaarheid, CO<sub>2</sub>-uitstoot en prijs instellen voor interconnector 11.
     flexibility_electricity_import_export_interconnectivity_12:
       title: "Interconnector 12"
       description: |
-        Hieronder kan je capaciteit, CO<sub>2</sub> uitstoot en prijs instellen voor interconnector 12.
+        Hieronder kan je capaciteit, beschikbaarheid, CO<sub>2</sub>-uitstoot en prijs instellen voor interconnector 12.
     flexibility_flexibility_cold_snap:
       title: Koude winter
       short_description:

--- a/config/locales/nl_custom_curves.yml
+++ b/config/locales/nl_custom_curves.yml
@@ -6,10 +6,11 @@ nl:
     download_file: Download bestand
     full_load_hours: Vollasturen
     interconnector_intro_html: |
-      Het ETM veronderstelt standaard dat de prijs van geïmporteerde stroom en de beschikbaarheid van
-      import en export constant zijn gedurende het jaar. Deze kun je instellen met de schuifjes
-      hierboven. Je kunt afwijken van deze aannames door hieronder CSV-bestanden te importeren met de prijs of
-      beschikbaarheid per uur. Zie onze
+      Het ETM veronderstelt standaard dat de externe elektriciteitsprijs en de beschikbaarheid van
+      import en export, die je met de schuifjes hierboven kunt instellen, constant zijn gedurende het jaar. 
+      Je kunt van deze aanname afwijken door hieronder CSV-bestanden te importeren met een uurlijkse 
+      veranderende prijs of beschikbaarheid. </br></br>
+      Klik op de drop-down om te bepalen welke curve je wilt uploaden. Zie onze
       <a href=%{docs_path} target="_blank">documentatie</a> voor meer uitleg en voorbeelden van
       geschikte CSV-bestanden.
     interface_group_title: Aanpasbare profielen
@@ -44,18 +45,18 @@ nl:
       gas_import_export: "Import/export: Gassen"
       weather: Weerdata
     names:
-      interconnector_1_price: Interconnector 1 prijscurve
-      interconnector_2_price: Interconnector 2 prijscurve
-      interconnector_3_price: Interconnector 3 prijscurve
-      interconnector_4_price: Interconnector 4 prijscurve
-      interconnector_5_price: Interconnector 5 prijscurve
-      interconnector_6_price: Interconnector 6 prijscurve
-      interconnector_7_price: Interconnector 7 prijscurve
-      interconnector_8_price: Interconnector 8 prijscurve
-      interconnector_9_price: Interconnector 9 prijscurve
-      interconnector_10_price: Interconnector 10 prijscurve
-      interconnector_11_price: Interconnector 11 prijscurve
-      interconnector_12_price: Interconnector 12 prijscurve
+      interconnector_1_price: Interconnector 1 elektricteitsprijs
+      interconnector_2_price: Interconnector 2 elektricteitsprijs
+      interconnector_3_price: Interconnector 3 elektricteitsprijs
+      interconnector_4_price: Interconnector 4 elektricteitsprijs
+      interconnector_5_price: Interconnector 5 elektricteitsprijs
+      interconnector_6_price: Interconnector 6 elektricteitsprijs
+      interconnector_7_price: Interconnector 7 elektricteitsprijs
+      interconnector_8_price: Interconnector 8 elektricteitsprijs
+      interconnector_9_price: Interconnector 9 elektricteitsprijs
+      interconnector_10_price: Interconnector 10 elektricteitsprijs
+      interconnector_11_price: Interconnector 11 elektricteitsprijs
+      interconnector_12_price: Interconnector 12 elektricteitsprijs
       interconnector_1_import_availability: Interconnector 1 import beschikbaarheid
       interconnector_2_import_availability: Interconnector 2 import beschikbaarheid
       interconnector_3_import_availability: Interconnector 3 import beschikbaarheid


### PR DESCRIPTION
This PR closes #3981. The goal of this PR is to more clearly describe the new functionality of uploading multiple curves for interconnectors: price, import availability, and export availability.

@Charlottevm could you please check if the functionality is described more clearly now?