### PR TITLE
Add texts for custom agriculture heat curve

### DIFF
--- a/config/locales/en_custom_curves.yml
+++ b/config/locales/en_custom_curves.yml
@@ -33,6 +33,7 @@ en:
       too_many_columns: Curve must contain only a single numeric value on each line; multiple values separated by commas are not permitted
       wrong_length: Curve must have 8760 numeric values, one for each hour in a typical year
     groups:
+      agriculture: Agriculture
       heat_production: "Supply: Heat"
       electricity_production: "Supply: Electricity"
       buildings: "Demand: Buildings"
@@ -43,6 +44,7 @@ en:
       gas_import_export: "Import/export: Gases"
       weather: Weather data
     names:
+      agriculture_heating: Agriculture heat demand
       interconnector_1_price: Interconnector 1 electricity price
       interconnector_2_price: Interconnector 2 electricity price
       interconnector_3_price: Interconnector 3 electricity price

--- a/config/locales/nl_custom_curves.yml
+++ b/config/locales/nl_custom_curves.yml
@@ -35,6 +35,7 @@ nl:
       too_many_columns: Profiel mag per regel maar één getal bevatten; meerdere getallen gescheiden door een komma zijn niet toegestaan.
       wrong_length: Profiel moet 8760 getallen bevatten (één getal voor elk uur in een jaar)
     groups:
+      agriculture: Landbouw
       heat_production: "Aanbod: Warmte"
       electricity_production: "Aanbod: Elektriciteit"
       buildings: "Vraag: Gebouwen"
@@ -45,6 +46,7 @@ nl:
       gas_import_export: "Import/export: Gassen"
       weather: Weerdata
     names:
+      agriculture_heating: Landbouw warmtevraag
       interconnector_1_price: Interconnector 1 elektricteitsprijs
       interconnector_2_price: Interconnector 2 elektricteitsprijs
       interconnector_3_price: Interconnector 3 elektricteitsprijs


### PR DESCRIPTION
Adds translations for the agriculture group in the custom curve drop-down, and for the agriculture heat curve.

Goes with https://github.com/quintel/etsource/pull/2753