### PR TITLE
Discard my Transition Paths

### DIFF
--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -262,12 +262,16 @@ table.default
         pointer-events: initial
         .button
           background: none
+          &:hover
+            color: #000
+          &.destroy:hover
+            color: darken($error-red, 10%)
       &.discarded .big-icon
         padding: 8px 8px 2px 8px
         color: #666
         border: 1px solid #eee
         border-radius: 24px
-        margin: 10px 10px 10px 0px
+        margin: 10px 10px 10px 0
       a.title, .check input
         // title link and checkbox are clickable for the entire container.
         &::after
@@ -281,6 +285,22 @@ table.default
         span
           padding-left: 0.25rem
           font-size: 0.875rem
+      .sub-row
+        display: flex
+      .type-tag
+        color: $landing-gold
+        font-weight: normal
+        border: 1px solid $landing-gold
+        border-radius: 24px
+        padding: 1px 10px 0 8px
+        display: flex
+        margin-left: 10px
+        margin-top: -2px
+        font-size: 0.75rem
+        line-height: 1.2rem
+        span.icon
+            margin-top: 2px
+            padding-right: 4px
       .check, .scenario-info, .buttons
         padding: 0.5rem
       & > :first-child
@@ -334,8 +354,6 @@ table.default
       .title
         font-weight: 600
         font-size: 1rem
-        display: inline-block
-        width: 100%
       .info, .author, .last-updated
         font-size: 0.8125rem
       .info

--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -221,7 +221,7 @@ table.default
       display: flex
       font-size: 14px
       justify-content: center
-      padding: 0.5rem 0
+      padding: 0.75rem 0
       svg
         margin-right: 0.25rem
 
@@ -254,13 +254,20 @@ table.default
         .buttons
           opacity: 1
           pointer-events: initial
+      &.discarded
+        margin-top: 1rem
       &.discarded .buttons
         // buttons are always visible for discarded scenarios.
         opacity: 1
         pointer-events: initial
+        .button
+          background: none
       &.discarded .big-icon
-        padding: 14px 4px
+        padding: 8px 8px 2px 8px
         color: #666
+        border: 1px solid #eee
+        border-radius: 24px
+        margin: 10px 10px 10px 0px
       a.title, .check input
         // title link and checkbox are clickable for the entire container.
         &::after

--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -258,6 +258,9 @@ table.default
         // buttons are always visible for discarded scenarios.
         opacity: 1
         pointer-events: initial
+      &.discarded .big-icon
+        padding: 14px 4px
+        color: #666
       a.title, .check input
         // title link and checkbox are clickable for the entire container.
         &::after

--- a/app/controllers/multi_year_charts_controller.rb
+++ b/app/controllers/multi_year_charts_controller.rb
@@ -27,18 +27,20 @@ class MultiYearChartsController < ApplicationController
     end
   end
 
-  # Part of the My Scenarios view
+  # Part of the My Scenarios view, lists all MYC that are not discarded
   #
   # GET multi_year_charts/list
   def list
     @multi_year_charts = user_multi_year_charts
+      .kept
+      .includes(:user)
+      .order('created_at DESC')
+      .page(params[:page])
+      .per(50)
 
     respond_to do |format|
       format.html {render :layout => 'application'}
     end
-  end
-
-  def discarded
   end
 
   # Creates a new MultiYearChart record based on the scenario specified in the
@@ -105,7 +107,7 @@ class MultiYearChartsController < ApplicationController
       flash[:undo_params] = [discard_multi_year_chart_path(@multi_year_chart), { method: :put }]
     end
 
-    redirect_back(fallback_location: discarded_multi_year_charts_path)
+    redirect_back(fallback_location: discarded_saved_scenarios_path)
   end
 
   private

--- a/app/controllers/saved_scenarios_controller.rb
+++ b/app/controllers/saved_scenarios_controller.rb
@@ -43,9 +43,13 @@ class SavedScenariosController < ApplicationController
   end
 
   def discarded
