### PR TITLE
Add output element presets

### DIFF
--- a/app/assets/javascripts/lib/views/output_element_preset_list_view.js
+++ b/app/assets/javascripts/lib/views/output_element_preset_list_view.js
@@ -1,0 +1,25 @@
+/* globals Backbone App */
+
+(function (window) {
+  'use strict';
+
+  var OutputElementPresetListView = Backbone.View.extend({
+    events: {
+      'click .dropdown-menu button': 'loadPreset',
+    },
+
+    loadPreset: function (event) {
+      const elements = event.target.dataset.outputElements;
+
+      App.settings
+        .save({ locked_charts: elements.length === 0 ? [] : elements.split(',') })
+        .done(function () {
+          location.reload();
+        });
+    },
+  });
+
+  // # Globals ---------------------------------------------------------------
+
+  window.OutputElementPresetListView = OutputElementPresetListView;
+})(window);

--- a/app/assets/stylesheets/_general_layout.sass
+++ b/app/assets/stylesheets/_general_layout.sass
@@ -43,8 +43,6 @@ body#model
   #active-content
     margin-left: 20px
     padding-bottom: 120px
-    #title
-      overflow: hidden
 
     #accordion_wrapper
       float: left

--- a/app/assets/stylesheets/_header.sass
+++ b/app/assets/stylesheets/_header.sass
@@ -388,7 +388,7 @@ header.main-header
     padding: 0
 
   // Items which will have a divider above them.
-  li.sep-above
+  li.sep-above, li.sep
     border-top: 1px solid rgba(0, 0, 0, 0.15)
     margin-top: 0.5rem
     padding-top: 0.5rem

--- a/app/assets/stylesheets/_title.sass
+++ b/app/assets/stylesheets/_title.sass
@@ -1,4 +1,8 @@
 #title
+  align-items: center
+  display: flex
+  gap: 0.5rem
+
   padding:
     top: 20px
     bottom: 15px
@@ -11,33 +15,41 @@
     font-weight: bold
     float: left
     line-height: 21px
-    margin: 3px 30px 0 0
+    margin: 3px auto 0 0
     text-align: left
 
-  a:first-child
-    margin-left: 40px
+  .help a, #oe_preset_list_button
+    align-items: center
+    appearance: none
+    border-radius: 3px
+    border: none
+    color: #444
+    cursor: pointer
+    display: flex
+    font-family: $body-font-family
+    font-size: 14px
+    line-height: 1
+    padding: 8px 10px
+    text-transform: none
+    transition: color 0.1s ease, background-color 0.15s ease
 
-  .help
-    float: right
+  .help a
+    background: #eee
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.07)
+    &:hover
+      background: #ddd
+      color: #222
+      text-decoration: none
+    &:active
+      background: #ccc
 
-    a
-      align-items: center
+    svg
+      margin: -0.5rem 0.125rem -0.5rem -0.125rem
+
+  #oe_preset_list_button
+    background: transparent
+    &:hover
       background: #eee
-      border-radius: 3px
-      box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.07)
-      color: #444
-      display: inline-flex
-      font-size: 14px
-      margin: -2px 0 0 25px
-      padding: 5px 9px 5px 7px
-      text-transform: none
-      transition: color 0.1s ease, background-color 0.1s ease
-      &:hover
-        background: #ddd
-        color: #222
-        text-decoration: none
-      &:active
-        background: #ccc
+    &:active
+      background: #ddd
 
-      svg
-        margin-right: 0.125rem

--- a/app/models/output_element_preset.rb
+++ b/app/models/output_element_preset.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: output_element_presets
+#
+#  key                        String
+#  output_elements            Array[String]
+#  dependent_on               String
+#
+
+# Entity used for filling charts
+class OutputElementPreset < YModel::Base
+  include AreaDependent::YModel
+
+  index_on :key
+  source_file 'config/interface/output_element_presets.yml'
+
+  default_attribute :output_elements, with: -> { [] }
+
+  def title
+    I18n.t("output_element_presets.#{key}.title")
+  end
+
+  def self.whitelisted
+    all.reject(&:not_allowed_in_this_area)
+  end
+
+  def self.for_list
+    whitelisted.sort_by(&:title)
+  end
+
+  def output_elements_for_js
+    output_elements.map { |el_key| "#{el_key}-C" }
+  end
+end

--- a/app/views/layouts/etm/_title.html.haml
+++ b/app/views/layouts/etm/_title.html.haml
@@ -1,5 +1,22 @@
 %h2= raw t("sidebar_items.#{@interface.current_sidebar_item.key}.title")
 
+#output_element_preset_list.dropdown
+  %button#oe_preset_list_button{ aria: { expanded: 'false' }, data: { toggle: 'dropdown' } }
+    = t("chart_presets.title")
+    %span.fa.fa-caret-down{ style: 'margin-left: 0.375rem' }
+  %ul.dropdown-menu.dropdown-menu-right{ 'aria-labelledby': 'oe_preset_list_button' }
+    %li
+      %button.dropdown-item{ data: { output_elements: '' } }
+        = t("chart_presets.reset_to_default")
+    %li.sep
+    - OutputElementPreset.for_list.each do |preset|
+      %li
+        %button.dropdown-item{ data: { output_elements: preset.output_elements_for_js.join(',') } }
+          = preset.title
+
+:javascript
+  new DropdownView({ el: $('#output_element_preset_list') })
+
 .help
   %a.add_chart{:href => output_elements_path}
     :plain

