### PR TITLE
Filter featured scenarios on homepage

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -31,3 +31,4 @@
 //= require load_pico_embed
 //= require copy_link_box
 //= require header
+//= require featured_scenario

--- a/app/assets/javascripts/featured_scenario.js
+++ b/app/assets/javascripts/featured_scenario.js
@@ -1,0 +1,97 @@
+/* globals $ App Backbone I18n */
+(function (window) {
+    var ScenarioEndYearView = Backbone.View.extend({
+      events: {
+        'click a': 'onClickItem',
+      },
+
+      constructor: function () {
+        Backbone.View.apply(this, arguments);
+
+        this.yearList = this.options.yearList;
+        this.hideAll = this.options.hideAll;
+        this.isFirstElem = this.options.firstElem;
+      },
+
+      render: function() {
+        if (this.isFirstElem) {
+            this.toggle();
+        }
+      },
+
+      /**
+       * Event triggered when the user clicks one of the two tabs.
+       *
+       * @param {MouseEvent} event
+       */
+      toggle: function (event) {
+        event && event.preventDefault();
+
+        this.el.classList.add('active');
+        this.yearList.classList.add('show');
+      },
+
+
+      onClickItem: function () {
+        this.hideAll();
+        this.toggle();
+      },
+    });
+
+    var FeaturedScenarioView = Backbone.View.extend({
+      events: {
+      },
+
+      constructor: function () {
+        Backbone.View.apply(this, arguments);
+
+        this.yearLists = this.el.querySelectorAll('.scenario-list');
+      },
+
+      render: function () {
+        var scenarioList = this.scenarioList.bind(this);
+        var hideAll = this.hideAll.bind(this);
+        var firstElem = true;
+
+        this.el.querySelectorAll('.year-tabs .end-year-tab').forEach(function (element) {
+            new ScenarioEndYearView({
+                el: element,
+                yearList: scenarioList(element.getAttribute('year')),
+                hideAll: hideAll,
+                firstElem: firstElem,
+            }).render();
+
+            firstElem = false;
+        });
+
+
+      },
+
+      scenarioList: function (end_year) {
+        var found;
+        this.yearLists.forEach( function (element) {
+            if (element.getAttribute('year') == end_year) {
+                found = element;
+                // how to break when found?
+            }
+        });
+        return found;
+      },
+
+      hideAll: function () {
+        this.el.querySelectorAll('.year-tabs .end-year-tab').forEach( function (element) {
+            element.classList.remove('active');
+        });
+        this.yearLists.forEach( function (element) {
+            element.classList.remove('show');
+        });
+      },
+    });
+
+    $(function () {
+      new FeaturedScenarioView({ el: document.querySelector('#preset-scenario') }).render();
+    });
+
+    window.ScenarioEndYearView = ScenarioEndYearView;
+    window.FeaturedScenarioView = FeaturedScenarioView;
+  })(window);

--- a/app/assets/stylesheets/_root.sass
+++ b/app/assets/stylesheets/_root.sass
@@ -348,11 +348,42 @@ body#root
 
     .hint
       color: $landing-grey
+      margin: 1.5rem 0
+
+    .year-tabs
+      display: flex
+      border-bottom: solid 1px $landing-border-color
+      .end-year-tab
+        border: 1px solid $landing-border-color
+        border-bottom: none
+        border-radius: 3px 3px 0 0
+        font-size: .875rem
+        padding: 5px 13px
+
+        a
+          color: $landing-grey
+          &:hover
+            text-decoration: none
+            cursor: pointer
+            color: #666
+        &.active
+          border-top: solid 2px $landing-green
+          margin-bottom: -1px
+          background: white
+          a
+            color: #333
+          &:hover
+            cursor: default
+        &:first-child
+          margin-left: 5px
 
     ul.scenario-list
       list-style: none
       margin: 20px -20px 0
       padding: 0
+      display: none
+      &.show
+        display: block
 
       li.title
         font-weight: 500

--- a/app/assets/stylesheets/_root.sass
+++ b/app/assets/stylesheets/_root.sass
@@ -345,6 +345,11 @@ body#root
 
   #preset-scenario
     border-top-color: $landing-gold
+    .header-container a
+      color: $landing-grey
+      text-decoration: underline
+      &:hover
+        color: $landing-blue
 
     .hint
       color: $landing-grey
@@ -353,6 +358,7 @@ body#root
     .year-tabs
       display: flex
       border-bottom: solid 1px $landing-border-color
+      margin-bottom: 5px
       .end-year-tab
         border: 1px solid $landing-border-color
         border-bottom: none
@@ -367,7 +373,7 @@ body#root
             cursor: pointer
             color: #666
         &.active
-          border-top: solid 2px $landing-green
+          border-top: solid 2px $landing-grey
           margin-bottom: -1px
           background: white
           a
@@ -379,11 +385,17 @@ body#root
 
     ul.scenario-list
       list-style: none
