### PR TITLE
Change annual electricity output to charge cycles in electricity storage table

### DIFF
--- a/app/views/output_elements/tables/_storage_specifications.html.haml
+++ b/app/views/output_elements/tables/_storage_specifications.html.haml
@@ -23,8 +23,8 @@
         = t 'output_elements.tables.flexibility.annual_input'
         (PJ)
       %th
-        = t 'output_elements.tables.flexibility.annual_output'
-        (PJ)
+        = t 'output_elements.tables.flexibility.full_charge_cycles'
+        (-)
   %tbody
     %tr
       %th= t "output_elements.tables.flexibility.households_flexibility_p2p"
@@ -34,7 +34,7 @@
       %td{:data => {:gquery => "households_flexibility_p2p_electricity_volume_to_capacity_ratio",   :graph => :future}}
       %td{:data => {:gquery => "households_flexibility_p2p_electricity_efficiency",                 :graph => :future}}
       %td{:data => {:gquery => "households_flexibility_p2p_electricity_annual_input",               :graph => :future}}
-      %td{:data => {:gquery => "households_flexibility_p2p_electricity_annual_output",              :graph => :future}}
+      %td{:data => {:gquery => "households_flexibility_p2p_electricity_full_charge_cycles",         :graph => :future}}
     %tr
       %th= t "output_elements.tables.flexibility.transport_car_flexibility_p2p"
       %td{:data => {:gquery => "transport_car_flexibility_p2p_electricity_input_capacity",           :graph => :future}}
@@ -43,7 +43,7 @@
       %td{:data => {:gquery => "transport_car_flexibility_p2p_electricity_volume_to_capacity_ratio", :graph => :future}}
       %td{:data => {:gquery => "transport_car_flexibility_p2p_electricity_efficiency",               :graph => :future}}
       %td{:data => {:gquery => "transport_car_flexibility_p2p_electricity_annual_input",             :graph => :future}}
-      %td{:data => {:gquery => "transport_car_flexibility_p2p_electricity_annual_output",            :graph => :future}}
+      %td{:data => {:gquery => "transport_car_flexibility_p2p_electricity_full_charge_cycles",       :graph => :future}}
     %tr
       %th= t "output_elements.tables.flexibility.transport_bus_flexibility_p2p"
       %td{:data => {:gquery => "transport_bus_flexibility_p2p_electricity_input_capacity",           :graph => :future}}
@@ -52,7 +52,7 @@
       %td{:data => {:gquery => "transport_bus_flexibility_p2p_electricity_volume_to_capacity_ratio", :graph => :future}}
       %td{:data => {:gquery => "transport_bus_flexibility_p2p_electricity_efficiency",               :graph => :future}}
       %td{:data => {:gquery => "transport_bus_flexibility_p2p_electricity_annual_input",             :graph => :future}}
-      %td{:data => {:gquery => "transport_bus_flexibility_p2p_electricity_annual_output",            :graph => :future}}
+      %td{:data => {:gquery => "transport_bus_flexibility_p2p_electricity_full_charge_cycles",       :graph => :future}}
     %tr
       %th= t "output_elements.tables.flexibility.transport_truck_flexibility_p2p"
       %td{:data => {:gquery => "transport_truck_flexibility_p2p_electricity_input_capacity",           :graph => :future}}
@@ -61,7 +61,7 @@
       %td{:data => {:gquery => "transport_truck_flexibility_p2p_electricity_volume_to_capacity_ratio", :graph => :future}}
       %td{:data => {:gquery => "transport_truck_flexibility_p2p_electricity_efficiency",               :graph => :future}}
       %td{:data => {:gquery => "transport_truck_flexibility_p2p_electricity_annual_input",             :graph => :future}}
-      %td{:data => {:gquery => "transport_truck_flexibility_p2p_electricity_annual_output",            :graph => :future}}
+      %td{:data => {:gquery => "transport_truck_flexibility_p2p_electricity_full_charge_cycles",       :graph => :future}}
     %tr
       %th= t "output_elements.tables.flexibility.transport_van_flexibility_p2p"
       %td{:data => {:gquery => "transport_van_flexibility_p2p_electricity_input_capacity",           :graph => :future}}
@@ -70,7 +70,7 @@
       %td{:data => {:gquery => "transport_van_flexibility_p2p_electricity_volume_to_capacity_ratio", :graph => :future}}
       %td{:data => {:gquery => "transport_van_flexibility_p2p_electricity_efficiency",               :graph => :future}}
       %td{:data => {:gquery => "transport_van_flexibility_p2p_electricity_annual_input",             :graph => :future}}
-      %td{:data => {:gquery => "transport_van_flexibility_p2p_electricity_annual_output",            :graph => :future}}
+      %td{:data => {:gquery => "transport_van_flexibility_p2p_electricity_full_charge_cycles",       :graph => :future}}
     %tr
       %th= t "output_elements.tables.flexibility.energy_flexibility_mv_batteries"
       %td{:data => {:gquery => "energy_flexibility_mv_batteries_input_capacity",           :graph => :future}}
@@ -79,7 +79,7 @@
       %td{:data => {:gquery => "energy_flexibility_mv_batteries_volume_to_capacity_ratio", :graph => :future}}
       %td{:data => {:gquery => "energy_flexibility_mv_batteries_efficiency",               :graph => :future}}
       %td{:data => {:gquery => "energy_flexibility_mv_batteries_annual_input",             :graph => :future}}
-      %td{:data => {:gquery => "energy_flexibility_mv_batteries_annual_output",            :graph => :future}}
+      %td{:data => {:gquery => "energy_flexibility_mv_batteries_full_charge_cycles",       :graph => :future}}
     %tr
       %th= t "output_elements.tables.flexibility.energy_flexibility_pumped_storage"
       %td{:data => {:gquery => "energy_flexibility_pumped_storage_input_capacity",           :graph => :future}}
