### PR TITLE
Tentatively hide additional investment costs for electric cars

### DIFF
--- a/config/interface/input_elements/costs_electric_car_investment.yml
+++ b/config/interface/input_elements/costs_electric_car_investment.yml
@@ -1,6 +1,0 @@
----
-- key: investment_costs_electric_cars
-  step_value: 250.0
-  unit: euro
-  position: 1
-  slide_key: costs_electric_car_investment

--- a/config/interface/output_elements/cost.yml
+++ b/config/interface/output_elements/cost.yml
@@ -51,7 +51,7 @@
   key: investment_electric_cars
   max_axis_value:
   min_axis_value:
-  hidden: false
+  hidden: true
   requires_merit_order: false
   dependent_on: ''
   output_element_type_name: vertical_stacked_bar

--- a/config/interface/slides/specs_transport.yml
+++ b/config/interface/slides/specs_transport.yml
@@ -1,9 +1,9 @@
 ---
-- key: costs_electric_car_investment
-  position: 1
-  sidebar_item_key: specs_transport
-  alt_output_element_key: investment_electric_cars
-  output_element_key: investment_electric_cars
+# - key: costs_electric_car_investment
+#   position: 1
+#   sidebar_item_key: specs_transport
+#   alt_output_element_key: investment_electric_cars
+#   output_element_key: investment_electric_cars
 - key: specs_transport_efficiency_improvement
   image: car_engine.gif
   general_sub_header: "%/year"

--- a/config/locales/interface/en_sidebar_items.yml
+++ b/config/locales/interface/en_sidebar_items.yml
@@ -417,9 +417,8 @@ en:
       description: 
     specs_transport:
       short_title: Transport
-      title: Transport
-      short_description: How expensive will transport be in the future? Will investment
-        costs for new technologies even out or will we (still) be paying more?
+      title: Transport efficiencies
+      short_description: ''
       description: ''
     transport_freight_transport:
       short_title: Freight transport

--- a/config/locales/interface/nl_sidebar_items.yml
+++ b/config/locales/interface/nl_sidebar_items.yml
@@ -413,10 +413,8 @@ nl:
         de afgelopen decennia.\r\n\r\n"
     specs_transport:
       short_title: Transport
-      title: Transport
-      short_description: Hoe duur zal transport zijn in de toekomst? Zullen investeringskosten
-        voor nieuwe technologieën op gelijke hoogte komen of betalen wij (nog steeds)
-        meer?
+      title: Transportefficiënties
+      short_description: ''
       description: ''
     transport_freight_transport:
       short_title: Vrachtvervoer


### PR DESCRIPTION
Summary of discussion on Basecamp: for electric and hydrogen cars, users can add additional costs. When adding number_of_vehicles for electric buses, vans and trucks, the question was whether to add this functionality for these vehicles as well.

- For all electricity storage technologies, costs are taken into account. It would be strange if electric vehicles would provide 'free' storage.
- However, we typically don't take transport vehicle costs (e.g. we don't calculate prices of inland ships) into account, so it would be more in line with our costs method if we were to exclude vehicle costs
- At the same time, we do calculate household heating technology costs.
- The costs method therefore does not entirely seem MECE  - which is confirmed by our own [documentation](https://docs.energytransitionmodel.com/main/cost-main-principles/): "the ETM makes no claim to be exhaustive in the scope of its cost calculation."
- In the end, the decisive argument is that this slider is only used in a very limited number of scenario, and not in featured scenarios such as the II3050 or Northern-Ireland scenarios.

We therefore decided to tentatively hide the additional investment costs for electric cars and the corresponding chart. If we receive no complaints, after some time we can remove this functionality altogether.