-      margin: 20px -20px 0
+      margin: 0 -20px 0
       padding: 0
-      display: none
+      // display: none
+      transition: opacity 1s ease-out
+      opacity: 0
+      height: 0
+      overflow: hidden
       &.show
-        display: block
+        // display: block
+        opacity: 1
+        height: auto
 
       li.title
         font-weight: 500
@@ -411,6 +423,11 @@ body#root
         font-size: 13px
         line-height: 1
         margin-left: 6px
+
+      span.last_updated
+        margin-left: auto
+        color: darken($landing-background-color, 18%)
+        font-size: 0.75rem
 
   #legal
     border-top: 1px solid $landing-border-color

--- a/app/assets/stylesheets/_root.sass
+++ b/app/assets/stylesheets/_root.sass
@@ -346,6 +346,9 @@ body#root
   #preset-scenario
     border-top-color: $landing-gold
 
+    .hint
+      color: $landing-grey
+
     ul.scenario-list
       list-style: none
       margin: 20px -20px 0

--- a/app/models/featured_scenario.rb
+++ b/app/models/featured_scenario.rb
@@ -60,6 +60,15 @@ class FeaturedScenario < ApplicationRecord
     end.flatten.compact
   end
 
+  def self.in_groups_per_end_year(featured_scenarios, groups=SORTABLE_GROUPS)
+    scenarios = featured_scenarios.group_by(&:end_year)
+    scenarios.each do |end_year, year_scenarios|
+      scenarios[end_year] = FeaturedScenario.in_groups(year_scenarios, groups)
+    end
+
+    scenarios
+  end
+
   def localized_title(locale)
     (locale == :nl ? title_nl : title_en) || saved_scenario.title
   end

--- a/app/models/featured_scenario.rb
+++ b/app/models/featured_scenario.rb
@@ -14,7 +14,7 @@ class FeaturedScenario < ApplicationRecord
   validates :description_en, :description_nl, :title_en, :title_nl, presence: true
   validates :group, inclusion: GROUPS
 
-  delegate :area_code, :end_year, :scenario_id, to: :saved_scenario
+  delegate :area_code, :end_year, :scenario_id, :updated_at, to: :saved_scenario
 
   # Public: Given an array of scenarios, an array of display groups, groups the
   # scenarios according to their display_group, in the order specified in the

--- a/app/views/pages/root_page/_preset_scenario.html.haml
+++ b/app/views/pages/root_page/_preset_scenario.html.haml
@@ -2,9 +2,15 @@
   .header-container
     %h4== #{t('intro.load_a_scenario')}
     = link_to "#{t('header.load_scenario')} →", saved_scenarios_path
-    - grouped = FeaturedScenario.in_groups(FeaturedScenario.includes(:saved_scenario))
+    - year_grouped = FeaturedScenario.in_groups_per_end_year(FeaturedScenario.includes(:saved_scenario))
   %p.hint
     = t('intro.about_featured_scenarios')
-  %ul.scenario-list
-    - grouped.each do |data|
-      = render partial: 'pages/root_page/scenario_group', locals: { group: data[:name], scenarios: data[:scenarios] }
+
+  .year-tabs
+    - year_grouped.keys.sort.each do |year|
+      .end-year-tab{year: year}
+        %a= year
+  - year_grouped.each do |year, grouped|
+    %ul.scenario-list{year: year}
+      - grouped.each do |data|
+        = render partial: 'pages/root_page/scenario_group', locals: { group: data[:name], scenarios: data[:scenarios] }

--- a/app/views/pages/root_page/_preset_scenario.html.haml
+++ b/app/views/pages/root_page/_preset_scenario.html.haml
@@ -3,7 +3,8 @@
     %h4== #{t('intro.load_a_scenario')}
     = link_to "#{t('header.load_scenario')} →", saved_scenarios_path
     - grouped = FeaturedScenario.in_groups(FeaturedScenario.includes(:saved_scenario))
-
+  %p.hint
+    = t('intro.about_featured_scenarios')
   %ul.scenario-list
     - grouped.each do |data|
       = render partial: 'pages/root_page/scenario_group', locals: { group: data[:name], scenarios: data[:scenarios] }

--- a/app/views/pages/root_page/_scenario_group.haml
+++ b/app/views/pages/root_page/_scenario_group.haml
@@ -12,7 +12,11 @@
 
         %span.who= format_subscripts(main_title)
         %span.org= org.html_safe
+
+        %span.last_updated= t('last_updated_ago', when: time_ago_in_words(scenario.updated_at))
   - else
     %li
       = link_to saved_scenario_path(scenario.saved_scenario) do
         = format_subscripts(title)
+
+        %span.last_updated= t('last_updated_ago', when: time_ago_in_words(scenario.updated_at))

--- a/config/locales/en_intro.yml
+++ b/config/locales/en_intro.yml
@@ -13,6 +13,9 @@ en:
       Is the region you are interested in not in the list? Please
       <a href='https://energytransitionmodel.com/contact'>contact Quintel</a>,
       the developers of the ETM, for support.
