### PR TITLE
View and open 'My Transition Paths' from my scenarios

### DIFF
--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -266,6 +266,9 @@ table.default
           left: 0
           z-index: 1
           content: ""
+        span
+          padding-left: 0.25rem
+          font-size: 0.875rem
       .check, .scenario-info, .buttons
         padding: 0.5rem
       & > :first-child

--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -61,8 +61,8 @@ table.default
     background: white
     border: 1px solid $landing-border-color
     border-bottom-color: darken($landing-border-color, 5%)
-    border-top-color: $landing-gold
-    border-top-width: 2px
+    // border-top-color: #e4f7ff
+    // border-top-width: 2px
     box-shadow: 0 3px 5px rgba(50, 71, 93, 0.06), 0 1px 3px rgba(0, 0, 0, 0.04)
     border-radius: 4px
     padding: 15px 40px
@@ -182,6 +182,8 @@ table.default
       margin-left: 0.5rem
 
   &#index
+    min-height: 60vh
+
     .vertical-bar
       width: 0
       height: 26px
@@ -198,8 +200,7 @@ table.default
         margin: 0
         font-size: 14px
     .empty-state
-      text-align: center
-      padding: 2rem 8rem
+      padding-top: 2rem
       h4
         font-size: 18px
         font-weight: 500
@@ -595,9 +596,14 @@ table.default
         background: white
         color: black
         border-bottom: 1px solid white
+        border-top: 2px solid $landing-gold
+        border-radius: 4px 4px 0 0
         margin-bottom: -1px
+        margin-top: -2px
         &:hover
           color: black
+      &.myc
+        // background-color: #e4f7ff
       svg
         display: inline-block
         margin-right: 0.125rem

--- a/app/controllers/multi_year_charts_controller.rb
+++ b/app/controllers/multi_year_charts_controller.rb
@@ -21,6 +21,17 @@ class MultiYearChartsController < ApplicationController
     end
   end
 
+  # Part of the My Scenarios view
+  #
+  # GET multi_year_charts/list
+  def list
+    @multi_year_charts = user_multi_year_charts
+
+    respond_to do |format|
+      format.html
+    end
+  end
+
   # Creates a new MultiYearChart record based on the scenario specified in the
   # params.
   #

--- a/app/views/multi_year_charts/_multi_year_chart_row.html.haml
+++ b/app/views/multi_year_charts/_multi_year_chart_row.html.haml
@@ -2,6 +2,7 @@
   .scenario-info
     %a.title{ href: myc_url(multi_year_chart_row), target:'_blank' }
       = multi_year_chart_row.title
+      %span.fa.fa-external-link
     %span.info
       = t("areas.#{multi_year_chart_row.area_code}")
       = multi_year_chart_row.end_year

--- a/app/views/multi_year_charts/_multi_year_chart_row.html.haml
+++ b/app/views/multi_year_charts/_multi_year_chart_row.html.haml
@@ -1,0 +1,14 @@
+.scenario-row{ class: 'loadable' }
+  .scenario-info
+    %a.title{ href: myc_url(multi_year_chart_row), target:'_blank' }
+      = multi_year_chart_row.title
+    %span.info
+      = t("areas.#{multi_year_chart_row.area_code}")
+      = multi_year_chart_row.end_year
+      - if current_user.id != multi_year_chart_row.user_id
+        %span.author
+          = t('scenario.by')
+          = multi_year_chart_row.user&.name
+    %span.last-updated
+      •
+      = t('multi_year_charts.created_at', date: distance_of_time_in_words_to_now(multi_year_chart_row.created_at))

--- a/app/views/multi_year_charts/list.html.haml
+++ b/app/views/multi_year_charts/list.html.haml
@@ -1,0 +1,16 @@
+- content_for(:page_title) { "#{t('multi_year_charts.title')} - #{t('meta.name')}" }
+
+.background_wrapper#saved_scenario
+  .scenario_wrapper#index
+    = render partial: 'saved_scenarios/scenario_list_tabs', locals: { active_tab: :my_myc }
+
+    - if @multi_year_charts.any?
+      = render partial: 'multi_year_chart_row', collection: @multi_year_charts
+      = paginate @multi_year_charts
+    - else
+      .empty-state
+        %h4= t('multi_year_charts.title')
+        %p= t('multi_year_charts.description')
+        %p{ style: "font-weight: 500" }
+          = link_to scenarios_path do
+            == ← #{t('multi_year_charts.back')}

--- a/app/views/saved_scenarios/_scenario_list_tabs.html.haml
+++ b/app/views/saved_scenarios/_scenario_list_tabs.html.haml
@@ -5,6 +5,13 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
       </svg>
     %span.name= t('header.load_scenario')