-    @saved_scenarios = current_user.saved_scenarios.discarded
-      .includes(:featured_scenario, :user)
-      .order('updated_at DESC')
+    @discarded_scenarios = Kaminari.paginate_array(
+        (
+          current_user.saved_scenarios.discarded.includes(:featured_scenario, :user) +
+          current_user.multi_year_charts.discarded.includes(:user)
+        )
+        .sort_by(&:updated_at)
+      )
       .page(params[:page])
       .per(100)
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -39,5 +39,7 @@ class Ability
     can :read,    SavedScenario, user_id: user.id
     can :update,  SavedScenario, user_id: user.id
     can :destroy, SavedScenario, user_id: user.id
+
+    can :destroy, MultiYearChart, user_id: user.id
   end
 end

--- a/app/models/multi_year_chart.rb
+++ b/app/models/multi_year_chart.rb
@@ -43,6 +43,12 @@ class MultiYearChart < ApplicationRecord
     scenarios.pluck(:scenario_id).join(',')
   end
 
+  # Public: MYC doesn't have an update at, but we need it for sorting the items
+  # in the trash
+  def updated_at
+    created_at
+  end
+
   def as_json(options = {})
     options[:except] ||= %i[area_code end_year user_id]
 

--- a/app/models/multi_year_chart.rb
+++ b/app/models/multi_year_chart.rb
@@ -31,6 +31,13 @@ class MultiYearChart < ApplicationRecord
     }.merge(attrs))
   end
 
+  # Public: Destroys all multi year charts which were discarded some time ago.
+  def self.destroy_old_discarded!
+    discarded
+      .where(discarded_at: ..MultiYearChart::AUTO_DELETES_AFTER.ago)
+      .destroy_all
+  end
+
   # Public: Returns an way for the MYC app to identify this instance, to use
   # used when directing to the application.
   #

--- a/app/models/multi_year_chart.rb
+++ b/app/models/multi_year_chart.rb
@@ -3,6 +3,11 @@
 # Represents a saved multi-year charts session. Contains one or more scenario
 # which will be loaded in the MYC interface.
 class MultiYearChart < ApplicationRecord
+  include Discard::Model
+
+  # Discarded scenarios are deleted automatically after this period.
+  AUTO_DELETES_AFTER = 60.days
+
   belongs_to :user
 
   has_many :scenarios,
@@ -42,6 +47,7 @@ class MultiYearChart < ApplicationRecord
     options[:except] ||= %i[area_code end_year user_id]
 
     super(options).merge(
+      'discarded' => discarded_at.present?,
       'owner' => user.as_json(only: %i[id name]),
       'scenario_ids' => scenarios.pluck(:scenario_id).sort
     )

--- a/app/views/multi_year_charts/_multi_year_chart_row.html.haml
+++ b/app/views/multi_year_charts/_multi_year_chart_row.html.haml
@@ -2,7 +2,7 @@
   - if multi_year_chart_row.discarded?
     %span.big-icon
       :plain
-        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="20" viewBox="0 0 256 256">
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="currentColor" stroke-width="20" viewBox="0 0 256 256">
           <polyline points="232 56 136 152 96 112 24 184" stroke-linecap="round" stroke-linejoin="round"></polyline>
           <polyline points="232 120 232 56 168 56" stroke-linecap="round" stroke-linejoin="round"></polyline>
         </svg>

--- a/app/views/multi_year_charts/_multi_year_chart_row.html.haml
+++ b/app/views/multi_year_charts/_multi_year_chart_row.html.haml
@@ -1,25 +1,29 @@
 .scenario-row{ class: multi_year_chart_row.discarded? ? 'discarded' : 'loadable' }
-  - if multi_year_chart_row.discarded?
-    %span.big-icon
-      :plain
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="currentColor" stroke-width="20" viewBox="0 0 256 256">
-          <polyline points="232 56 136 152 96 112 24 184" stroke-linecap="round" stroke-linejoin="round"></polyline>
-          <polyline points="232 120 232 56 168 56" stroke-linecap="round" stroke-linejoin="round"></polyline>
-        </svg>
   .scenario-info