+    about_featured_scenarios: |
+      Here you can find a list of featured scenarios published by other parties. Explore them
+      by opening them, or use them as a basis for your own scenario.
     whats_new:
       title: What's new?
       description: |

--- a/config/locales/nl_intro.yml
+++ b/config/locales/nl_intro.yml
@@ -5,7 +5,7 @@ nl:
     your_current_scenario: "Jouw huidige scenario"
     root_text: |
       Met het Energietransitiemodel (ETM) kun je mogelijke toekomstige energiesystemen voor jouw
-      land, regio of gemeente verkennen. Kies een gebied en toekomstjaar om jouw eigen energiescenario 
+      land, regio of gemeente verkennen. Kies een gebied en toekomstjaar om jouw eigen energiescenario
       te starten!
     help_html: |
       Een nieuw scenario kan je starten door één van de beschikbare gebieden
@@ -13,6 +13,9 @@ nl:
       is beschikbaar voor verschillende geografische niveaus. Staat het gebied waarin
       je geïnteresseerd bent niet in de lijst? Neem dan contact op met
       <a href='https://energytransitionmodel.com/contact'>Quintel</a>, de makers van het ETM.
+    about_featured_scenarios: |
+      Hieronder vind je een lijst van uitgelichte scenario's gepubliceerd door verschillende
+      partijen. Ga op onderzoek uit door ze te openen, of gebruik ze als basis voor je eigen sceanrio.
     whats_new:
       title: Laatste updates
       description: |

--- a/spec/models/featured_scenario_spec.rb
+++ b/spec/models/featured_scenario_spec.rb
@@ -101,4 +101,58 @@ describe FeaturedScenario do
       expect(ordered[5][:scenarios]).to eq(group_nil)
     end
   end
+
+  describe '.in_groups_per_end_year' do
+    let(:defaults) { { group: nil, title: nil } }
+
+    let(:scenario_2050) { FactoryBot.build(:saved_scenario, end_year: 2050) }
+    let(:scenario_2030) { FactoryBot.build(:saved_scenario, end_year: 2030) }
+
+    let(:group_one) do
+      [
+        FactoryBot.build(:featured_scenario, group: 'one', title_en: 'A', saved_scenario: scenario_2030),
+        FactoryBot.build(:featured_scenario, group: 'one', title_en: 'B', saved_scenario: scenario_2030),
+        FactoryBot.build(:featured_scenario, group: 'one', title_en: 'C', saved_scenario: scenario_2050)
+      ]
+    end
+
+    let(:group_two) do
+      [
+        FactoryBot.build(:featured_scenario, group: 'two', saved_scenario: scenario_2030),
+        FactoryBot.build(:featured_scenario, group: 'two', saved_scenario: scenario_2050)
+      ]
+    end
+
+    let(:unsorted) do
+      [
+        group_one[2],
+        group_two[1],
+        group_one[0],
+        group_two[0],
+        group_one[1]
+      ]
+    end
+
+    let(:order) { ['one', 'two', :rest, nil] }
+
+    let(:ordered) { described_class.in_groups_per_end_year(unsorted, order) }
+
+    describe 'the 2030 group' do
+      it 'has scenarios which belong to the "one" group' do
+        expect(ordered[2030][0][:scenarios][0]).to be(group_one[0])
+      end
+      it 'has scenarios which belong to the "two" group' do
+        expect(ordered[2030][1][:scenarios][0]).to be(group_two[0])
+      end
+    end
+
+    describe 'the 2050 group' do
+      it 'has scenarios which belong to the "one" group' do
+        expect(ordered[2050][0][:scenarios][0]).to be(group_one[2])
+      end
+      it 'has scenarios which belong to the "two" group' do
+        expect(ordered[2050][1][:scenarios][0]).to be(group_two[1])
+      end
+    end
+  end
 end


### PR DESCRIPTION
To accommodate for the upcoming 16 II3050 scenarios that will be featured we need a filter on the homepage for it no to become a mess.

I quickly made a filter for end years, as it was a simple and easy way to make the lists a bit shorter.
![Screenshot 2023-04-04 at 15 30 15](https://user-images.githubusercontent.com/14875123/229811843-fff5e3de-b1dd-4973-922a-845011e1aa92.png)

A tab will be automatically created for each new end year that is featured.

I also included a 'last updated at' so our users (and we) can keep track of the up-to-dateness of the featured scenarios. But we can also leave that if you like.

There is now a small introduction to go above the tabs. If one of you could review this text that would be great, you can find it here:
- [English](https://github.com/quintel/etmodel/blob/c2d47ec4d73438545e07a3c0c27601b187e68789/config/locales/en_intro.yml#L16-L18)
- [Dutch](https://github.com/quintel/etmodel/blob/c2d47ec4d73438545e07a3c0c27601b187e68789/config/locales/nl_intro.yml#L16-L18)