--- a/app/views/scenarios/play.js.erb
+++ b/app/views/scenarios/play.js.erb
@@ -8,3 +8,8 @@ $("#title").busyBox('close')
 // setup slider values, defaults etc
 App.setup_sliders();
 App.accordion.open_right_tab();
+
+const presetListEl = $('#output_element_preset_list');
+if (presetListEl.length > 0) {
+  new OutputElementPresetListView({ el: presetListEl });
+}

--- a/config/interface/output_element_presets.yml
+++ b/config/interface/output_element_presets.yml
@@ -1,6 +1,17 @@
 ---
-- key: test
+- key: system_overview
   output_elements:
-  - ccus_sankey
-  - mekko_of_co2_demand_supply
+  - future_energy_imports
+  - source_of_electricity_production
+  - hourly_flexibility_electricity
+  - mekko_of_hydrogen_network
+  - source_of_electricity_in_p2g
+  - collective_heat_mekko
+  - heat_network_storage
+  - source_of_electricity_production
+  - dynamic_demand_curve
+  - merit_order
+  - flexibility_hourly_p2p_storage
+  - storage_options
+  - merit_order_table
   dependent_on: ''

--- a/config/interface/output_element_presets.yml
+++ b/config/interface/output_element_presets.yml
@@ -1,0 +1,6 @@
+---
+- key: test
+  output_elements:
+  - ccus_sankey
+  - mekko_of_co2_demand_supply
+  dependent_on: ''

--- a/config/interface/output_element_presets.yml
+++ b/config/interface/output_element_presets.yml
@@ -8,6 +8,7 @@
   - source_of_electricity_in_p2g
   - collective_heat_mekko
   - heat_network_storage
+  - merit_order_hourly_supply
   - source_of_electricity_production
   - dynamic_demand_curve
   - merit_order

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -87,7 +87,7 @@ en:
     open_in_etengine: "Open in ETEngine"
   chart_presets:
     reset_to_default: Reset to default
-    title: Presets
+    title: Chart sets
   scenario_nav:
     saving: "Saving"
     loading: "Loading"

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -85,6 +85,9 @@ en:
     current_language: "English"
     actions: "Actions"
     open_in_etengine: "Open in ETEngine"
+  chart_presets:
+    reset_to_default: Reset to default
+    title: Presets
   scenario_nav:
     saving: "Saving"
     loading: "Loading"

--- a/config/locales/interface/en_output_element_presets.yml
+++ b/config/locales/interface/en_output_element_presets.yml
@@ -1,5 +1,5 @@
 ---
 en:
   output_element_presets:
-    test:
-      title: A test preset
+    system_overview:
+      title: System overview

--- a/config/locales/interface/en_output_element_presets.yml
+++ b/config/locales/interface/en_output_element_presets.yml
@@ -1,0 +1,5 @@
+---
+en:
+  output_element_presets:
+    test:
+      title: A test preset

--- a/config/locales/interface/nl_output_element_presets.yml
+++ b/config/locales/interface/nl_output_element_presets.yml
@@ -1,5 +1,5 @@
 ---
 nl:
   output_element_presets:
-    test:
-      title: A test preset
+    system_overview:
+      title: Systeemoverzicht

--- a/config/locales/interface/nl_output_element_presets.yml
+++ b/config/locales/interface/nl_output_element_presets.yml
@@ -1,0 +1,5 @@
+---
+nl:
+  output_element_presets:
+    test:
+      title: A test preset

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -85,6 +85,9 @@ nl:
     current_language: "Nederlands"
     actions: "Acties"
     open_in_etengine: "Openen in ETEngine"
+  chart_presets:
+    reset_to_default: Terugzetten naar standaard
+    title: Grafiekensets
   scenario_nav:
     saving: "Besparing"
     loading: "Laden"

--- a/spec/models/output_element_preset_spec.rb
+++ b/spec/models/output_element_preset_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe OutputElementPreset do
+  describe '#output_elements_for_js' do
+    it 'returns an array of output elements in chart form' do
+      preset = described_class.new(output_elements: %w[foo bar])
+      expect(preset.output_elements_for_js).to eq(%w[foo-C bar-C])
+    end
+  end
+
+  describe '.for_list' do
+    it 'returns a list of output elements sorted by title' do
+      allow(OutputElementPreset).to receive(:all).and_return([
+        instance_double(OutputElementPreset, title: 'B', not_allowed_in_this_area: false),
+        instance_double(OutputElementPreset, title: 'A', not_allowed_in_this_area: false),
+        instance_double(OutputElementPreset, title: 'C', not_allowed_in_this_area: false)
+      ])
+
+      expect(OutputElementPreset.for_list.map(&:title)).to eq(%w[A B C])
+    end
+  end
+end


### PR DESCRIPTION
Allows us to specify a list of charts which will all be loaded when the user selects a preset.