-    %a.title{ href: myc_url(multi_year_chart_row), target:'_blank' }
-      = multi_year_chart_row.title
-      %span.fa.fa-external-link
-    %span.info
-      = t("areas.#{multi_year_chart_row.area_code}")
-      = multi_year_chart_row.end_year
-      - if current_user.id != multi_year_chart_row.user_id
-        %span.author
-          = t('scenario.by')
-          = multi_year_chart_row.user&.name
-    %span.last-updated
-      •
-      = t('multi_year_charts.created_at', date: distance_of_time_in_words_to_now(multi_year_chart_row.created_at))
+    .sub-row
+      %a.title{ href: myc_url(multi_year_chart_row), target:'_blank' }
+        = multi_year_chart_row.title
+        %span.fa.fa-external-link
+      - if multi_year_chart_row.discarded?
+        .type-tag
+          %span.type.icon
+            :plain
+              <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" fill="none" stroke="currentColor" stroke-width="20" viewBox="0 0 256 256">
+                <polyline points="232 56 136 152 96 112 24 184" stroke-linecap="round" stroke-linejoin="round"></polyline>
+                <polyline points="232 120 232 56 168 56" stroke-linecap="round" stroke-linejoin="round"></polyline>
+              </svg>
+          = t('multi_year_charts.transition_path')
+    .sub-row
+      %span.info
+        = t("areas.#{multi_year_chart_row.area_code}")
+        = multi_year_chart_row.end_year
+        - if current_user.id != multi_year_chart_row.user_id
+          %span.author
+            = t('scenario.by')
+            = multi_year_chart_row.user&.name
+      %span.last-updated
+        •
+        = t('multi_year_charts.created_at', date: distance_of_time_in_words_to_now(multi_year_chart_row.created_at))
   - if current_user.id == multi_year_chart_row.user_id
     .buttons
       - if multi_year_chart_row.discarded?

--- a/app/views/multi_year_charts/_multi_year_chart_row.html.haml
+++ b/app/views/multi_year_charts/_multi_year_chart_row.html.haml
@@ -1,4 +1,11 @@
-.scenario-row{ class: 'loadable' }
+.scenario-row{ class: multi_year_chart_row.discarded? ? 'discarded' : 'loadable' }
+  - if multi_year_chart_row.discarded?
+    %span.big-icon
+      :plain
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="20" viewBox="0 0 256 256">
+          <polyline points="232 56 136 152 96 112 24 184" stroke-linecap="round" stroke-linejoin="round"></polyline>
+          <polyline points="232 120 232 56 168 56" stroke-linecap="round" stroke-linejoin="round"></polyline>
+        </svg>
   .scenario-info
     %a.title{ href: myc_url(multi_year_chart_row), target:'_blank' }
       = multi_year_chart_row.title
@@ -13,3 +20,14 @@
     %span.last-updated
       •
       = t('multi_year_charts.created_at', date: distance_of_time_in_words_to_now(multi_year_chart_row.created_at))
+  - if current_user.id == multi_year_chart_row.user_id
+    .buttons
+      - if multi_year_chart_row.discarded?
+        = link_to t('restore'), undiscard_multi_year_chart_path(multi_year_chart_row), method: :put, class: 'button compare'
+        = link_to t('delete_permanently'), multi_year_chart_path(multi_year_chart_row), method: :delete, class: 'button compare destroy'
+      - else
+        = link_to discard_multi_year_chart_path(multi_year_chart_row), method: :put, class: 'discard tooltip', title: t('delete') do
+          :plain
+            <svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            </svg>

--- a/app/views/multi_year_charts/list.html.haml
+++ b/app/views/multi_year_charts/list.html.haml
@@ -1,8 +1,13 @@
 - content_for(:page_title) { "#{t('multi_year_charts.title')} - #{t('meta.name')}" }
 
+-# We'll render the flash in this view, so suppress doing so in the layout.
+- content_for(:flash) do
+  %span
+
 .background_wrapper#saved_scenario
   .scenario_wrapper#index
     = render partial: 'saved_scenarios/scenario_list_tabs', locals: { active_tab: :my_myc }
+    = render partial: 'saved_scenarios/flash_notice'
 
     - if @multi_year_charts.any?
       = render partial: 'multi_year_chart_row', collection: @multi_year_charts

--- a/app/views/saved_scenarios/_discarded_row.html.haml
+++ b/app/views/saved_scenarios/_discarded_row.html.haml
@@ -1,0 +1,4 @@
+- if discarded_row.is_a? MultiYearChart
+    = render partial: 'multi_year_charts/multi_year_chart_row', locals: {multi_year_chart_row: discarded_row}
+- else
+    = render partial: 'scenario_row', locals: {scenario_row: discarded_row}