@@ -88,7 +88,7 @@
       %td{:data => {:gquery => "energy_flexibility_pumped_storage_volume_to_capacity_ratio", :graph => :future}}
       %td{:data => {:gquery => "energy_flexibility_pumped_storage_efficiency",               :graph => :future}}
       %td{:data => {:gquery => "energy_flexibility_pumped_storage_annual_input",             :graph => :future}}
-      %td{:data => {:gquery => "energy_flexibility_pumped_storage_annual_output",            :graph => :future}}
+      %td{:data => {:gquery => "energy_flexibility_pumped_storage_full_charge_cycles",       :graph => :future}}
     %tr
       %th= t "output_elements.tables.flexibility.energy_flexibility_hv_opac"
       %td{:data => {:gquery => "energy_flexibility_hv_opac_input_capacity",           :graph => :future}}
@@ -97,7 +97,7 @@
       %td{:data => {:gquery => "energy_flexibility_hv_opac_volume_to_capacity_ratio", :graph => :future}}
       %td{:data => {:gquery => "energy_flexibility_hv_opac_efficiency",               :graph => :future}}
       %td{:data => {:gquery => "energy_flexibility_hv_opac_annual_input",             :graph => :future}}
-      %td{:data => {:gquery => "energy_flexibility_hv_opac_annual_output",            :graph => :future}}
+      %td{:data => {:gquery => "energy_flexibility_hv_opac_full_charge_cycles",       :graph => :future}}
     %tr
       %th= t "output_elements.tables.flexibility.energy_flexibility_flow_batteries"
       %td{:data => {:gquery => "energy_flexibility_flow_batteries_input_capacity",           :graph => :future}}
@@ -106,4 +106,4 @@
       %td{:data => {:gquery => "energy_flexibility_flow_batteries_volume_to_capacity_ratio", :graph => :future}}
       %td{:data => {:gquery => "energy_flexibility_flow_batteries_efficiency",               :graph => :future}}
       %td{:data => {:gquery => "energy_flexibility_flow_batteries_annual_input",             :graph => :future}}
-      %td{:data => {:gquery => "energy_flexibility_flow_batteries_annual_output",            :graph => :future}}
+      %td{:data => {:gquery => "energy_flexibility_flow_batteries_full_charge_cycles",       :graph => :future}}

--- a/config/locales/interface/output_elements/en_flexibility.yml
+++ b/config/locales/interface/output_elements/en_flexibility.yml
@@ -116,7 +116,9 @@ en:
         be found in the <a href="/scenario/flexibility/flexibility_storage/behaviour-of-storage-technologies">
         Flexibility</a> section of the model. Information about the behaviour of these technologies 
         can be found in our <a href="https://docs.energytransitionmodel.com/main/electricity-storage" target=\"_blank\">
-        documentation</a>. </br></br>
+        documentation</a>. The charge cycles are calculated by dividing the annual electricity input by the 
+        storage volume.
+        </br></br>
         By clicking on the toggle you can see the hourly behaviour of individual electricity storage 
         technologies. In <a href="#" class="open_chart" data-chart-key="hourly_flexibility_electricity" data-chart-location="side">
         this</a> chart you can view the combined charging and discharging behaviour of these technologies 

--- a/config/locales/interface/output_elements/labels_groups/en_tables.yml
+++ b/config/locales/interface/output_elements/labels_groups/en_tables.yml
@@ -214,6 +214,7 @@ en:
         roundtrip_efficiency: "Roundtrip efficiency"
         annual_input: "Annual electricity input"
         annual_output: "Annual electricity output"
+        full_charge_cycles: "Charge cycles"
       carbon_balance:
         used: "Used"
         available: "Available"

--- a/config/locales/interface/output_elements/labels_groups/nl_tables.yml
+++ b/config/locales/interface/output_elements/labels_groups/nl_tables.yml
@@ -223,6 +223,7 @@ nl:
         roundtrip_efficiency: "Roundtrip-efficiëntie"
         annual_input: "Jaarlijkse input elektriciteit"
         annual_output: "Jaarlijkse output elektriciteit"
+        full_charge_cycles: "Laadcycli"
       carbon_balance:
         used: "Gebruikt"
         available: "Beschikbaar"

--- a/config/locales/interface/output_elements/nl_flexibility.yml
+++ b/config/locales/interface/output_elements/nl_flexibility.yml
@@ -95,7 +95,9 @@ nl:
         te vinden in de sectie <a href="/scenario/flexibility/flexibility_storage/behaviour-of-storage-technologies">
         Flexibiliteit</a> van het model. Informatie over het gedrag van deze technologieën kun je vinden in onze
         <a href="https://docs.energytransitionmodel.com/main/electricity-storage" target=\"_blank\">
-        documentatie</a>. </br></br>
+        documentatie</a>. De laadcycli zijn berekend door de jaarlijkse elektriciteitsinput te delen door het 
+        opslagvolume.
+        </br></br>
         Door op de toggle te klikken kun je het uurlijkse gedrag van individuele opslagtechnologieën zien. In 
         <a href="#" class="open_chart" data-chart-key="hourly_flexibility_electricity" data-chart-location="side">
         deze</a> grafiek kun je het gecombineerde laad- en ontlaadgedrag van deze technologieën per uur zien.


### PR DESCRIPTION
This PR adds the number of charge cycles for electricity storage technologies in the `Electricity storage technologies specifications` [table](https://energytransitionmodel.com/scenario/flexibility/flexibility_forecast_storage_order/forecasting-storage-order), instead of the annual electricity output.

It goes with https://github.com/quintel/etsource/pull/2847