### PR TITLE
Fix local global pages to work with the changes caused by identity

### DIFF
--- a/app/assets/javascripts/compare/metric.js
+++ b/app/assets/javascripts/compare/metric.js
@@ -1,4 +1,4 @@
-/* globals $ _ Backbone I18n */
+/* globals $ _ Backbone App I18n */
 
 (function() {
   'use strict';
@@ -745,6 +745,8 @@
 
   $(function() {
     new Workspace(); // eslint-disable-line no-new
-    Backbone.history.start({ pushState: true });
+    if (!Backbone.History.started) {
+      Backbone.history.start({ pushState: true });
+    }
   });
 })();

--- a/app/helpers/compare_helper.rb
+++ b/app/helpers/compare_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Helpers for Compare (local-global)
+module CompareHelper
+  # Public: returns true if the saved scenario can be shown on the scenario picker
+  # of the compare index page
+  def eligible_for_compare?(saved_scenario)
+    saved_scenario.scenario(engine_client)&.loadable?
+  end
+end

--- a/app/views/compare/_scenarios_slice.html.haml
+++ b/app/views/compare/_scenarios_slice.html.haml
@@ -1,5 +1,5 @@
 - scenarios.each do |ss|
-  - if ss.scenario&.loadable?
+  - if eligible_for_compare?(ss)
     %li
       %label
         %span.check= check_box_tag('scenario_ids[]', ss.scenario_id)

--- a/app/views/compare/show.html.haml
+++ b/app/views/compare/show.html.haml
@@ -1,8 +1,9 @@
 %main
   #metrics
     .loading
-      = image_tag('layout/ajax-loader-small.gif')
-      = t('local_global.loading')
+      -# = image_tag('layout/ajax-loader-small.gif')
+      -# = t('local_global.loading')
+      = t('local_global.maintenance')
 
 %script#compare-metric-template(type="text/template")
   .summary

--- a/config/locales/en_local_global.yml
+++ b/config/locales/en_local_global.yml
@@ -20,7 +20,9 @@ en:
       each individual contibutes to the whole.
     legend_header: Comparing %{scenarios} scenarios
     loading: One moment please, loading data
-    maintenance: This page is under maintenance, we are sorry for the inconvenience
+    maintenance: |
+      This feature is under maintenance and therefore temporarily unavailable. 
+      We are working to bring it back online as quickly as possible.
     metrics:
       primary_demand_caused_by_final_demand: Energy use
       total_costs: Total costs

--- a/config/locales/en_local_global.yml
+++ b/config/locales/en_local_global.yml
@@ -20,6 +20,7 @@ en:
       each individual contibutes to the whole.
     legend_header: Comparing %{scenarios} scenarios
     loading: One moment please, loading data
+    maintenance: This page is under maintenance, we are sorry for the inconvenience
     metrics:
       primary_demand_caused_by_final_demand: Energy use
       total_costs: Total costs

--- a/config/locales/nl_local_global.yml
+++ b/config/locales/nl_local_global.yml
@@ -20,7 +20,9 @@ nl:
       optellen tot een gezamenlijk resultaat.
     legend_header: Er worden %{scenarios} scenarios vergeleken
     loading: Een moment geduld aub, de data wordt geladen
-    maintenance: Deze pagina is in onderhoud. Excuses voor het ongemak
+    maintenance: |
+      Deze feature is in onderhoud en daarom tijdelijk niet beschikbaar.
+      We werken eraan om het zo snel mogelijk weer online te brengen.
     metrics:
       primary_demand_caused_by_final_demand: Energiegebruik
       total_costs: Totale kosten

--- a/config/locales/nl_local_global.yml
+++ b/config/locales/nl_local_global.yml
@@ -20,6 +20,7 @@ nl:
       optellen tot een gezamenlijk resultaat.
     legend_header: Er worden %{scenarios} scenarios vergeleken
     loading: Een moment geduld aub, de data wordt geladen
+    maintenance: Deze pagina is in onderhoud. Excuses voor het ongemak
     metrics:
       primary_demand_caused_by_final_demand: Energiegebruik
       total_costs: Totale kosten


### PR DESCRIPTION
The `compare` functionality (know as local-global) was not working anymore. This mainly happened to changes within the app regarding the new identity stuff.

The index page where you pick your scenarios was relatively easy to fix, but the page where the comparison happens will require more work. Basically, the compare functionality now needs to know about the rest of the app (to use the correct authentication protocol), where before it was more of a standalone thing.

I think it will take me a few more hours to figure out how to make the compare part of the rest of the app - maybe this even means some rewriting of code, causing it to take up half a day or so.

We could merge this index page fix first, before the deploy, and fix the other page after, or I can spend the rest of my day on fixing the comparison page. Let me know what you think @ChaelKruip & @mabijkerk 