--- a/app/views/saved_scenarios/_scenario_list_tabs.html.haml
+++ b/app/views/saved_scenarios/_scenario_list_tabs.html.haml
@@ -5,7 +5,7 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
       </svg>
     %span.name= t('header.load_scenario')
-  %a.tab.myc{ href: multi_year_charts_list_path, class: active_tab == :my_myc ? 'active' : '' }
+  %a.tab.myc{ href: list_multi_year_charts_path, class: active_tab == :my_myc ? 'active' : '' }
     :plain
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="20" viewBox="0 0 256 256">
         <polyline points="232 56 136 152 96 112 24 184" stroke-linecap="round" stroke-linejoin="round"></polyline>
@@ -18,7 +18,7 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
       </svg>
     %span.name= t('trash')
-    = tab_count(current_user.saved_scenarios.discarded.count, class: 'red')
+    = tab_count(current_user.saved_scenarios.discarded.count + current_user.multi_year_charts.discarded.count, class: 'red')
   - if current_user.admin?
     %a.tab{ href: all_saved_scenarios_path, class: active_tab == :all_scenarios ? 'active' : '' }
       :plain

--- a/app/views/saved_scenarios/_scenario_row.html.haml
+++ b/app/views/saved_scenarios/_scenario_row.html.haml
@@ -1,7 +1,10 @@
 .scenario-row{ class: classes_for_scenario_row(scenario_row) }
-  -# - unless scenario_row.discarded?
-  -#   .check
-  -#     = check_box_tag 'scenario_ids[]', scenario_row.scenario_id, false, disabled: !scenario_row.loadable?
+  - if scenario_row.discarded?
+    %span.big-icon
+      :plain
+        <svg style="transform: rotate(90deg);" height="24" width="24" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
+        </svg>
   .scenario-info
     - if scenario_row.loadable?
       %a.title{ href:"/saved_scenarios/#{scenario_row.id}" }

--- a/app/views/saved_scenarios/_scenario_row.html.haml
+++ b/app/views/saved_scenarios/_scenario_row.html.haml
@@ -1,33 +1,41 @@
 .scenario-row{ class: classes_for_scenario_row(scenario_row) }
-  - if scenario_row.discarded?
-    %span.big-icon
-      :plain
-        <svg style="transform: rotate(90deg);" height="20" width="20" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
-        </svg>
   .scenario-info