+  %a.tab.myc{ href: multi_year_charts_list_path, class: active_tab == :my_myc ? 'active' : '' }
+    :plain
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="20" viewBox="0 0 256 256">
+        <polyline points="232 56 136 152 96 112 24 184" stroke-linecap="round" stroke-linejoin="round"></polyline>
+        <polyline points="232 120 232 56 168 56" stroke-linecap="round" stroke-linejoin="round"></polyline>
+      </svg>
+    %span.name= t('multi_year_charts.title')
   %a.tab{ href: discarded_saved_scenarios_path, class: active_tab == :trash ? 'active' : '' }
     :plain
       <svg style="margin-top: -2px" height="24" width="24" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">

--- a/app/views/saved_scenarios/_scenario_list_tabs.html.haml
+++ b/app/views/saved_scenarios/_scenario_list_tabs.html.haml
@@ -11,7 +11,7 @@
         <polyline points="232 56 136 152 96 112 24 184" stroke-linecap="round" stroke-linejoin="round"></polyline>
         <polyline points="232 120 232 56 168 56" stroke-linecap="round" stroke-linejoin="round"></polyline>
       </svg>
-    %span.name= t('multi_year_charts.title')
+    %span.name= t('multi_year_charts.my_myc')
   %a.tab{ href: discarded_saved_scenarios_path, class: active_tab == :trash ? 'active' : '' }
     :plain
       <svg style="margin-top: -2px" height="24" width="24" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">

--- a/config/locales/en_multi_year_charts.yml
+++ b/config/locales/en_multi_year_charts.yml
@@ -21,6 +21,7 @@ en:
     resume: Resume an existing session
     start: Start a new session
     title: Transition Paths
+    my_myc: My Transition Paths
     description: |
       Explore the possible transition paths to a scenario for 2050 and discover
       the actions and consequences for aspired goals in 2023, 2030 and 2040.

--- a/config/locales/en_multi_year_charts.yml
+++ b/config/locales/en_multi_year_charts.yml
@@ -21,3 +21,8 @@ en:
     resume: Resume an existing session
     start: Start a new session
     title: Transition Paths
+    description: |
+      Explore the possible transition paths to a scenario for 2050 and discover
+      the actions and consequences for aspired goals in 2023, 2030 and 2040.
+      Start by selecting one of your saved 2050 scenarios from your scenarios.
+    back: Go to my saved scenarios

--- a/config/locales/nl_multi_year_charts.yml
+++ b/config/locales/nl_multi_year_charts.yml
@@ -22,6 +22,7 @@ nl:
     resume: Ga door met een bestaande sessie
     start: Start een nieuwe sessie
     title: Transitiepaden
+    my_myc: Mijn Transitiepaden
     description: |
       Verken de mogelijke transitiepaden naar een 2050 toekomstbeeld en ontdek
       wat dit zou kunnen betekenen voor de tussentijdse doelstellingen voor de

--- a/config/locales/nl_multi_year_charts.yml
+++ b/config/locales/nl_multi_year_charts.yml
@@ -22,3 +22,9 @@ nl:
     resume: Ga door met een bestaande sessie
     start: Start een nieuwe sessie
     title: Transitiepaden
+    description: |
+      Verken de mogelijke transitiepaden naar een 2050 toekomstbeeld en ontdek
+      wat dit zou kunnen betekenen voor de tussentijdse doelstellingen voor de
+      belangrijkste zichtjaren (2023, 2030 en 2040). Begin vanuit één van je
+      opgeslagen toekomstscenario's voor 2050.
+    back: Ga naar mijn scenario's

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,6 +140,7 @@ Rails.application.routes.draw do
   get '/local-global/:ids' => 'compare#show', as: :local_global_scenarios
 
   resources :multi_year_charts, only: %i[index create destroy]
+  get '/multi_year_charts/list' => 'multi_year_charts#list'
 
   get '/import_esdl'  => 'import_esdl#index'
   post '/import_esdl/create' => 'import_esdl#create', as: :import_esdl_create


### PR DESCRIPTION
Adds a view to check and open a users MYC from the ETM.

See your transition paths in a new tab next to my scenarios.

<img width="1498" alt="List of my transition paths" src="https://user-images.githubusercontent.com/14875123/226293121-1250caed-97df-4418-8f6c-25d42a89547b.png">

When you don't have MYC's yet, you can read the description of what they are about. (This screenshot still says 'Transitiepaden' in the tab title, but I changed it to 'Mijn Transitiepaden').

![Screenshot 2023-03-17 at 17 24 46](https://user-images.githubusercontent.com/14875123/226293179-9d541001-3153-4789-bfdb-67ca066413c9.png)

**Note: MYC are not part of the Trash; MYC are not yet part of All Scenario's (admin)**

Closes  #4083