### PR TITLE
Add CSV data export of storage technologies parameters

### DIFF
--- a/config/interface/slides/data_export.yml
+++ b/config/interface/slides/data_export.yml
@@ -1,54 +1,58 @@
 ---
 - key: data_export_overview
-  position: 1
+  position: 100
   sidebar_item_key: data_export
   output_element_key: final_energy_demand_per_sector_joule
 - key: data_export_energy_flows
-  position: 2
+  position: 105
   sidebar_item_key: data_export
   output_element_key: final_energy_demand_per_sector_joule
 - key: data_export_molecule_flows
-  position: 3
+  position: 110
   sidebar_item_key: data_export
   output_element_key: co2_emissions
 - key: data_export_application_demands
-  position: 4
+  position: 120
   sidebar_item_key: data_export
   output_element_key: use_of_primary_energy
 - key: data_export_production
-  position: 5
+  position: 200
   sidebar_item_key: data_export
   output_element_key: costs_overview_detailed
 - key: data_export_costs
-  position: 6
+  position: 210
   sidebar_item_key: data_export
   output_element_key: costs_overview_detailed
+- key: data_export_storage
+  position: 220
+  sidebar_item_key: data_export
+  output_element_key: storage_specifications
 - key: data_export_household_heat
-  position: 7
+  position: 300
   sidebar_item_key: data_export
   output_element_key: household_heat_demand_and_production
 - key: data_export_hydrogen
-  position: 8
+  position: 310
   sidebar_item_key: data_export
   output_element_key: hydrogen_demand
 - key: data_export_network_gas
-  position: 9
+  position: 320
   sidebar_item_key: data_export
   output_element_key: network_gas_demand
 - key: data_export_heat_network
-  position: 10
+  position: 330
   sidebar_item_key: data_export
   output_element_key: heat_network_demand
 - key: data_export_agriculture_heat
-  position: 11
+  position: 340
   sidebar_item_key: data_export
   output_element_key: agriculture_local_heat_mekko
 - key: flexibility_merit_order_merit_order_price
-  position: 12
+  position: 350
   sidebar_item_key: data_export
   alt_output_element_key: merit_order_price_curve
   output_element_key: merit_order_price_curve
 - key: data_export_residual_load_curves
-  position: 13
+  position: 360
   sidebar_item_key: data_export
   output_element_key: flexibility_hourly_carriers_inflexible_imbalance

--- a/config/locales/interface/slides/en_data.yml
+++ b/config/locales/interface/slides/en_data.yml
@@ -53,6 +53,17 @@ en:
             </a>
           </li>
         </ul>
+    data_export_storage:
+      title: Specifications storage technologies
+      short_description:
+      description: |
+        <ul class="data-download">
+          <li>
+            <a href="/passthru/%{scenario_id}/storage_parameters.csv" target="_blank">
+              <span class="name">Specifications storage technologies</span> <span class="filetype">23KB CSV</span>
+            </a>
+          </li>
+        </ul>
     data_export_energy_flows:
       title: Yearly energy flows
       short_description:

--- a/config/locales/interface/slides/en_data.yml
+++ b/config/locales/interface/slides/en_data.yml
@@ -69,7 +69,7 @@ en:
         <ul class="data-download">
           <li>
             <a href="/passthru/%{scenario_id}/storage_parameters.csv" target="_blank">
-              <span class="name">Specifications storage technologies</span> <span class="filetype">23KB CSV</span>
+              <span class="name">Specifications storage technologies</span> <span class="filetype">10KB CSV</span>
             </a>
           </li>
         </ul>

--- a/config/locales/interface/slides/en_data.yml
+++ b/config/locales/interface/slides/en_data.yml
@@ -7,7 +7,7 @@ en:
       description: |
         In this section you can find extensive data downloads for the calculations underpinning your scenario. <br/><br/>
         You can choose to download <b>yearly results</b> (flows, emissions, demand and supply), additional <b>specifications</b>