-    - if scenario_row.loadable?
-      %a.title{ href:"/saved_scenarios/#{scenario_row.id}" }
-        = scenario_row.localized_title(I18n.locale)
-      %span.info
-        = t("areas.#{scenario_row.area_code}")
-        = scenario_row.end_year
-    - else
-      %span.title.unavailable
-        = scenario_row.localized_title(I18n.locale)
-      %span.info.unavailable
-        %code= scenario_row.area_code
-        (#{t('scenario.area_not_exists')})
-        = scenario_row.end_year
-    - if current_user.id != scenario_row.user_id
-      %span.author
-        = t('scenario.by')
-        = scenario_row.user&.name
-    %span.last-updated
-      •
-      = t('last_updated_ago', when: time_ago_in_words(scenario_row.updated_at))
-    - if scenario_row.featured?
-      %span.featured.tooltip{ title: t('scenario.featured_scenario')} &#9733;
+    .sub-row
+      - if scenario_row.loadable?
+        %a.title{ href:"/saved_scenarios/#{scenario_row.id}" }
+          = scenario_row.localized_title(I18n.locale)
+        - if scenario_row.discarded?
+          .type-tag
+            %span.type.icon
+              :plain
+                <svg style="transform: rotate(90deg);" height="13" width="13" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
+                </svg>
+            = t('scenario.scenario')
+      - else
+        %span.title.unavailable
+          = scenario_row.localized_title(I18n.locale)
+
+    .sub-row
+      - if scenario_row.loadable?
+        %span.info
+          = t("areas.#{scenario_row.area_code}")
+          = scenario_row.end_year
+      - else
+        %span.info.unavailable
+          %code= scenario_row.area_code
+          (#{t('scenario.area_not_exists')})
+          = scenario_row.end_year
+      - if current_user.id != scenario_row.user_id
+        %span.author
+          = t('scenario.by')
+          = scenario_row.user&.name
+      %span.last-updated
+        •
+        = t('last_updated_ago', when: time_ago_in_words(scenario_row.updated_at))
+      - if scenario_row.featured?
+        %span.featured.tooltip{ title: t('scenario.featured_scenario')} &#9733;
+
   - if current_user.id == scenario_row.user_id
     .buttons
       - if scenario_row.discarded?

--- a/app/views/saved_scenarios/_scenario_row.html.haml
+++ b/app/views/saved_scenarios/_scenario_row.html.haml
@@ -2,7 +2,7 @@
   - if scenario_row.discarded?
     %span.big-icon
       :plain
-        <svg style="transform: rotate(90deg);" height="24" width="24" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <svg style="transform: rotate(90deg);" height="20" width="20" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
         </svg>
   .scenario-info

--- a/app/views/saved_scenarios/discarded.html.haml
+++ b/app/views/saved_scenarios/discarded.html.haml
@@ -9,16 +9,15 @@
     = render partial: 'scenario_list_tabs', locals: { active_tab: :trash }
     = render partial: 'flash_notice'
 
-    - if @saved_scenarios.any?
+    - if @discarded_scenarios.any?
       .trash-notice
         :plain
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
           </svg>
         = t('scenario.trash.notice', deleted_after: SavedScenario::AUTO_DELETES_AFTER.in_days.to_i)
-
-      = render partial: 'scenario_row', collection: @saved_scenarios
-      = paginate @saved_scenarios
+      = render partial: 'discarded_row', collection: @discarded_scenarios
+      = paginate @discarded_scenarios
     - else
       .empty-state
         %h4= t('scenario.trash.empty.title')

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -269,6 +269,7 @@ en:
     save_desc_asmany: "You can save as many scenarios as you want. "
     save_first: "Do you want to save your scenario first?"
     saved: "Saved Scenarios"
+    scenario: Scenario
     title: "Title"
     cannot_load: Sorry, your scenario could not be loaded.
     privacy:

--- a/config/locales/en_multi_year_charts.yml
+++ b/config/locales/en_multi_year_charts.yml
@@ -21,6 +21,7 @@ en:
     resume: Resume an existing session
     start: Start a new session
     title: Transition Paths
+    transition_path: Transition Path
     my_myc: My Transition Paths
     description: |
       Explore the possible transition paths to a scenario for 2050 and discover

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -270,6 +270,7 @@ nl:
     save_desc_asmany: "Je kunt zoveel scenarios opslaan als je wilt. "
     save_first: "Wil je je huidige scenario eerst opslaan?"
     saved: "Opgeslagen Scenario's"
+    scenario: Scenario
     title: "Titel"
     cannot_load: Sorry, jouw scenario kan niet worden geladen.
     privacy:

--- a/config/locales/nl_multi_year_charts.yml
+++ b/config/locales/nl_multi_year_charts.yml
@@ -22,6 +22,7 @@ nl:
     resume: Ga door met een bestaande sessie
     start: Start een nieuwe sessie
     title: Transitiepaden
+    transition_path: Transitiepad
     my_myc: Mijn Transitiepaden
     description: |
       Verken de mogelijke transitiepaden naar een 2050 toekomstbeeld en ontdek

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,8 +139,17 @@ Rails.application.routes.draw do
   get '/local-global' => 'compare#index', as: :local_global
   get '/local-global/:ids' => 'compare#show', as: :local_global_scenarios
 
-  resources :multi_year_charts, only: %i[index create destroy]
-  get '/multi_year_charts/list' => 'multi_year_charts#list'
+  resources :multi_year_charts, except: %i[new show edit update] do
+    member do
+      put :discard
+      put :undiscard
+    end
+
+    collection do
+      get :discarded
+      get :list
+    end
+  end
 
   get '/import_esdl'  => 'import_esdl#index'
   post '/import_esdl/create' => 'import_esdl#create', as: :import_esdl_create

--- a/db/migrate/20230321133548_add_discarde_at_to_multi_year_charts.rb
+++ b/db/migrate/20230321133548_add_discarde_at_to_multi_year_charts.rb
@@ -1,0 +1,6 @@
+class AddDiscardeAtToMultiYearCharts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :multi_year_charts, :discarded_at, :datetime
+    add_index :multi_year_charts, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_20_152312) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_21_133548) do
   create_table "area_dependencies", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "dependent_on"
     t.text "description"
