### PR TITLE
Adding missing translations in 'profitability of dispatchable power plants' table

### DIFF
--- a/app/assets/javascripts/lib/views/plant_profitability_table_view.coffee
+++ b/app/assets/javascripts/lib/views/plant_profitability_table_view.coffee
@@ -68,7 +68,6 @@ class @PlantProfitabilityTableView extends HtmlTableChartView
     energy_power_engine_network_gas: 'gas_engine'
     energy_power_turbine_network_gas: 'gas_turbine'
     energy_power_ultra_supercritical_lignite: 'lignite'
-    energy_chp_ultra_supercritical_lignite: 'lignite_chp'
     energy_power_ultra_supercritical_oxyfuel_ccs_lignite: 'lignite_oxy'
     energy_power_supercritical_waste_mix: 'energy_power_supercritical_waste_mix'
     energy_power_supercritical_ccs_waste_mix: 'energy_power_supercritical_ccs_waste_mix'
@@ -87,6 +86,8 @@ class @PlantProfitabilityTableView extends HtmlTableChartView
     energy_power_turbine_hydrogen: 'hydrogen_turbine'
     energy_chp_local_wood_pellets: 'local_chp_wood'
     energy_chp_local_engine_network_gas: 'local_chp_gas'
+    energy_power_hydro_mountain: 'hydro_mountain'
+    industry_chp_turbine_hydrogen: 'industry_chp_hydrogen_turbine'
 
   # Sort by two fields
   #

--- a/config/locales/interface/output_elements/labels_groups/en_tables.yml
+++ b/config/locales/interface/output_elements/labels_groups/en_tables.yml
@@ -1,4 +1,5 @@
 en:
+
   output_elements:
     tables:
       capacity:
@@ -58,6 +59,7 @@ en:
         industry_chp_gas_engine: "Industry gas CHP (combustion engine)"
         industry_chp_hydrogen_turbine: "Industry hydrogen CHP (turbine)"
         industry_chp_turbine_hydrogen: "Industry hydrogen CHP (turbine)"
+        industry_chp_wood: "Industry wood pellet CHP"
         lignite: "Lignite"
         lignite_chp: "Lignite CHP"
         lignite_oxy: "Lignite Oxyfuel CCS"

--- a/config/locales/interface/output_elements/labels_groups/en_tables.yml
+++ b/config/locales/interface/output_elements/labels_groups/en_tables.yml
@@ -1,5 +1,4 @@
 en:
-
   output_elements:
     tables:
       capacity:

--- a/config/locales/interface/output_elements/labels_groups/en_tables.yml
+++ b/config/locales/interface/output_elements/labels_groups/en_tables.yml
@@ -58,7 +58,7 @@ en:
         industry_chp_gas_engine: "Industry gas CHP (combustion engine)"
         industry_chp_hydrogen_turbine: "Industry hydrogen CHP (turbine)"
         industry_chp_turbine_hydrogen: "Industry hydrogen CHP (turbine)"
-        industry_chp_wood: "Industry wood pellet CHP"
+        industry_chp_wood: "Industry biomass CHP"
         lignite: "Lignite"
         lignite_chp: "Lignite CHP"
         lignite_oxy: "Lignite Oxyfuel CCS"
@@ -132,7 +132,7 @@ en:
         industry_chp_turbine_gas_power_fuelmix: "Industry gas turbine CHP"
         industry_chp_ultra_supercritical_coal: "Industry coal CHP"
         industry_chp_turbine_hydrogen: "Industry hydrogen CHP (turbine)"
-        industry_chp_wood_pellets: "Industry wood pellet CHP"
+        industry_chp_wood_pellets: "Industry biomass CHP"
       investments:
         agriculture: "Agriculture"
         bln_euro: "BLN. EURO"

--- a/config/locales/interface/output_elements/labels_groups/nl_tables.yml
+++ b/config/locales/interface/output_elements/labels_groups/nl_tables.yml
@@ -66,7 +66,7 @@ nl:
         nuclear_iii: "Kern 3e Gen"
         nuclear_smr: "Kern kleine modulaire reactor"
         oil_chp: "Olie-WKK"
-        oil_plant: "Olie ultrasupercritisch"
+        oil_plant: "Olie ultrasuperkritisch"
         offshore_wind_turbines: "Wind op zee"
         onshore_wind_turbines: "Wind op land"
         operating_costs: "Marginale kosten"
@@ -109,6 +109,7 @@ nl:
         local_chp_gas: "Gasmotor-WKK (kleinschalig)"
         local_chp_wood: "Biomassa-WKK (kleinschalig)"
         local_chp_biogas: "Biogas-WKK (must-run)"
+        industry_chp_wood: "Industriële biomassa-WKK"
       power_plants:
         capacity: "Geïnstalleerd vermogen"
         investment: "Investering"
@@ -140,7 +141,7 @@ nl:
         industry_chp_turbine_gas_power_fuelmix: "Industriële gas-WKK (turbine)"
         industry_chp_ultra_supercritical_coal: "Industriële kolen-WKK"
         industry_chp_turbine_hydrogen: "Industriële waterstof-WKK (turbine)"
-        industry_chp_wood_pellets: "Industriële houtpellet-WKK"
+        industry_chp_wood_pellets: "Industriële biomassa-WKK"
       investments:
         agriculture: "Landbouw"
         bln_euro: "MLD. EURO"


### PR DESCRIPTION
![afbeelding](https://user-images.githubusercontent.com/74194356/232478150-1bfa08f2-8b19-42fb-8392-d6066ca61c2b.png)

Currently some translations are missing in the Profitability of dispatchable powerplant table. This PR resolves these missing translations.