-        (capacities, number of units and costs) or you can download <b>hourly results</b> (electricity,
+        (capacities, storage, technologies, number of units and costs) or you can download <b>hourly results</b> (electricity,
         household heat, gas, hydrogen and heat networks). <br/><br/>
         You can also upload hourly demand and supply curves for your scenario in the
         <a href="/scenario/flexibility/curve_upload/upload-curves">Flexibility → Modify hourly profiles </a> section.
@@ -57,6 +57,15 @@ en:
       title: Specifications storage technologies
       short_description:
       description: |
+        Download detailed information about the parameters of 
+        <a href="#" class="open_chart" data-chart-key="flexibility_hourly_p2p_storage" data-chart-location="side">
+        Electricity storage</a> technologies,
+        <a href="#" class="open_chart" data-chart-key="heat_network_storage" data-chart-location="side">
+        (Seasonal) storage of heat</a> on the district heating network,
+        <a href="#" class="open_chart" data-chart-key="hydrogen_storage" data-chart-location="side">
+        Hydrogen storage</a> and
+        <a href="#" class="open_chart" data-chart-key="network_gas_storage" data-chart-location="side">
+        Network gas storage</a>.
         <ul class="data-download">
           <li>
             <a href="/passthru/%{scenario_id}/storage_parameters.csv" target="_blank">

--- a/config/locales/interface/slides/nl_data.yml
+++ b/config/locales/interface/slides/nl_data.yml
@@ -7,7 +7,7 @@ nl:
       description: |
         In deze sectie kan je uitgebreide data-downloads vinden voor de onderliggende berekeningen van jouw scenario. <br/><br/>
         Je kunt er voor kiezen om <b>jaarlijkse resultaten</b> (stromen, emissies, vraag en aanbod), aanvullende
-        <b>specificaties</b> (vermogens, aantal eenheden en kosten), of <b>uurlijkse
+        <b>specificaties</b> (vermogens, opslagtechnologieën, aantal eenheden en kosten), of <b>uurlijkse
         resultaten</b> (elektriciteit, warmte in huishoudens, gas, waterstof en warmtenetten) te downloaden. <br/><br/>
         Je kunt ook de uurlijkse vraag- en aanbodprofielen uploaden in jouw scenario in de
         <a href="/scenario/flexibility/curve_upload/upload-curves">Flexibiliteit → Uurprofielen aanpassen</a> sectie.
@@ -49,6 +49,26 @@ nl:
           <li>
             <a href="%{etengine_url}/api/v3/scenarios/%{scenario_id}/costs_parameters.csv" target="_blank">
               <span class="name">Eindspecificaties kosten</span> <span class="filetype">23KB CSV</span>
+            </a>
+          </li>
+        </ul>
+    data_export_storage:
+      title: Specificaties opslagtechnologieën
+      short_description:
+      description: |
+        Download gedetailleerde informatie over de parameters van 
+        <a href="#" class="open_chart" data-chart-key="flexibility_hourly_p2p_storage" data-chart-location="side">
+        Elektriciteitsopslagtechnologieën</a>,
+        <a href="#" class="open_chart" data-chart-key="heat_network_storage" data-chart-location="side">
+        (Seizoens)opslag van warmte</a> op het residentiële warmtenet,
+        <a href="#" class="open_chart" data-chart-key="hydrogen_storage" data-chart-location="side">
+        Waterstofopslag</a> en
+        <a href="#" class="open_chart" data-chart-key="network_gas_storage" data-chart-location="side">
+        Gasberging</a>.
+        <ul class="data-download">
+          <li>
+            <a href="/passthru/%{scenario_id}/storage_parameters.csv" target="_blank">
+              <span class="name">Specificaties opslagtechnologieën</span> <span class="filetype">23KB CSV</span>
             </a>
           </li>
         </ul>

--- a/config/locales/interface/slides/nl_data.yml
+++ b/config/locales/interface/slides/nl_data.yml
@@ -68,7 +68,7 @@ nl:
         <ul class="data-download">
           <li>
             <a href="/passthru/%{scenario_id}/storage_parameters.csv" target="_blank">
-              <span class="name">Specificaties opslagtechnologieën</span> <span class="filetype">23KB CSV</span>
+              <span class="name">Specificaties opslagtechnologieën</span> <span class="filetype">10KB CSV</span>
             </a>
           </li>
         </ul>


### PR DESCRIPTION
The data export contains for each storage technology for electricity, hydrogen, network gas and heat on the district heating the following parameters:

- Energy input
- Energy output
- Energy losses
- Storage volume
- Installed input capacity
- Installed output capacity
- Peak input capacity
- Peak output capacity

See for reference [Documentation of Storage parameters data-export.xlsx](https://github.com/quintel/etengine/files/11027008/Documentation.of.Storage.parameters.data-export.xlsx)

Goes with https://github.com/quintel/etsource/pull/2862 and https://github.com/quintel/etengine/pull/1329