@@ -71,6 +71,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_20_152312) do
     t.string "area_code", null: false
     t.integer "end_year", null: false
     t.datetime "created_at", precision: nil, null: false
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_multi_year_charts_on_discarded_at"
     t.index ["user_id"], name: "index_multi_year_charts_on_user_id"
   end
 
@@ -133,7 +135,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_20_152312) do
     t.index ["key"], name: "index_translations_on_key"
   end
 
-  create_table "users", id: :bigint, default: nil, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "users", id: :bigint, default: nil, charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/lib/tasks/cron.rake
+++ b/lib/tasks/cron.rake
@@ -4,5 +4,6 @@ namespace :cron do
   # Removes scenarios which were discarded some time ago.
   task delete_discarded_scenarios: :environment do
     SavedScenario.destroy_old_discarded!
+    MultiYearChart.destroy_old_discarded!
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe Ability do
     it 'may not destroy a saved scenario' do
       expect(ability).not_to be_able_to(:destroy, create(:saved_scenario))
     end
+
+    it 'may not destroy a multi year chart' do
+      expect(ability).not_to be_able_to(:destroy, create(:saved_scenario))
+    end
   end
 
   context 'when a user' do
@@ -67,6 +71,14 @@ RSpec.describe Ability do
 
     it 'may not destroy someone elses saved scenario' do
       expect(ability).not_to be_able_to(:destroy, create(:saved_scenario, user: create(:user)))
+    end
+
+    it 'may destroy their own multi year chart' do
+      expect(ability).to be_able_to(:destroy, create(:multi_year_chart, user:))
+    end
+
+    it 'may not destroy someone elses multi year chart' do
+      expect(ability).not_to be_able_to(:destroy, create(:multi_year_chart, user: create(:user)))
     end
   end
 end

--- a/spec/models/multi_year_chart_spec.rb
+++ b/spec/models/multi_year_chart_spec.rb
@@ -3,5 +3,43 @@
 require 'rails_helper'
 
 RSpec.describe MultiYearChart, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '.destroy_old_discarded!' do
+    it 'does not destroy a myc which is not discarded' do
+      myc = FactoryBot.create(:multi_year_chart)
+
+      expect { described_class.destroy_old_discarded! }
+        .not_to change { described_class.exists?(myc.id) }
+        .from(true)
+    end
+
+    it 'does not destroy a recently discarded myc' do
+      myc = FactoryBot.create(:multi_year_chart, discarded_at: Time.zone.now)
+
+      expect { described_class.destroy_old_discarded! }
+        .not_to change { described_class.exists?(myc.id) }
+        .from(true)
+    end
+
+    it 'does not delete a discarded myc on the threshold of being old' do
+      myc = FactoryBot.create(
+        :multi_year_chart,
+        discarded_at: (MultiYearChart::AUTO_DELETES_AFTER - 10.seconds).ago
+      )
+
+      expect { described_class.destroy_old_discarded! }
+        .not_to change { described_class.exists?(myc.id) }
+        .from(true)
+    end
+
+    it 'destroys an old discarded myc' do
+      myc = FactoryBot.create(
+        :multi_year_chart,
+        discarded_at: (MultiYearChart::AUTO_DELETES_AFTER + 10.seconds).ago
+      )
+
+      expect { described_class.destroy_old_discarded! }
+        .to change { described_class.exists?(myc.id) }
+        .from(true).to(false)
+    end
+  end
 end


### PR DESCRIPTION
The same discard functionality we have for saved scenarios is now also available for multi year charts.

Two questions remain open:
- Do we want to add a discard option to the API? Or keep just keep the hard delete like we have now?
- Do we want to show in the MYC app that this scenario is in the trash? This could be quite some work.

An impression of the trash can, which is now shared between scenarios and TP's:

![Screenshot 2023-03-24 at 14 22 48](https://user-images.githubusercontent.com/14875123/227544017-594fd4d0-32d3-4948-8504-3fb2a65e95dd.png)

---

Closes #4084 