### PR TITLE
Adjustable storage parameters

### DIFF
--- a/config/interface/input_elements/costs_flexibility_storage.yml
+++ b/config/interface/input_elements/costs_flexibility_storage.yml
@@ -1,34 +1,34 @@
 ---
 - key: investment_costs_households_flexibility_p2p_electricity
-  interface_group: costs
+  interface_group: investment_costs
   step_value: 1.0
   unit: "%"
   related_node: households_flexibility_p2p_electricity
   position: 100
   slide_key: costs_flexibility_storage
 - key: investment_costs_energy_flexibility_mv_batteries_electricity
-  interface_group: costs
+  interface_group: investment_costs
   step_value: 1.0
   unit: "%"
   related_node: energy_flexibility_mv_batteries_electricity
   position: 105
   slide_key: costs_flexibility_storage
 - key: investment_costs_energy_flexibility_hv_opac_electricity
-  interface_group: costs
+  interface_group: investment_costs
   step_value: 1.0
   unit: "%"
   related_node: energy_flexibility_hv_opac_electricity
   position: 110
   slide_key: costs_flexibility_storage
 - key: capacity_costs_energy_flexibility_flow_batteries_electricity
-  interface_group: costs
+  interface_group: investment_costs
   step_value: 1.0
   unit: "%"
   related_node: energy_flexibility_flow_batteries_electricity
   position: 115
   slide_key: costs_flexibility_storage
 - key: volume_costs_energy_flexibility_flow_batteries_electricity
-  interface_group: costs
+  interface_group: investment_costs
   step_value: 1.0
   unit: "%"
   related_node: energy_flexibility_flow_batteries_electricity
@@ -36,42 +36,43 @@
   slide_key: costs_flexibility_storage
 
 - key: efficiency_households_flexibility_p2p_electricity
-  interface_group: efficiency
+  interface_group: roundtrip_efficiency
   step_value: 1.0
   unit: "%"
   related_node: households_flexibility_p2p_electricity
   position: 200
   slide_key: costs_flexibility_storage
 - key: efficiency_transport_flexibility_p2p_electricity
-  interface_group: efficiency
+  interface_group: roundtrip_efficiency
   step_value: 1.0
   unit: "%"
   related_node: transport_car_flexibility_p2p_electricity
   position: 205
   slide_key: costs_flexibility_storage
 - key: efficiency_energy_flexibility_mv_batteries_electricity
-  interface_group: efficiency
+  interface_group: roundtrip_efficiency
   step_value: 1.0
   unit: "%"
   related_node: energy_flexibility_mv_batteries_electricity
   position: 210
   slide_key: costs_flexibility_storage
 - key: efficiency_energy_flexibility_pumped_storage_electricity
-  interface_group: efficiency
+  interface_group: roundtrip_efficiency
+  dependent_on: has_mountains
   step_value: 1.0
   unit: "%"
   related_node: energy_flexibility_pumped_storage_electricity
   position: 215
   slide_key: costs_flexibility_storage
 - key: efficiency_energy_flexibility_hv_opac_electricity
-  interface_group: efficiency
+  interface_group: roundtrip_efficiency
   step_value: 1.0
   unit: "%"
   related_node: energy_flexibility_hv_opac_electricity
   position: 220
   slide_key: costs_flexibility_storage
 - key: efficiency_energy_flexibility_flow_batteries_electricity
-  interface_group: efficiency
+  interface_group: roundtrip_efficiency
   step_value: 1.0
   unit: "%"
   related_node: energy_flexibility_flow_batteries_electricity

--- a/config/interface/input_elements/costs_flexibility_storage.yml
+++ b/config/interface/input_elements/costs_flexibility_storage.yml
@@ -1,28 +1,79 @@
 ---
 - key: investment_costs_households_flexibility_p2p_electricity
+  interface_group: costs
   step_value: 1.0
   unit: "%"
   related_node: households_flexibility_p2p_electricity
-  position: 1
-  slide_key: costs_flexibility_storage
-- key: investment_costs_energy_flexibility_hv_opac_electricity
-  step_value: 1.0
-  unit: "%"
-  position: 3
-  slide_key: costs_flexibility_storage
-- key: investment_costs_energy_flexibility_mv_batteries_electricity
-  step_value: 1.0
-  unit: "%"
-  position: 2
-  slide_key: costs_flexibility_storage
-- key: capacity_costs_energy_flexibility_flow_batteries_electricity
-  step_value: 1.0
-  unit: "%"
   position: 100
   slide_key: costs_flexibility_storage
-- key: volume_costs_energy_flexibility_flow_batteries_electricity
+- key: investment_costs_energy_flexibility_mv_batteries_electricity
+  interface_group: costs
   step_value: 1.0
   unit: "%"
+  related_node: energy_flexibility_mv_batteries_electricity
   position: 105
   slide_key: costs_flexibility_storage
+- key: investment_costs_energy_flexibility_hv_opac_electricity
+  interface_group: costs
+  step_value: 1.0
+  unit: "%"
+  related_node: energy_flexibility_hv_opac_electricity
+  position: 110
+  slide_key: costs_flexibility_storage
+- key: capacity_costs_energy_flexibility_flow_batteries_electricity
+  interface_group: costs
+  step_value: 1.0
+  unit: "%"
+  related_node: energy_flexibility_flow_batteries_electricity
+  position: 115
+  slide_key: costs_flexibility_storage
+- key: volume_costs_energy_flexibility_flow_batteries_electricity
+  interface_group: costs
+  step_value: 1.0
+  unit: "%"
+  related_node: energy_flexibility_flow_batteries_electricity
+  position: 115
+  slide_key: costs_flexibility_storage
 
+- key: efficiency_households_flexibility_p2p_electricity
+  interface_group: efficiency
+  step_value: 1.0
+  unit: "%"
+  related_node: households_flexibility_p2p_electricity
+  position: 200
+  slide_key: costs_flexibility_storage
+- key: efficiency_transport_flexibility_p2p_electricity
+  interface_group: efficiency
+  step_value: 1.0
+  unit: "%"
+  related_node: transport_car_flexibility_p2p_electricity
+  position: 205
+  slide_key: costs_flexibility_storage
+- key: efficiency_energy_flexibility_mv_batteries_electricity
+  interface_group: efficiency
+  step_value: 1.0
+  unit: "%"
+  related_node: energy_flexibility_mv_batteries_electricity
+  position: 210
+  slide_key: costs_flexibility_storage
+- key: efficiency_energy_flexibility_pumped_storage_electricity
+  interface_group: efficiency
+  step_value: 1.0
+  unit: "%"
+  related_node: energy_flexibility_pumped_storage_electricity
+  position: 215
+  slide_key: costs_flexibility_storage
+- key: efficiency_energy_flexibility_hv_opac_electricity
+  interface_group: efficiency
+  step_value: 1.0
+  unit: "%"
+  related_node: energy_flexibility_hv_opac_electricity
+  position: 220
+  slide_key: costs_flexibility_storage
+- key: efficiency_energy_flexibility_flow_batteries_electricity
+  interface_group: efficiency
+  step_value: 1.0
+  unit: "%"
+  related_node: energy_flexibility_flow_batteries_electricity
+  position: 225
+  slide_key: costs_flexibility_storage

--- a/config/interface/input_elements/flexibility_flexibility_power_storage.yml
+++ b/config/interface/input_elements/flexibility_flexibility_power_storage.yml
@@ -156,9 +156,19 @@
 - key: capacity_of_energy_flexibility_hv_opac_electricity
   step_value: 1.0
   unit: MW
-  interface_group: capacity
+  interface_group: technical_specifications
   related_node: energy_flexibility_hv_opac_electricity
   position: 40
+  slide_key: flexibility_power_storage_energy_flexibility_hv_opac_electricity
+  additional_specs:
+    other:
+      timeframe: i_h_d_w_s
+- key: volume_of_energy_flexibility_hv_opac_electricity
+  step_value: 1.0
+  unit: hour
+  interface_group: technical_specifications
+  related_node: energy_flexibility_hv_opac_electricity
+  position: 41
   slide_key: flexibility_power_storage_energy_flexibility_hv_opac_electricity
   additional_specs:
     other:
@@ -168,7 +178,7 @@
   unit: "€/MWh"
   interface_group: price_sensitive
   related_node: energy_flexibility_hv_opac_electricity
-  position: 41
+  position: 42
   slide_key: flexibility_power_storage_energy_flexibility_hv_opac_electricity
   additional_specs:
     other:
@@ -178,7 +188,7 @@
   unit: "€/MWh"
   interface_group: price_sensitive
   related_node: energy_flexibility_hv_opac_electricity
-  position: 42
+  position: 43
   slide_key: flexibility_power_storage_energy_flexibility_hv_opac_electricity
   additional_specs:
     other:
@@ -186,7 +196,7 @@
 - key: settings_enable_storage_optimisation_energy_flexibility_hv_opac_electricity
   step_value: 1.0
   unit: boolean
-  position: 43
+  position: 44
   interface_group: storage_optimisation
   slide_key: flexibility_power_storage_energy_flexibility_hv_opac_electricity
   config:

--- a/config/interface/input_elements/flexibility_flexibility_power_storage.yml
+++ b/config/interface/input_elements/flexibility_flexibility_power_storage.yml
@@ -54,9 +54,19 @@
 - key: transport_car_using_electricity_availability
   step_value: 0.1
   unit: "%"
-  interface_group: capacity
+  interface_group: technical_specifications_cars
   related_node: transport_car_flexibility_p2p_electricity
   position: 20
+  slide_key: flexibility_power_storage_transport_car_flexibility_p2p_electricity
+  additional_specs:
+    other:
+      timeframe: i_h_d_w
+- key: volume_of_transport_car_using_electricity
+  step_value: 0.1
+  unit: "hours"
+  interface_group: technical_specifications_cars
+  related_node: transport_car_flexibility_p2p_electricity
+  position: 21
   slide_key: flexibility_power_storage_transport_car_flexibility_p2p_electricity
   additional_specs:
     other:
@@ -64,9 +74,19 @@
 - key: transport_bus_using_electricity_availability
   step_value: 0.1
   unit: "%"
-  interface_group: capacity
+  interface_group: technical_specifications_buses
   related_node: transport_bus_flexibility_p2p_electricity
-  position: 21
+  position: 22
+  slide_key: flexibility_power_storage_transport_car_flexibility_p2p_electricity
+  additional_specs:
+    other:
+      timeframe: i_h_d_w
+- key: volume_of_transport_bus_using_electricity
+  step_value: 0.1
+  unit: "hours"
+  interface_group: technical_specifications_buses
+  related_node: transport_bus_flexibility_p2p_electricity
+  position: 23
   slide_key: flexibility_power_storage_transport_car_flexibility_p2p_electricity
   additional_specs:
     other:
@@ -74,9 +94,19 @@
 - key: transport_truck_using_electricity_availability
   step_value: 0.1
   unit: "%"
-  interface_group: capacity
+  interface_group: technical_specifications_trucks
   related_node: transport_truck_flexibility_p2p_electricity
-  position: 22
+  position: 24
+  slide_key: flexibility_power_storage_transport_car_flexibility_p2p_electricity
+  additional_specs:
+    other:
+      timeframe: i_h_d_w
+- key: volume_of_transport_truck_using_electricity
+  step_value: 0.1
+  unit: "hours"
+  interface_group: technical_specifications_trucks
+  related_node: transport_truck_flexibility_p2p_electricity
+  position: 25
   slide_key: flexibility_power_storage_transport_car_flexibility_p2p_electricity
   additional_specs:
     other:
@@ -84,9 +114,19 @@
 - key: transport_van_using_electricity_availability
   step_value: 0.1
   unit: "%"
-  interface_group: capacity
+  interface_group: technical_specifications_vans
   related_node: transport_van_flexibility_p2p_electricity
-  position: 23
+  position: 26
+  slide_key: flexibility_power_storage_transport_car_flexibility_p2p_electricity
+  additional_specs:
+    other:
+      timeframe: i_h_d_w
+- key: volume_of_transport_van_using_electricity
+  step_value: 0.1
+  unit: "hours"
+  interface_group: technical_specifications_vans
+  related_node: transport_van_flexibility_p2p_electricity
+  position: 27
   slide_key: flexibility_power_storage_transport_car_flexibility_p2p_electricity
   additional_specs:
     other:
@@ -96,7 +136,7 @@
   unit: "€/MWh"
   interface_group: price_sensitive
   related_node: transport_car_flexibility_p2p_electricity
-  position: 24
+  position: 28
   slide_key: flexibility_power_storage_transport_car_flexibility_p2p_electricity
   additional_specs:
     other:
@@ -106,7 +146,7 @@
   unit: "€/MWh"
   interface_group: price_sensitive
   related_node: transport_car_flexibility_p2p_electricity
-  position: 25
+  position: 29
   slide_key: flexibility_power_storage_transport_car_flexibility_p2p_electricity
   additional_specs:
     other:
@@ -114,7 +154,7 @@
 - key: settings_enable_storage_optimisation_transport_car_flexibility_p2p_electricity
   step_value: 1.0
   unit: boolean
-  position: 26
+  position: 30
   interface_group: storage_optimisation
   slide_key: flexibility_power_storage_transport_car_flexibility_p2p_electricity
   config:
@@ -174,7 +214,7 @@
     other:
       timeframe: i_h_d_w_s
 - key: volume_of_energy_flexibility_hv_opac_electricity
-  step_value: 1.0
+  step_value: 0.1
   unit: "hours"
   interface_group: technical_specifications
   related_node: energy_flexibility_hv_opac_electricity
@@ -226,7 +266,7 @@
     other:
       timeframe: i_h_d
 - key: volume_of_energy_flexibility_mv_batteries_electricity
-  step_value: 1.0
+  step_value: 0.1
   unit: "hours"
   interface_group: technical_specifications
   related_node: energy_flexibility_mv_batteries_electricity
@@ -270,7 +310,7 @@
 - key: capacity_of_energy_flexibility_flow_batteries_electricity
   step_value: 1.0
   unit: MW
-  interface_group: capacity
+  interface_group: technical_specifications
   related_node: energy_flexibility_flow_batteries_electricity
   position: 60
   slide_key: flexibility_power_storage_energy_flexibility_flow_batteries_electricity
@@ -280,7 +320,7 @@
 - key: volume_of_energy_flexibility_flow_batteries_electricity
   step_value: 0.1
   unit: "hours"
-  interface_group: volume
+  interface_group: technical_specifications
   related_node: energy_flexibility_flow_batteries_electricity
   position: 61
   slide_key: flexibility_power_storage_energy_flexibility_flow_batteries_electricity

--- a/config/interface/input_elements/flexibility_flexibility_power_storage.yml
+++ b/config/interface/input_elements/flexibility_flexibility_power_storage.yml
@@ -2,9 +2,19 @@
 - key: households_flexibility_p2p_electricity_market_penetration
   step_value: 0.1
   unit: "%"
-  interface_group: capacity
+  interface_group: technical_specifications
   related_node: households_flexibility_p2p_electricity
   position: 10
+  slide_key: flexibility_power_storage_households_flexibility_p2p_electricity
+  additional_specs:
+    other:
+      timeframe: i_h_d_w
+- key: volume_of_households_flexibility_p2p_electricity
+  step_value: 0.1
+  unit: "hours"
+  interface_group: technical_specifications
+  related_node: households_flexibility_p2p_electricity
+  position: 11
   slide_key: flexibility_power_storage_households_flexibility_p2p_electricity
   additional_specs:
     other:
@@ -14,7 +24,7 @@
   unit: "€/MWh"
   interface_group: price_sensitive
   related_node: households_flexibility_p2p_electricity
-  position: 11
+  position: 12
   slide_key: flexibility_power_storage_households_flexibility_p2p_electricity
   additional_specs:
     other:
@@ -24,7 +34,7 @@
   unit: "€/MWh"
   interface_group: price_sensitive
   related_node: households_flexibility_p2p_electricity
-  position: 12
+  position: 13
   slide_key: flexibility_power_storage_households_flexibility_p2p_electricity
   additional_specs:
     other:
@@ -33,7 +43,7 @@
   step_value: 1.0
   unit: boolean
   interface_group: storage_optimisation
-  position: 13
+  position: 14
   slide_key: flexibility_power_storage_households_flexibility_p2p_electricity
   config:
     when_true:
@@ -165,7 +175,7 @@
       timeframe: i_h_d_w_s
 - key: volume_of_energy_flexibility_hv_opac_electricity
   step_value: 1.0
-  unit: hour
+  unit: "hours"
   interface_group: technical_specifications
   related_node: energy_flexibility_hv_opac_electricity
   position: 41
@@ -208,9 +218,19 @@
 - key: capacity_of_energy_flexibility_mv_batteries_electricity
   step_value: 1.0
   unit: MW
-  interface_group: capacity
+  interface_group: technical_specifications
   related_node: energy_flexibility_mv_batteries_electricity
   position: 50
+  slide_key: flexibility_power_storage_energy_flexibility_mv_batteries_electricity
+  additional_specs:
+    other:
+      timeframe: i_h_d
+- key: volume_of_energy_flexibility_mv_batteries_electricity
+  step_value: 1.0
+  unit: "hours"
+  interface_group: technical_specifications
+  related_node: energy_flexibility_mv_batteries_electricity
+  position: 51
   slide_key: flexibility_power_storage_energy_flexibility_mv_batteries_electricity
   additional_specs:
     other:
@@ -220,7 +240,7 @@
   unit: "€/MWh"
   interface_group: price_sensitive
   related_node: energy_flexibility_mv_batteries_electricity
-  position: 51
+  position: 52
   slide_key: flexibility_power_storage_energy_flexibility_mv_batteries_electricity
   additional_specs:
     other:
@@ -230,7 +250,7 @@
   unit: "€/MWh"
   interface_group: price_sensitive
   related_node: energy_flexibility_mv_batteries_electricity
-  position: 52
+  position: 53
   slide_key: flexibility_power_storage_energy_flexibility_mv_batteries_electricity
   additional_specs:
     other:
@@ -238,7 +258,7 @@
 - key: settings_enable_storage_optimisation_energy_flexibility_mv_batteries_electricity
   step_value: 1.0
   unit: boolean
-  position: 53
+  position: 54
   interface_group: storage_optimisation
   slide_key: flexibility_power_storage_energy_flexibility_mv_batteries_electricity
   config:

--- a/config/interface/input_elements/flexibility_flexibility_power_storage.yml
+++ b/config/interface/input_elements/flexibility_flexibility_power_storage.yml
@@ -166,10 +166,20 @@
 - key: capacity_of_energy_flexibility_pumped_storage_electricity
   step_value: 1.0
   unit: MW
-  interface_group: capacity
+  interface_group: technical_specifications
   related_node: energy_flexibility_pumped_storage_electricity
   position: 30
   dependent_on: has_mountains
+  slide_key: flexibility_power_storage_energy_flexibility_pumped_storage_electricity
+  additional_specs:
+    other:
+      timeframe: i_h_d_w_s
+- key: volume_of_energy_flexibility_pumped_storage_electricity
+  step_value: 0.1
+  unit: "hours"
+  interface_group: technical_specifications
+  related_node: energy_flexibility_pumped_storage_electricity
+  position: 31
   slide_key: flexibility_power_storage_energy_flexibility_pumped_storage_electricity
   additional_specs:
     other:
@@ -180,7 +190,7 @@
   interface_group: price_sensitive
   dependent_on: has_mountains
   related_node: energy_flexibility_pumped_storage_electricity
-  position: 31
+  position: 32
   slide_key: flexibility_power_storage_energy_flexibility_pumped_storage_electricity
   additional_specs:
     other:
@@ -191,7 +201,7 @@
   dependent_on: has_mountains
   interface_group: price_sensitive
   related_node: energy_flexibility_pumped_storage_electricity
-  position: 32
+  position: 33
   slide_key: flexibility_power_storage_energy_flexibility_pumped_storage_electricity
   additional_specs:
     other:
@@ -199,7 +209,7 @@
 - key: settings_enable_storage_optimisation_energy_flexibility_pumped_storage_electricity
   step_value: 1.0
   unit: boolean
-  position: 33
+  position: 34
   interface_group: storage_optimisation
   slide_key: flexibility_power_storage_energy_flexibility_pumped_storage_electricity
 

--- a/config/interface/input_elements/flexibility_power_storage_solar_pv_solar_radiation.yml
+++ b/config/interface/input_elements/flexibility_power_storage_solar_pv_solar_radiation.yml
@@ -3,14 +3,24 @@
   step_value: 0.1
   unit: "%"
   interface_group: solar_pv_solar_radiation
-  position: 3
+  position: 100
   slide_key: flexibility_power_storage_solar_pv_solar_radiation
 - key: battery_capacity_always_on_solar_pv_solar_radiation
   step_value: 0.1
   unit: "%"
   interface_group: solar_pv_solar_radiation
   related_node: energy_flexibility_solar_batteries_electricity
-  position: 4
+  position: 200
+  slide_key: flexibility_power_storage_solar_pv_solar_radiation
+  additional_specs:
+    other:
+      timeframe: i_h_d
+- key: volume_of_energy_flexibility_solar_batteries_electricity
+  step_value: 0.1
+  unit: "hours"
+  interface_group: solar_pv_solar_radiation
+  related_node: energy_flexibility_solar_batteries_electricity
+  position: 300
   slide_key: flexibility_power_storage_solar_pv_solar_radiation
   additional_specs:
     other:

--- a/config/interface/input_elements/flexibility_power_storage_wind_turbine_inland.yml
+++ b/config/interface/input_elements/flexibility_power_storage_wind_turbine_inland.yml
@@ -3,14 +3,24 @@
   step_value: 0.1
   unit: "%"
   interface_group: wind_turbine_inland
-  position: 1
+  position: 100
   slide_key: flexibility_power_storage_wind_turbine_inland
 - key: battery_capacity_always_on_wind_turbine_inland
   step_value: 0.1
   unit: "%"
   interface_group: wind_turbine_inland
   related_node: energy_flexibility_wind_batteries_electricity
-  position: 2
+  position: 200
+  slide_key: flexibility_power_storage_wind_turbine_inland
+  additional_specs:
+    other:
+      timeframe: i_h_d
+- key: volume_of_energy_flexibility_wind_batteries_electricity
+  step_value: 0.1
+  unit: "hours"
+  interface_group: wind_turbine_inland
+  related_node: energy_flexibility_wind_batteries_electricity
+  position: 300
   slide_key: flexibility_power_storage_wind_turbine_inland
   additional_specs:
     other:

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -483,6 +483,7 @@ en:
     fertilizer_production_route: "Ammonia production route"
     must_run_chps: "Must-run capacity"
     flexible_chps: "Dispatchable capacity"
+    technical_specifications: "Technical specifications"
 
   "or": "or"
   "go": "go"

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -484,6 +484,10 @@ en:
     must_run_chps: "Must-run capacity"
     flexible_chps: "Dispatchable capacity"
     technical_specifications: "Technical specifications"
+    technical_specifications_cars: "Technical specifications cars"
+    technical_specifications_buses: "Technical specifications buses"
+    technical_specifications_trucks: "Technical specifications trucks"
+    technical_specifications_vans: "Technical specifications vans"
     investment_costs: "Investment costs"
     roundtrip_efficiency: "Round-trip efficiency"
 

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -484,6 +484,8 @@ en:
     must_run_chps: "Must-run capacity"
     flexible_chps: "Dispatchable capacity"
     technical_specifications: "Technical specifications"
+    investment_costs: "Investment costs"
+    roundtrip_efficiency: "Round-trip efficiency"
 
   "or": "or"
   "go": "go"

--- a/config/locales/interface/en_sidebar_items.yml
+++ b/config/locales/interface/en_sidebar_items.yml
@@ -103,7 +103,7 @@ en:
         to spend on other things.
     costs_flexibility:
       short_title: Flexibility
-      title: Flexibility costs
+      title: Flexibility
       short_description: ''
       description: ''
     costs_heat:

--- a/config/locales/interface/input_elements/en_costs.yml
+++ b/config/locales/interface/input_elements/en_costs.yml
@@ -372,21 +372,21 @@ en:
         waste-incinerator plants. Costs are compared to current costs.\r\n<br/>\r\n<br/>\r\nWaste-incinerators
         are often used to generate both heat and electricity."
     investment_costs_households_flexibility_p2p_electricity:
-      title: Investment costs household batteries
+      title: Batteries in households
       short_description:
       description: "Household batteries are often mentioned as a convenient way to
         store excess electricity such that you can use it at a later time. With <a
         href=\"/scenario/flexibility/flexibility_storage/storage-in-household-batteries\"
         >this slider</a> you can choose what percentage of all households should have
-        such a battery and with the above slider you can presumably set your assumption
+        such a battery and with the above slider you can set your assumption
         for the future change in investment costs of households batteries.\r\n</br>"
     investment_costs_energy_flexibility_hv_opac_electricity:
-      title: Investment costs underground pumped hydro storage
+      title: Underground pumped hydro storage
       short_description:
       description: This slider determines the future change in investment costs of
         underground hydro pumped storage.
     investment_costs_energy_flexibility_mv_batteries_electricity:
-      title: Investment costs large-scale batteries
+      title: Large-scale batteries
       short_description:
       description: |
         This slider determines the future change in investment costs large-scale
@@ -975,7 +975,7 @@ en:
       It is not possible to the absolute value of the future SCOP of air-source heat pumps with a slider as this is a result of hourly
       calculations based on the hourly outside temperature curve."
     capacity_costs_energy_flexibility_flow_batteries_electricity:
-      title: Investment costs per MW flow batteries
+      title: Flow batteries per MW
       short_decription: ''
       description: |
         In contrast to other batteries, the input capacity and storage volume of flowbatteries can 
@@ -986,7 +986,7 @@ en:
         Flexibility</a> section you can determine the installed capacity and relative storage volume 
         for your scenario.
     volume_costs_energy_flexibility_flow_batteries_electricity:
-      title: Investment costs per MWh flow batteries
+      title: Flow batteries per MWh
       short_decription: ''
       description: |
         In contrast to other batteries, the input capacity and storage volume of flowbatteries can 
@@ -1042,3 +1042,67 @@ en:
       short_description:
       description: |
         This slider sets the future efficiency of ammonia reformers.
+    efficiency_households_flexibility_p2p_electricity:
+      title: Batteries in households
+      short_description:
+      description: |
+        The round-trip efficiency is the ratio of the energy output compared to the energy 
+        input of a storage technology, taking into account losses incurred during charging 
+        and discharging. </br></br>
+        With this slider you can determine the future round-trip efficiency of 
+        <a href="/scenario/flexibility/flexibility_storage/batteries-in-households">
+        batteries in households</a>.
+    efficiency_transport_flexibility_p2p_electricity:
+      title: Batteries in electric vehicles
+      short_description:
+      description: |
+        The round-trip efficiency is the ratio of the energy output compared to the energy 
+        input of a storage technology, taking into account losses incurred during charging 
+        and discharging. </br></br>
+        With this slider you can determine the future round-trip efficiency of 
+        <a href="/scenario/flexibility/flexibility_storage/batteries-in-electric-vehicles">
+        batteries in electric vehicles</a>: cars, buses, trucks and vans.
+    efficiency_energy_flexibility_mv_batteries_electricity:
+      title: Large-scale batteries
+      short_description:
+      description: |
+        The round-trip efficiency is the ratio of the energy output compared to the energy 
+        input of a storage technology, taking into account losses incurred during charging 
+        and discharging. </br></br>
+        With this slider you can determine the future round-trip efficiency of 
+        <a href="/scenario/flexibility/flexibility_storage/large-scale-batteries">
+        large-scale batteries</a>, including the batteries used in 
+        <a href="/scenario/flexibility/flexibility_storage/wind-turbines-with-storage-systems">
+        wind turbines with storage systems</a> and in 
+        <a href="/scenario/flexibility/flexibility_storage/solar-plants-with-storage-systems">
+        solar plants with storage systems</a>.
+    efficiency_energy_flexibility_pumped_storage_electricity:
+      title: Reservoirs
+      short_description:
+      description: |
+        The round-trip efficiency is the ratio of the energy output compared to the energy 
+        input of a storage technology, taking into account losses incurred during charging 
+        and discharging. </br></br>
+        With this slider you can determine the future round-trip efficiency of 
+        <a href="/scenario/flexibility/flexibility_storage/reservoirs">
+        reservoirs</a>.
+    efficiency_energy_flexibility_hv_opac_electricity:
+      title: Underground pumped hydro storage
+      short_description:
+      description: |
+        The round-trip efficiency is the ratio of the energy output compared to the energy 
+        input of a storage technology, taking into account losses incurred during charging 
+        and discharging. </br></br>
+        With this slider you can determine the future round-trip efficiency of 
+        <a href="/scenario/flexibility/flexibility_storage/underground-pumped-hydro-storage">
+        underground pumped hydro storage</a>.
+    efficiency_energy_flexibility_flow_batteries_electricity:
+      title: Flow batteries
+      short_description:
+      description: |
+        The round-trip efficiency is the ratio of the energy output compared to the energy 
+        input of a storage technology, taking into account losses incurred during charging 
+        and discharging. </br></br>
+        With this slider you can determine the future round-trip efficiency of 
+        <a href="/scenario/flexibility/flexibility_storage/flow-batteries">
+        flow batteries</a>.

--- a/config/locales/interface/input_elements/en_flexibility.yml
+++ b/config/locales/interface/input_elements/en_flexibility.yml
@@ -539,7 +539,7 @@ en:
         <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
         this chart</a>.
     transport_car_using_electricity_availability:
-      title: Batteries in electric cars
+      title: Deployable capacity
       short_description:
       description: |
         Not all of the storage volume of electric cars can be used to provide storage services to the electricity 
@@ -561,8 +561,12 @@ en:
         change these parameters in the sliders below and you can view the hourly electricity price in
         <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
         this chart</a>.
+    volume_of_transport_car_using_electricity:
+      title: Relative storage volume
+      short_description:
+      description:
     transport_bus_using_electricity_availability:
-      title: Batteries in electric buses
+      title: Deployable capacity
       short_description:
       description: |
         Not all of the storage volume of electric buses can be used to provide storage services to the electricity 
@@ -584,8 +588,12 @@ en:
         change these parameters in the sliders below and you can view the hourly electricity price in
         <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
         this chart</a>.
+    volume_of_transport_bus_using_electricity:
+      title: Relative storage volume
+      short_description:
+      description:
     transport_truck_using_electricity_availability:
-      title: Batteries in electric trucks
+      title: Deployable capacity
       short_description:
       description: |
         Not all of the storage volume of electric trucks can be used to provide storage services to the electricity 
@@ -607,8 +615,12 @@ en:
         change these parameters in the sliders below and you can view the hourly electricity price in
         <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
         this chart</a>.
+    volume_of_transport_truck_using_electricity:
+      title: Relative storage volume
+      short_description:
+      description:
     transport_van_using_electricity_availability:
-      title: Batteries in electric vans
+      title: Deployable capacity
       short_description:
       description: |
         Not all of the storage volume of electric vans can be used to provide storage services to the electricity 
@@ -630,6 +642,10 @@ en:
         change these parameters in the sliders below and you can view the hourly electricity price in
         <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
         this chart</a>.
+    volume_of_transport_van_using_electricity:
+      title: Relative storage volume
+      short_description:
+      description:
     wtp_of_transport_car_flexibility_p2p_electricity:
       title: Willingness to pay
       short_description:
@@ -676,7 +692,7 @@ en:
       title: Reservoirs
       short_description:
       description: |
-        With this slider, you can set the input capacity of reservoirs. </br></br>
+        With this slider, you can set the installed input capacity of reservoirs. </br></br>
         A number of charts are available to help you determine the effect of using reservoirs: </br></br>
         <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
         The yearly use of electricity consumed by flexible demand technologies.</a></li>
@@ -737,7 +753,7 @@ en:
       title: Installed capacity
       short_description:
       description: |
-        With this slider, you can set the input capacity of underground pumped hydro storage (UPHS).
+        With this slider, you can set the installed input capacity of underground pumped hydro storage (UPHS).
         The investment costs of UPHS can be adjusted
         <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">here</a>. </br></br>
         A number of charts are available to help you determine the effect of using UPHS: </br></br>
@@ -821,7 +837,7 @@ en:
       title: Installed capacity
       short_description:
       description: |
-        With this slider, you can set the input capacity of large-scale batteries.
+        With this slider, you can set the installed input capacity of large-scale batteries.
         The investment costs of large-scale batteries can be adjusted
         <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">here</a>. </br></br>
         A number of charts are available to help you determine the effect of using large-scale batteries: </br></br>
@@ -902,10 +918,10 @@ en:
         <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
         this chart</a>.
     capacity_of_energy_flexibility_flow_batteries_electricity:
-      title: Flow batteries
+      title: Installed capacity
       short_description:
       description: |
-        With this slider, you can set the input capacity of flow batteries. Because the capacity and
+        With this slider, you can set the installed input capacity of flow batteries. Because the capacity and
         storage volume of flow batteries can be adjusted independently, the investment costs of these
         batteries also consist of two components. You can change the costs per MW of input capacity
         <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">here</a>. </br></br>

--- a/config/locales/interface/input_elements/en_flexibility.yml
+++ b/config/locales/interface/input_elements/en_flexibility.yml
@@ -453,11 +453,33 @@ en:
         peak power. Offshore solar PV plants are connected to the offshore-net in the ETM.
         The installed capacity can be adjusted <a href="/scenario/demand/households/solar-panels">here</a>.
     households_flexibility_p2p_electricity_market_penetration:
-      title: Batteries in households
+      title: Market penetration
       short_description:
       description: |
         Using this slider you can set the percentage of households that is equipped with a household
         battery. You can click on the 'Technical and financial properties' to see the resulting
+        installed capacity and storage volume. The investment costs of household batteries can be adjusted
+        <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">here</a>. </br></br>
+        A number of charts are available to help you determine the effect of installing household batteries: </br></br>
+        <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
+        The yearly use of electricity consumed by flexible demand technologies.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="hourly_flexibility_electricity" data-chart-location="side">
+        The hourly electricity supply and demand by flexible technologies.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="flexibility_integral_costs" data-chart-location="side">
+        The integral costs of flexible demand technologies.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="storage_options" data-chart-location="side">
+        A table overview of the use of flexible demand technologies.</a></li></ul> </br>
+        If you do not see an effect of changing this slider, it may be the case that the hourly electricity
+        price never drops below the willingness to pay or never exceeds the willingness to accept. You can
+        change these parameters in the sliders below and you can view the hourly electricity price in
+        <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
+        this chart</a>.
+    volume_of_households_flexibility_p2p_electricity:
+      title: Relative storage volume
+      short_description:
+      description: |
+        Using this slider you can set the relative storage volume in hours of household
+        batteries. You can click on the 'Technical and financial properties' to see the resulting
         installed capacity and storage volume. The investment costs of household batteries can be adjusted
         <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">here</a>. </br></br>
         A number of charts are available to help you determine the effect of installing household batteries: </br></br>
@@ -796,10 +818,31 @@ en:
         <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
         this chart</a>.
     capacity_of_energy_flexibility_mv_batteries_electricity:
-      title: Large-scale batteries
+      title: Installed capacity
       short_description:
       description: |
         With this slider, you can set the input capacity of large-scale batteries.
+        The investment costs of large-scale batteries can be adjusted
+        <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">here</a>. </br></br>
+        A number of charts are available to help you determine the effect of using large-scale batteries: </br></br>
+        <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
+        The yearly use of electricity consumed by flexible demand technologies.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="hourly_flexibility_electricity" data-chart-location="side">
+        The hourly electricity supply and demand by flexible technologies.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="flexibility_integral_costs" data-chart-location="side">
+        The integral costs of flexible demand technologies.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="storage_options" data-chart-location="side">
+        A table overview of the use of flexible demand technologies.</a></li></ul> </br>
+        If you do not see an effect of changing this slider, it may be the case that the hourly electricity
+        price never drops below the willingness to pay or never exceeds the willingness to accept. You can
+        change these parameters in the sliders below and you can view the hourly electricity price in
+        <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
+        this chart</a>.
+    volume_of_energy_flexibility_mv_batteries_electricity:
+      title: Relative storage volume
+      short_description:
+      description: |
+        With this slider, you can set the relative storage volume of large-scale batteries.
         The investment costs of large-scale batteries can be adjusted
         <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">here</a>. </br></br>
         A number of charts are available to help you determine the effect of using large-scale batteries: </br></br>

--- a/config/locales/interface/input_elements/en_flexibility.yml
+++ b/config/locales/interface/input_elements/en_flexibility.yml
@@ -712,10 +712,31 @@ en:
         <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
         this chart</a>.
     capacity_of_energy_flexibility_hv_opac_electricity:
-      title: Underground pumped hydro storage
+      title: Installed capacity
       short_description:
       description: |
         With this slider, you can set the input capacity of underground pumped hydro storage (UPHS).
+        The investment costs of UPHS can be adjusted
+        <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">here</a>. </br></br>
+        A number of charts are available to help you determine the effect of using UPHS: </br></br>
+        <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
+        The yearly use of electricity consumed by flexible demand technologies.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="hourly_flexibility_electricity" data-chart-location="side">
+        The hourly electricity supply and demand by flexible technologies.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="flexibility_integral_costs" data-chart-location="side">
+        The integral costs of flexible demand technologies.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="storage_options" data-chart-location="side">
+        A table overview of the use of flexible demand technologies.</a></li></ul> </br>
+        If you do not see an effect of changing this slider, it may be the case that the hourly electricity
+        price never drops below the willingness to pay or never exceeds the willingness to accept. You can
+        change these parameters in the sliders below and you can view the hourly electricity price in
+        <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
+        this chart</a>.
+    volume_of_energy_flexibility_hv_opac_electricity:
+      title: Relative storage volume
+      short_description:
+      description: |
+        With this slider, you can set the storage volume of underground pumped hydro storage (UPHS).
         The investment costs of UPHS can be adjusted
         <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">here</a>. </br></br>
         A number of charts are available to help you determine the effect of using UPHS: </br></br>

--- a/config/locales/interface/input_elements/en_flexibility.yml
+++ b/config/locales/interface/input_elements/en_flexibility.yml
@@ -458,8 +458,8 @@ en:
       description: |
         Using this slider you can set the percentage of households that is equipped with a household
         battery. You can click on the 'Technical and financial properties' to see the resulting
-        installed capacity and storage volume. The investment costs of household batteries can be adjusted
-        <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">here</a>. </br></br>
+        installed capacity and storage volume. The efficiency and investment costs of household batteries can be adjusted
+        <a href="/scenario/costs/costs_flexibility/electricity-storage">here</a>. </br></br>
         A number of charts are available to help you determine the effect of installing household batteries: </br></br>
         <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
         The yearly use of electricity consumed by flexible demand technologies.</a></li>
@@ -478,24 +478,14 @@ en:
       title: Relative storage volume
       short_description:
       description: |
-        Using this slider you can set the relative storage volume in hours of household
-        batteries. You can click on the 'Technical and financial properties' to see the resulting
-        installed capacity and storage volume. The investment costs of household batteries can be adjusted
-        <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">here</a>. </br></br>
-        A number of charts are available to help you determine the effect of installing household batteries: </br></br>
-        <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
-        The yearly use of electricity consumed by flexible demand technologies.</a></li>
-        <li><a href="#" class="open_chart" data-chart-key="hourly_flexibility_electricity" data-chart-location="side">
-        The hourly electricity supply and demand by flexible technologies.</a></li>
-        <li><a href="#" class="open_chart" data-chart-key="flexibility_integral_costs" data-chart-location="side">
-        The integral costs of flexible demand technologies.</a></li>
-        <li><a href="#" class="open_chart" data-chart-key="storage_options" data-chart-location="side">
-        A table overview of the use of flexible demand technologies.</a></li></ul> </br>
-        If you do not see an effect of changing this slider, it may be the case that the hourly electricity
-        price never drops below the willingness to pay or never exceeds the willingness to accept. You can
-        change these parameters in the sliders below and you can view the hourly electricity price in
-        <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
-        this chart</a>.
+        With this slider, you can set the storage volume relative to the input capacity of the battery.
+        This determines how many hours the battery needs to charge at full capacity to go from being empty 
+        to fully charged. Effectively this slider therefore changes the total storage volume, given a 
+        certain amount of installed capacity. </br></br>
+        You can see the total resulting storage volume in the 'Technical and financial 
+        properties' below. To quickly compare it with other storage technologies you can also open
+        <a href="#" class="open_chart" data-chart-key="storage_specifications" data-chart-location="side">
+        this table</a>.
     wtp_of_households_flexibility_p2p_electricity:
       title: Willingness to pay
       short_description:
@@ -545,8 +535,11 @@ en:
         Not all of the storage volume of electric cars can be used to provide storage services to the electricity 
         grid, because some of the electricity is needed to power the next ride. With this slider, you can therefore 
         determine which percentage of the total available battery capacity can be used for storage 
-        services. The total available capacity of car batteries is determined by the share of electric cars in the 
-        <a href="/scenario/demand/transport_passenger_transport/car-technology">car technology</a> section. </br></br>
+        services. </br></br>
+        The total available capacity of car batteries is determined by the share of electric cars in the 
+        <a href="/scenario/demand/transport_passenger_transport/car-technology">car technology</a> section.
+        The efficiency of electric vehicles can be can be adjusted
+        <a href="/scenario/costs/costs_flexibility/electricity-storage">here</a>. </br></br>
         A number of charts are available to help you determine the effect of using batteries in electric vehicles: </br></br>
         <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
         The yearly use of electricity consumed by flexible demand technologies.</a></li>
@@ -564,7 +557,15 @@ en:
     volume_of_transport_car_using_electricity:
       title: Relative storage volume
       short_description:
-      description:
+      description: |
+        With this slider, you can set the storage volume relative to the input capacity of the battery.
+        This determines how many hours the battery needs to charge at full capacity to go from being empty 
+        to fully charged. Effectively this slider therefore changes the total storage volume, given a 
+        certain amount of installed capacity. </br></br>
+        You can see the total resulting storage volume in the 'Technical and financial 
+        properties' below. To quickly compare it with other storage technologies you can also open
+        <a href="#" class="open_chart" data-chart-key="storage_specifications" data-chart-location="side">
+        this table</a>.
     transport_bus_using_electricity_availability:
       title: Deployable capacity
       short_description:
@@ -572,8 +573,11 @@ en:
         Not all of the storage volume of electric buses can be used to provide storage services to the electricity 
         grid, because some of the electricity is needed to power the next ride. With this slider, you can therefore 
         determine which percentage of the total available battery capacity can be used for storage 
-        services. The total available capacity of bus batteries is determined by the share of electric buses in the 
-        <a href="/scenario/demand/transport_passenger_transport/bus-technology">bus technology</a> section. </br></br>
+        services. </br></br>
+        The total available capacity of bus batteries is determined by the share of electric buses in the 
+        <a href="/scenario/demand/transport_passenger_transport/bus-technology">bus technology</a> section.
+        The efficiency of electric vehicles can be can be adjusted
+        <a href="/scenario/costs/costs_flexibility/electricity-storage">here</a>. </br></br>
         A number of charts are available to help you determine the effect of using batteries in electric vehicles: </br></br>
         <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
         The yearly use of electricity consumed by flexible demand technologies.</a></li>
@@ -591,7 +595,15 @@ en:
     volume_of_transport_bus_using_electricity:
       title: Relative storage volume
       short_description:
-      description:
+      description: |
+        With this slider, you can set the storage volume relative to the input capacity of the battery.
+        This determines how many hours the battery needs to charge at full capacity to go from being empty 
+        to fully charged. Effectively this slider therefore changes the total storage volume, given a 
+        certain amount of installed capacity. </br></br>
+        You can see the total resulting storage volume in the 'Technical and financial 
+        properties' below. To quickly compare it with other storage technologies you can also open
+        <a href="#" class="open_chart" data-chart-key="storage_specifications" data-chart-location="side">
+        this table</a>.
     transport_truck_using_electricity_availability:
       title: Deployable capacity
       short_description:
@@ -599,8 +611,11 @@ en:
         Not all of the storage volume of electric trucks can be used to provide storage services to the electricity 
         grid, because some of the electricity is needed to power the next ride. With this slider, you can therefore 
         determine which percentage of the total available battery capacity can be used for storage 
-        services. The total available capacity of truck batteries is determined by the share of electric trucks in the 
-        <a href="/scenario/demand/transport_freight_transport/truck-technology">truck technology</a> section. </br></br>
+        services. </br></br>
+        The total available capacity of truck batteries is determined by the share of electric trucks in the 
+        <a href="/scenario/demand/transport_freight_transport/truck-technology">truck technology</a> section.
+        The efficiency of electric vehicles can be can be adjusted
+        <a href="/scenario/costs/costs_flexibility/electricity-storage">here</a>. </br></br>
         A number of charts are available to help you determine the effect of using batteries in electric vehicles: </br></br>
         <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
         The yearly use of electricity consumed by flexible demand technologies.</a></li>
@@ -618,7 +633,15 @@ en:
     volume_of_transport_truck_using_electricity:
       title: Relative storage volume
       short_description:
-      description:
+      description: |
+        With this slider, you can set the storage volume relative to the input capacity of the battery.
+        This determines how many hours the battery needs to charge at full capacity to go from being empty 
+        to fully charged. Effectively this slider therefore changes the total storage volume, given a 
+        certain amount of installed capacity. </br></br>
+        You can see the total resulting storage volume in the 'Technical and financial 
+        properties' below. To quickly compare it with other storage technologies you can also open
+        <a href="#" class="open_chart" data-chart-key="storage_specifications" data-chart-location="side">
+        this table</a>.
     transport_van_using_electricity_availability:
       title: Deployable capacity
       short_description:
@@ -626,8 +649,11 @@ en:
         Not all of the storage volume of electric vans can be used to provide storage services to the electricity 
         grid, because some of the electricity is needed to power the next ride. With this slider, you can therefore 
         determine which percentage of the total available battery capacity can be used for storage 
-        services. The total available capacity of van batteries is determined by the share of electric vans in the 
-        <a href="/scenario/demand/transport_freight_transport/van-technology">van technology</a> section. </br></br>
+        services. </br></br>
+        The total available capacity of van batteries is determined by the share of electric vans in the 
+        <a href="/scenario/demand/transport_freight_transport/van-technology">van technology</a> section. 
+        The efficiency of electric vehicles can be can be adjusted
+        <a href="/scenario/costs/costs_flexibility/electricity-storage">here</a>. </br></br>
         A number of charts are available to help you determine the effect of using batteries in electric vehicles: </br></br>
         <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
         The yearly use of electricity consumed by flexible demand technologies.</a></li>
@@ -645,7 +671,15 @@ en:
     volume_of_transport_van_using_electricity:
       title: Relative storage volume
       short_description:
-      description:
+      description: |
+        With this slider, you can set the storage volume relative to the input capacity of the battery.
+        This determines how many hours the battery needs to charge at full capacity to go from being empty 
+        to fully charged. Effectively this slider therefore changes the total storage volume, given a 
+        certain amount of installed capacity. </br></br>
+        You can see the total resulting storage volume in the 'Technical and financial 
+        properties' below. To quickly compare it with other storage technologies you can also open
+        <a href="#" class="open_chart" data-chart-key="storage_specifications" data-chart-location="side">
+        this table</a>.
     wtp_of_transport_car_flexibility_p2p_electricity:
       title: Willingness to pay
       short_description:
@@ -689,10 +723,12 @@ en:
         <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
         this chart</a>.
     capacity_of_energy_flexibility_pumped_storage_electricity:
-      title: Reservoirs
+      title: Installed capacity
       short_description:
       description: |
-        With this slider, you can set the installed input capacity of reservoirs. </br></br>
+        With this slider, you can set the installed input capacity of reservoirs. 
+        The efficiency of reservoirs can be can be adjusted
+        <a href="/scenario/costs/costs_flexibility/electricity-storage">here</a>. </br></br>
         A number of charts are available to help you determine the effect of using reservoirs: </br></br>
         <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
         The yearly use of electricity consumed by flexible demand technologies.</a></li>
@@ -707,6 +743,18 @@ en:
         change these parameters in the sliders below and you can view the hourly electricity price in
         <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
         this chart</a>.
+    volume_of_energy_flexibility_pumped_storage_electricity:
+      title: Relative storage volume
+      short_description:
+      description: |
+        With this slider, you can set the storage volume relative to the input capacity of the reservoirs.
+        This determines how many hours the reservoirs need to consume electricity at full capacity to go from being empty 
+        to being full. Effectively this slider therefore changes the total storage volume, given a 
+        certain amount of installed capacity. </br></br>
+        You can see the total resulting storage volume in the 'Technical and financial 
+        properties' below. To quickly compare it with other storage technologies you can also open
+        <a href="#" class="open_chart" data-chart-key="storage_specifications" data-chart-location="side">
+        this table</a>.
     wtp_of_energy_flexibility_pumped_storage_electricity:
       title: Willingness to pay
       short_description:
@@ -754,8 +802,8 @@ en:
       short_description:
       description: |
         With this slider, you can set the installed input capacity of underground pumped hydro storage (UPHS).
-        The investment costs of UPHS can be adjusted
-        <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">here</a>. </br></br>
+        The efficiency and investment costs of UPHS can be adjusted
+        <a href="/scenario/costs/costs_flexibility/electricity-storage">here</a>. </br></br>
         A number of charts are available to help you determine the effect of using UPHS: </br></br>
         <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
         The yearly use of electricity consumed by flexible demand technologies.</a></li>
@@ -774,23 +822,14 @@ en:
       title: Relative storage volume
       short_description:
       description: |
-        With this slider, you can set the storage volume of underground pumped hydro storage (UPHS).
-        The investment costs of UPHS can be adjusted
-        <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">here</a>. </br></br>
-        A number of charts are available to help you determine the effect of using UPHS: </br></br>
-        <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
-        The yearly use of electricity consumed by flexible demand technologies.</a></li>
-        <li><a href="#" class="open_chart" data-chart-key="hourly_flexibility_electricity" data-chart-location="side">
-        The hourly electricity supply and demand by flexible technologies.</a></li>
-        <li><a href="#" class="open_chart" data-chart-key="flexibility_integral_costs" data-chart-location="side">
-        The integral costs of flexible demand technologies.</a></li>
-        <li><a href="#" class="open_chart" data-chart-key="storage_options" data-chart-location="side">
-        A table overview of the use of flexible demand technologies.</a></li></ul> </br>
-        If you do not see an effect of changing this slider, it may be the case that the hourly electricity
-        price never drops below the willingness to pay or never exceeds the willingness to accept. You can
-        change these parameters in the sliders below and you can view the hourly electricity price in
-        <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
-        this chart</a>.
+        With this slider, you can set the storage volume relative to the input capacity of the underground pumped hydro storage (UPHS).
+        This determines how many hours the UPHS needs to consume electricity at full capacity to go from being empty 
+        to being full. Effectively this slider therefore changes the total storage volume, given a 
+        certain amount of installed capacity. </br></br>
+        You can see the total resulting storage volume in the 'Technical and financial 
+        properties' below. To quickly compare it with other storage technologies you can also open
+        <a href="#" class="open_chart" data-chart-key="storage_specifications" data-chart-location="side">
+        this table</a>.
     wtp_of_energy_flexibility_hv_opac_electricity:
       title: Willingness to pay
       short_description:
@@ -838,8 +877,8 @@ en:
       short_description:
       description: |
         With this slider, you can set the installed input capacity of large-scale batteries.
-        The investment costs of large-scale batteries can be adjusted
-        <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">here</a>. </br></br>
+        The efficiency and investment costs of large-scale batteries can be adjusted
+        <a href="/scenario/costs/costs_flexibility/electricity-storage">here</a>. </br></br>
         A number of charts are available to help you determine the effect of using large-scale batteries: </br></br>
         <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
         The yearly use of electricity consumed by flexible demand technologies.</a></li>
@@ -858,23 +897,14 @@ en:
       title: Relative storage volume
       short_description:
       description: |
-        With this slider, you can set the relative storage volume of large-scale batteries.
-        The investment costs of large-scale batteries can be adjusted
-        <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">here</a>. </br></br>
-        A number of charts are available to help you determine the effect of using large-scale batteries: </br></br>
-        <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
-        The yearly use of electricity consumed by flexible demand technologies.</a></li>
-        <li><a href="#" class="open_chart" data-chart-key="hourly_flexibility_electricity" data-chart-location="side">
-        The hourly electricity supply and demand by flexible technologies.</a></li>
-        <li><a href="#" class="open_chart" data-chart-key="flexibility_integral_costs" data-chart-location="side">
-        The integral costs of flexible demand technologies.</a></li>
-        <li><a href="#" class="open_chart" data-chart-key="storage_options" data-chart-location="side">
-        A table overview of the use of flexible demand technologies.</a></li></ul> </br>
-        If you do not see an effect of changing this slider, it may be the case that the hourly electricity
-        price never drops below the willingness to pay or never exceeds the willingness to accept. You can
-        change these parameters in the sliders below and you can view the hourly electricity price in
-        <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
-        this chart</a>.
+        With this slider, you can set the storage volume relative to the input capacity of the battery.
+        This determines how many hours the battery needs to charge at full capacity to go from being empty 
+        to fully charged. Effectively this slider therefore changes the total storage volume, given a 
+        certain amount of installed capacity. </br></br>
+        You can see the total resulting storage volume in the 'Technical and financial 
+        properties' below. To quickly compare it with other storage technologies you can also open
+        <a href="#" class="open_chart" data-chart-key="storage_specifications" data-chart-location="side">
+        this table</a>.
     wtp_of_energy_flexibility_mv_batteries_electricity:
       title: Willingness to pay
       short_description:
@@ -923,8 +953,8 @@ en:
       description: |
         With this slider, you can set the installed input capacity of flow batteries. Because the capacity and
         storage volume of flow batteries can be adjusted independently, the investment costs of these
-        batteries also consist of two components. You can change the costs per MW of input capacity
-        <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">here</a>. </br></br>
+        batteries also consist of two components. You can change the efficiency of the flow batteries and the costs per MW and MWh
+        <a href="/scenario/costs/costs_flexibility/electricity-storage">here</a>. </br></br>
         A number of charts are available to help you determine the effect of using flow batteries: </br></br>
         <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
         The yearly use of electricity consumed by flexible demand technologies.</a></li>
@@ -943,11 +973,13 @@ en:
       title: Relative storage volume
       short_description:
       description: |
-        With this slider, you can set the storage volume of flow batteries, relative to the input capacity. Effectively
-        this sliders determines how many hours an empty flow battery can charge at full volume before it is full. You
-        can see the total resulting storage volume in the 'Technical and financial properties' below. To quickly compare
-        it with other storage technologies you can also open
-        <a href="#" class="open_chart" data-chart-key="storage_options" data-chart-location="side">
+        With this slider, you can set the storage volume relative to the input capacity of the battery.
+        This determines how many hours the battery needs to charge at full capacity to go from being empty 
+        to fully charged. Effectively this slider therefore changes the total storage volume, given a 
+        certain amount of installed capacity. </br></br>
+        You can see the total resulting storage volume in the 'Technical and financial 
+        properties' below. To quickly compare it with other storage technologies you can also open
+        <a href="#" class="open_chart" data-chart-key="storage_specifications" data-chart-location="side">
         this table</a>. </br></br>
         Because the capacity and storage volume of flow batteries can be adjusted independently, the investment
         costs of these batteries also consist of two components. You can change the costs per MWh of storage volume
@@ -1291,7 +1323,9 @@ en:
         The storage volume is related to the charging capacity by a fixed ratio. This means
         that the storage volume will therefore also be updated if you change this slider.
         To see the effect of this slider on the total battery capacity and storage volume,
-        you can click on the 'Technical and financial properties'.
+        you can click on the 'Technical and financial properties'. </br></br>
+        The efficiency of the battery can be adjusted
+        <a href="/scenario/costs/costs_flexibility/electricity-storage">here</a>.
     battery_capacity_always_on_solar_pv_solar_radiation:
       title: Relative battery capacity
       short_description:
@@ -1299,7 +1333,7 @@ en:
         The input capacity, or charging capacity, of the battery is set relative to the
         installed capacity of the solar PV plants with battery systems. This means that if
         you change the installed capacity in the
-        <a href="/scenario/supply/electricity_renewable/solar-power>
+        <a href="/scenario/supply/electricity_renewable/solar-power">
         Supply</a> section, the charging capacity will change accordingly, with the ratio
         specified by this slider. <br/><br/>
         The battery system only consumes electricity when the production exceeds the grid
@@ -1309,7 +1343,33 @@ en:
         The storage volume is related to the charging capacity by a fixed ratio. This means
         that the storage volume will therefore also be updated if you change this slider.
         To see the effect of this slider on the total battery capacity and storage volume,
-        you can click on the 'Technical and financial properties'.
+        you can click on the 'Technical and financial properties'. </br></br>
+        The efficiency of the battery can be adjusted
+        <a href="/scenario/costs/costs_flexibility/electricity-storage">here</a>.
+    volume_of_energy_flexibility_wind_batteries_electricity:
+      title: Relative storage volume
+      short_description:
+      description: |
+        With this slider, you can set the storage volume relative to the input capacity of the battery.
+        This determines how many hours the battery needs to charge at full capacity to go from being empty 
+        to fully charged. Effectively this slider therefore changes the total storage volume, given a 
+        certain amount of installed capacity. </br></br>
+        You can see the total resulting storage volume in the 'Technical and financial 
+        properties' below. To quickly compare it with other storage technologies you can also open
+        <a href="#" class="open_chart" data-chart-key="storage_specifications" data-chart-location="side">
+        this table</a>.
+    volume_of_energy_flexibility_solar_batteries_electricity:
+      title: Relative storage volume
+      short_description:
+      description: |
+        With this slider, you can set the storage volume relative to the input capacity of the battery.
+        This determines how many hours the battery needs to charge at full capacity to go from being empty 
+        to fully charged. Effectively this slider therefore changes the total storage volume, given a 
+        certain amount of installed capacity. </br></br>
+        You can see the total resulting storage volume in the 'Technical and financial 
+        properties' below. To quickly compare it with other storage technologies you can also open
+        <a href="#" class="open_chart" data-chart-key="storage_specifications" data-chart-location="side">
+        this table</a>.
     flexibility_residual_load_curve_moving_average:
       title: Moving average time period
       short_description:

--- a/config/locales/interface/input_elements/nl_costs.yml
+++ b/config/locales/interface/input_elements/nl_costs.yml
@@ -396,7 +396,7 @@ nl:
         de investeringskosten van waterstofcentrales. De kosten worden vergeleken met de
         kosten van vandaag de dag.
     investment_costs_households_flexibility_p2p_electricity:
-      title: Investeringskosten batterijen in huishoudens
+      title: Batterijen in huishoudens
       short_description:
       description: "Batterijen in huishouden worden vaak genoemd als oplossing voor
         het opvangen van elektriciteitsoverschotten. Met <a href=\"/scenario/flexibility/flexibility_storage/storage-in-household-batteries\"
@@ -404,12 +404,12 @@ nl:
         met batterijopslag en vervolgens kan je met bovenstaande slider aangeven hoeveel
         de investeringskosten zullen veranderen voor deze batterijen.\r\n</br>"
     investment_costs_energy_flexibility_hv_opac_electricity:
-      title: Investeringskosten OPAC
+      title: OPAC
       short_description:
       description: Dit schuifje bepaalt de toekomstige verandering in investeringskosten
         van Ondergrondse Pomp Accumulatie Centrale (OPAC).
     investment_costs_energy_flexibility_mv_batteries_electricity:
-      title: Investeringskosten grootschalige batterijopslag
+      title: Grootschalige batterijopslag
       short_description:
       description: |
         Dit schuifje bepaalt de toekomstige verandering in investeringskosten van grootschalige batterijopslag. 
@@ -1017,7 +1017,7 @@ nl:
         Het is niet mogelijk om de absolute waarde van de SCOP van de hybride warmtepompen in te stellen, omdat het een resultaat is van uurlijkse berekeningen o.b.v.
         het uurlijkse profiel van de buitentemperatuur.
     capacity_costs_energy_flexibility_flow_batteries_electricity:
-      title: Investeringskosten per MW flowbatterijen
+      title: Flowbatterijen per MW
       short_decription:
       description: |
         In tegenstelling tot andere batterijen kunnen voor flowbatterijen het inputvermogen en het 
@@ -1028,7 +1028,7 @@ nl:
         Flexibiliteit</a> sectie kun je het opgesteld vermogen en de verhouding met het opslagvolume 
         aanpassen.
     volume_costs_energy_flexibility_flow_batteries_electricity:
-      title: Investeringskosten per MWh flowbatterijen
+      title: Flowbatterijen per MWh
       short_decription:
       description: |
         In tegenstelling tot andere batterijen kunnen voor flowbatterijen het inputvermogen en het 
@@ -1084,3 +1084,67 @@ nl:
       short_description:
       description: |
         Dit schuifje stelt de toekomstige efficiëntie van ammoniak reformers in.
+    efficiency_households_flexibility_p2p_electricity:
+      title: Batterijen in huishoudens
+      short_description:
+      description: |
+        De retourefficiëntie is de verhouding tussen de energie-output en de energie-input 
+        van een opslagtechnologie, rekening houdend met verliezen die optreden tijdens het 
+        opladen en ontladen. </br></br>
+        Met dit schuifje kun je de toekomstige retourefficiëntie van 
+        <a href="/scenario/flexibility/flexibility_storage/batteries-in-households">
+        batterijen in huishoudens</a> bepalen.
+    efficiency_transport_flexibility_p2p_electricity:
+      title: Batterijen in elektrische voertuigen
+      short_description:
+      description: |
+        De retourefficiëntie is de verhouding tussen de energie-output en de energie-input 
+        van een opslagtechnologie, rekening houdend met verliezen die optreden tijdens het 
+        opladen en ontladen. </br></br>
+        Met dit schuifje kun je de toekomstige retourefficiëntie van 
+        <a href="/scenario/flexibility/flexibility_storage/batteries-in-electric-vehicles">
+        batterijen in elektrische voertuigen</a> bepalen: auto's, bussen, vrachtwagens en bestelbussen.
+    efficiency_energy_flexibility_mv_batteries_electricity:
+      title: Grootschalige batterijopslag
+      short_description:
+      description: |
+        De retourefficiëntie is de verhouding tussen de energie-output en de energie-input 
+        van een opslagtechnologie, rekening houdend met verliezen die optreden tijdens het 
+        opladen en ontladen. </br></br>
+        Met dit schuifje kun je de toekomstige retourefficiëntie van 
+        <a href="/scenario/flexibility/flexibility_storage/large-scale-batteries">
+        grootschalige batterijopslag</a> bepalen, waaronder ook de batterijen die gebruikt worden in
+        <a href="/scenario/flexibility/flexibility_storage/wind-turbines-with-storage-systems">
+        windmolens met opslagsystemen</a> en
+        <a href="/scenario/flexibility/flexibility_storage/solar-plants-with-storage-systems">
+        zonnecentrales met opslagsystemen</a>.
+    efficiency_energy_flexibility_pumped_storage_electricity:
+      title: Stuwmeren
+      short_description:
+      description: |
+        De retourefficiëntie is de verhouding tussen de energie-output en de energie-input 
+        van een opslagtechnologie, rekening houdend met verliezen die optreden tijdens het 
+        opladen en ontladen. </br></br>
+        Met dit schuifje kun je de toekomstige retourefficiëntie van 
+        <a href="/scenario/flexibility/flexibility_storage/reservoirs">
+        stuwmeren</a> bepalen.
+    efficiency_energy_flexibility_hv_opac_electricity:
+      title: OPAC
+      short_description:
+      description: |
+        De retourefficiëntie is de verhouding tussen de energie-output en de energie-input 
+        van een opslagtechnologie, rekening houdend met verliezen die optreden tijdens het 
+        opladen en ontladen. </br></br>
+        Met dit schuifje kun je de toekomstige retourefficiëntie van 
+        <a href="/scenario/flexibility/flexibility_storage/underground-pumped-hydro-storage">
+        OPAC</a> bepalen.
+    efficiency_energy_flexibility_flow_batteries_electricity:
+      title: Flowbatterijen
+      short_description:
+      description: |
+        De retourefficiëntie is de verhouding tussen de energie-output en de energie-input 
+        van een opslagtechnologie, rekening houdend met verliezen die optreden tijdens het 
+        opladen en ontladen. </br></br>
+        Met dit schuifje kun je de toekomstige retourefficiëntie van 
+        <a href="/scenario/flexibility/flexibility_storage/flow-batteries">
+        flowbatterijen</a> bepalen.

--- a/config/locales/interface/input_elements/nl_flexibility.yml
+++ b/config/locales/interface/input_elements/nl_flexibility.yml
@@ -750,10 +750,32 @@ nl:
         <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
         deze grafiek</a>.
     capacity_of_energy_flexibility_hv_opac_electricity:
-      title: OPAC
+      title: Geïnstalleerd vermogen
       short_description:
       description: |
         Met dit schuifje kun je het inputvermogen van Ondergrondse Pomp Accumulatie Centrales (OPAC) bepalen.
+        De investeringskosten van OPAC kunnen <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">
+        hier</a> worden aangepast. <br></br>
+        Er zijn een aantal grafieken beschikbaar om je te helpen bepalen wat het effect is
+        van de inzet van OPAC: </br></br>
+        <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
+        De jaarlijkse inzet van elektriciteit geconsumeerd door flexible vraagtechnologieën.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="hourly_flexibility_electricity" data-chart-location="side">
+        De uurlijkse elektriciteitsvraag en -aanbod van flexibele technologieën.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="flexibility_integral_costs" data-chart-location="side">
+        De integrale kosten van flexible vraagtechnnologieën</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="storage_options" data-chart-location="side">
+        Een overzicht van de inzet van flexibele vraagtechnologieën in tabelvorm.</a></li></ul> </br>
+        Als je geen effect ziet van veranderingen in dit schuifje, dan kan het zijn dat de uurlijkse elektriciteitsprijs
+        nooit onder de willingness-to-pay zakt, of nooit boven de willingness-to-accept uitkomt. Deze parameters kun
+        je met de onderstaande schuifjes veranderen. De uurlijkse elektriciteitsprijs is te zien in
+        <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
+        deze grafiek</a>.
+    volume_of_energy_flexibility_hv_opac_electricity:
+      title: Relatief opslagvolume
+      short_description:
+      description: |
+        Met dit schuifje kun je het opslagvolume van Ondergrondse Pomp Accumulatie Centrales (OPAC) bepalen.
         De investeringskosten van OPAC kunnen <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">
         hier</a> worden aangepast. <br></br>
         Er zijn een aantal grafieken beschikbaar om je te helpen bepalen wat het effect is

--- a/config/locales/interface/input_elements/nl_flexibility.yml
+++ b/config/locales/interface/input_elements/nl_flexibility.yml
@@ -473,10 +473,33 @@ nl:
         Het geïnstalleerd vermogen is <a href="/scenario/supply/electricity_renewable/solar-power">hier</a>
         aan te passen.
     households_flexibility_p2p_electricity_market_penetration:
-      title: Batterijen in huishoudens
+      title: Marktaandeel
       short_description:
       description: |
         Met dit schuifje kan je bepalen welk percentage van de huishoudens wordt uitgerust met een batterij.
+        Bij de 'Technische parameters en kosten' kun je vervolgens zien wat het totaal geïnstalleerde vermogen
+        en opslagvolume is. De investeringskosten van batterijen in huishoudens kunnen
+        <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">hier</a> worden aangepast. </br></br>
+        Er zijn een aantal grafieken beschikbaar om je te helpen bepalen wat het effect is
+        van de installatie van batterijen in huishoudens: </br></br>
+        <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
+        De jaarlijkse inzet van elektriciteit geconsumeerd door flexible vraagtechnologieën.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="hourly_flexibility_electricity" data-chart-location="side">
+        De uurlijkse elektriciteitsvraag en -aanbod van flexibele technologieën.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="flexibility_integral_costs" data-chart-location="side">
+        De integrale kosten van flexible vraagtechnnologieën</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="storage_options" data-chart-location="side">
+        Een overzicht van de inzet van flexibele vraagtechnologieën in tabelvorm.</a></li></ul> </br>
+        Als je geen effect ziet van veranderingen in dit schuifje, dan kan het zijn dat de uurlijkse elektriciteitsprijs
+        nooit onder de willingness-to-pay zakt, of nooit boven de willingness-to-accept uitkomt. Deze parameters kun
+        je met de onderstaande schuifjes veranderen. De uurlijkse elektriciteitsprijs is te zien in
+        <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
+        deze grafiek</a>.
+    volume_of_households_flexibility_p2p_electricity:
+      title: Relatief opslagvolume
+      short_description:
+      description: |
+        Met dit schuifje kan je het relatieve opslagvolume van thuisbatterijen instellen in uren.
         Bij de 'Technische parameters en kosten' kun je vervolgens zien wat het totaal geïnstalleerde vermogen
         en opslagvolume is. De investeringskosten van batterijen in huishoudens kunnen
         <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">hier</a> worden aangepast. </br></br>
@@ -840,10 +863,32 @@ nl:
         <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
         deze grafiek</a>.
     capacity_of_energy_flexibility_mv_batteries_electricity:
-      title: Grootschalige batterijopslag
+      title: Geïnstalleerd vermogen
       short_description:
       description: |
         Met dit schuifje kun je het inputvermogen van grootschalige batterijopslag bepalen.
+        De investeringskosten van grootschalige batterijopslag kunnen <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">
+        hier</a> worden aangepast. <br></br>
+        Er zijn een aantal grafieken beschikbaar om je te helpen bepalen wat het effect is
+        van de inzet van grootschalige batterijopslag: </br></br>
+        <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
+        De jaarlijkse inzet van elektriciteit geconsumeerd door flexible vraagtechnologieën.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="hourly_flexibility_electricity" data-chart-location="side">
+        De uurlijkse elektriciteitsvraag en -aanbod van flexibele technologieën.</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="flexibility_integral_costs" data-chart-location="side">
+        De integrale kosten van flexible vraagtechnnologieën</a></li>
+        <li><a href="#" class="open_chart" data-chart-key="storage_options" data-chart-location="side">
+        Een overzicht van de inzet van flexibele vraagtechnologieën in tabelvorm.</a></li></ul> </br>
+        Als je geen effect ziet van veranderingen in dit schuifje, dan kan het zijn dat de uurlijkse elektriciteitsprijs
+        nooit onder de willingness-to-pay zakt, of nooit boven de willingness-to-accept uitkomt. Deze parameters kun
+        je met de onderstaande schuifjes veranderen. De uurlijkse elektriciteitsprijs is te zien in
+        <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
+        deze grafiek</a>.
+    volume_of_energy_flexibility_mv_batteries_electricity:
+      title: Relatief opslagvolume
+      short_description:
+      description: |
+        Met dit schuifje kun je het relatieve opslagvolume van grootschalige batterijopslag bepalen.
         De investeringskosten van grootschalige batterijopslag kunnen <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">
         hier</a> worden aangepast. <br></br>
         Er zijn een aantal grafieken beschikbaar om je te helpen bepalen wat het effect is

--- a/config/locales/interface/input_elements/nl_flexibility.yml
+++ b/config/locales/interface/input_elements/nl_flexibility.yml
@@ -478,8 +478,8 @@ nl:
       description: |
         Met dit schuifje kan je bepalen welk percentage van de huishoudens wordt uitgerust met een batterij.
         Bij de 'Technische parameters en kosten' kun je vervolgens zien wat het totaal geïnstalleerde vermogen
-        en opslagvolume is. De investeringskosten van batterijen in huishoudens kunnen
-        <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">hier</a> worden aangepast. </br></br>
+        en opslagvolume is. De investeringskosten en efficiëntie van batterijen in huishoudens kunnen
+        <a href="/scenario/costs/costs_flexibility/electricity-storage">hier</a> worden aangepast. </br></br>
         Er zijn een aantal grafieken beschikbaar om je te helpen bepalen wat het effect is
         van de installatie van batterijen in huishoudens: </br></br>
         <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
@@ -499,25 +499,14 @@ nl:
       title: Relatief opslagvolume
       short_description:
       description: |
-        Met dit schuifje kan je het relatieve opslagvolume van thuisbatterijen instellen in uren.
-        Bij de 'Technische parameters en kosten' kun je vervolgens zien wat het totaal geïnstalleerde vermogen
-        en opslagvolume is. De investeringskosten van batterijen in huishoudens kunnen
-        <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">hier</a> worden aangepast. </br></br>
-        Er zijn een aantal grafieken beschikbaar om je te helpen bepalen wat het effect is
-        van de installatie van batterijen in huishoudens: </br></br>
-        <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
-        De jaarlijkse inzet van elektriciteit geconsumeerd door flexible vraagtechnologieën.</a></li>
-        <li><a href="#" class="open_chart" data-chart-key="hourly_flexibility_electricity" data-chart-location="side">
-        De uurlijkse elektriciteitsvraag en -aanbod van flexibele technologieën.</a></li>
-        <li><a href="#" class="open_chart" data-chart-key="flexibility_integral_costs" data-chart-location="side">
-        De integrale kosten van flexible vraagtechnnologieën</a></li>
-        <li><a href="#" class="open_chart" data-chart-key="storage_options" data-chart-location="side">
-        Een overzicht van de inzet van flexibele vraagtechnologieën in tabelvorm.</a></li></ul> </br>
-        Als je geen effect ziet van veranderingen in dit schuifje, dan kan het zijn dat de uurlijkse elektriciteitsprijs
-        nooit onder de willingness-to-pay zakt, of nooit boven de willingness-to-accept uitkomt. Deze parameters kun
-        je met de onderstaande schuifjes veranderen. De uurlijkse elektriciteitsprijs is te zien in
-        <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
-        deze grafiek</a>.
+        Met dit schuifje kun je het opslagvolume van de batterij relatief ten opzichte van het inputvermogen instellen.
+        Dit bepaalt hoeveel uur de batterij op vol vermogen moet laden om van leeg naar volledig vol te gaan.
+        Effectief verandert dit schuifje daarom het totale opslagvolume, gegeven een bepaalde hoeveelheid 
+        geïnstalleerd vermogen. </br></br>
+        Het totale opslagvolume kun je zien in de 'Technische parameters en kosten' hieronder. Als het snel wilt
+        vergelijken met andere opslagtechnologieën kun je ook
+        <a href="#" class="open_chart" data-chart-key="storage_specifications" data-chart-location="side">
+        deze tabel</a> openen.
     wtp_of_households_flexibility_p2p_electricity:
       title: Willingness-to-pay
       short_description:
@@ -570,9 +559,12 @@ nl:
       description: |
         Niet al het opslagvolume van elektrische auto's kan worden gebruikt om opslagdiensten te verlenen aan het elektriciteitsnet,
         omdat een deel van de opgeslagen elektriciteit nog nodig is om mee te kunnen rijden. Met dit schuifje kun je daarom bepalen 
-        welk percentage van de totale beschikbare batterijcapaciteit kan worden ingezet voor opslagdiensten. De totale beschikbare 
+        welk percentage van de totale beschikbare batterijcapaciteit kan worden ingezet voor opslagdiensten. </br></br>
+        De totale beschikbare 
         capaciteit van batterijen in auto's hangt af van het aandeel elektrische auto's in de 
-        <a href="/scenario/demand/transport_passenger_transport/car-technology">autotechnologie</a> sectie. </br></br>
+        <a href="/scenario/demand/transport_passenger_transport/car-technology">autotechnologie</a> sectie. 
+        De efficiëntie van batterijen in elektrische voertuigen kan
+        <a href="/scenario/costs/costs_flexibility/electricity-storage">hier</a> worden aangepast. </br></br>
         Er zijn een aantal grafieken beschikbaar om je te helpen bepalen wat het effect is
         van het benutten van batterijen in elektrische auto's: </br></br>
         <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
@@ -591,16 +583,27 @@ nl:
     volume_of_transport_car_using_electricity:
       title: Relatief opslagvolume
       short_description:
-      description:
+      description: |
+        Met dit schuifje kun je het opslagvolume van de batterij relatief ten opzichte van het inputvermogen instellen.
+        Dit bepaalt hoeveel uur de batterij op vol vermogen moet laden om van leeg naar volledig vol te gaan.
+        Effectief verandert dit schuifje daarom het totale opslagvolume, gegeven een bepaalde hoeveelheid 
+        geïnstalleerd vermogen. </br></br>
+        Het totale opslagvolume kun je zien in de 'Technische parameters en kosten' hieronder. Als het snel wilt
+        vergelijken met andere opslagtechnologieën kun je ook
+        <a href="#" class="open_chart" data-chart-key="storage_specifications" data-chart-location="side">
+        deze tabel</a> openen.
     transport_bus_using_electricity_availability:
       title: Inzetbaar vermogen
       short_description:
       description: |
         Niet al het opslagvolume van elektrische bussen kan worden gebruikt om opslagdiensten te verlenen aan het elektriciteitsnet,
         omdat een deel van de opgeslagen elektriciteit nog nodig is om mee te kunnen rijden. Met dit schuifje kun je daarom bepalen 
-        welk percentage van de totale beschikbare batterijcapaciteit kan worden ingezet voor opslagdiensten. De totale beschikbare 
+        welk percentage van de totale beschikbare batterijcapaciteit kan worden ingezet voor opslagdiensten. </br></br>
+        De totale beschikbare 
         capaciteit van batterijen in bussen hangt af van het aandeel elektrische bussen in de 
-        <a href="/scenario/demand/transport_passenger_transport/bus-technology">bustechnologie</a> sectie. </br></br>
+        <a href="/scenario/demand/transport_passenger_transport/bus-technology">bustechnologie</a> sectie.
+        De efficiëntie van batterijen in elektrische voertuigen kan
+        <a href="/scenario/costs/costs_flexibility/electricity-storage">hier</a> worden aangepast. </br></br>
         Er zijn een aantal grafieken beschikbaar om je te helpen bepalen wat het effect is
         van het benutten van batterijen in elektrische auto's: </br></br>
         <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
@@ -619,16 +622,27 @@ nl:
     volume_of_transport_bus_using_electricity:
       title: Relatief opslagvolume
       short_description:
-      description:
+      description: |
+        Met dit schuifje kun je het opslagvolume van de batterij relatief ten opzichte van het inputvermogen instellen.
+        Dit bepaalt hoeveel uur de batterij op vol vermogen moet laden om van leeg naar volledig vol te gaan.
+        Effectief verandert dit schuifje daarom het totale opslagvolume, gegeven een bepaalde hoeveelheid 
+        geïnstalleerd vermogen. </br></br>
+        Het totale opslagvolume kun je zien in de 'Technische parameters en kosten' hieronder. Als het snel wilt
+        vergelijken met andere opslagtechnologieën kun je ook
+        <a href="#" class="open_chart" data-chart-key="storage_specifications" data-chart-location="side">
+        deze tabel</a> openen.
     transport_truck_using_electricity_availability:
       title: Inzetbaar vermogen
       short_description:
       description: |
         Niet al het opslagvolume van elektrische vrachtwagens kan worden gebruikt om opslagdiensten te verlenen aan het elektriciteitsnet,
         omdat een deel van de opgeslagen elektriciteit nog nodig is om mee te kunnen rijden. Met dit schuifje kun je daarom bepalen 
-        welk percentage van de totale beschikbare batterijcapaciteit kan worden ingezet voor opslagdiensten. De totale beschikbare 
+        welk percentage van de totale beschikbare batterijcapaciteit kan worden ingezet voor opslagdiensten. </br></br>
+        De totale beschikbare 
         capaciteit van batterijen in vrachtwagens hangt af van het aandeel elektrische vrachtwagens in de 
-        <a href="/scenario/demand/transport_freight_transport/truck-technology">vrachtwagentechnologie</a> sectie. </br></br>
+        <a href="/scenario/demand/transport_freight_transport/truck-technology">vrachtwagentechnologie</a> sectie.
+        De efficiëntie van batterijen in elektrische voertuigen kan
+        <a href="/scenario/costs/costs_flexibility/electricity-storage">hier</a> worden aangepast. </br></br>
         Er zijn een aantal grafieken beschikbaar om je te helpen bepalen wat het effect is
         van het benutten van batterijen in elektrische auto's: </br></br>
         <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
@@ -647,16 +661,27 @@ nl:
     volume_of_transport_truck_using_electricity:
       title: Relatief opslagvolume
       short_description:
-      description:
+      description: |
+        Met dit schuifje kun je het opslagvolume van de batterij relatief ten opzichte van het inputvermogen instellen.
+        Dit bepaalt hoeveel uur de batterij op vol vermogen moet laden om van leeg naar volledig vol te gaan.
+        Effectief verandert dit schuifje daarom het totale opslagvolume, gegeven een bepaalde hoeveelheid 
+        geïnstalleerd vermogen. </br></br>
+        Het totale opslagvolume kun je zien in de 'Technische parameters en kosten' hieronder. Als het snel wilt
+        vergelijken met andere opslagtechnologieën kun je ook
+        <a href="#" class="open_chart" data-chart-key="storage_specifications" data-chart-location="side">
+        deze tabel</a> openen.
     transport_van_using_electricity_availability:
       title: Inzetbaar vermogen
       short_description:
       description: |
         Niet al het opslagvolume van elektrische bestelbussen kan worden gebruikt om opslagdiensten te verlenen aan het elektriciteitsnet,
         omdat een deel van de opgeslagen elektriciteit nog nodig is om mee te kunnen rijden. Met dit schuifje kun je daarom bepalen 
-        welk percentage van de totale beschikbare batterijcapaciteit kan worden ingezet voor opslagdiensten. De totale beschikbare 
+        welk percentage van de totale beschikbare batterijcapaciteit kan worden ingezet voor opslagdiensten. </br></br>
+        De totale beschikbare 
         capaciteit van batterijen in bestelbussen hangt af van het aandeel elektrische bestelbussen in de 
-        <a href="/scenario/demand/transport_freight_transport/truck-technology">bestelbussentechnologie</a> sectie. </br></br>
+        <a href="/scenario/demand/transport_freight_transport/truck-technology">bestelbussentechnologie</a> sectie.
+        De efficiëntie van batterijen in elektrische voertuigen kan
+        <a href="/scenario/costs/costs_flexibility/electricity-storage">hier</a> worden aangepast. </br></br>
         Er zijn een aantal grafieken beschikbaar om je te helpen bepalen wat het effect is
         van het benutten van batterijen in elektrische auto's: </br></br>
         <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
@@ -675,7 +700,15 @@ nl:
     volume_of_transport_van_using_electricity:
       title: Relatief opslagvolume
       short_description:
-      description:
+      description: |
+        Met dit schuifje kun je het opslagvolume van de batterij relatief ten opzichte van het inputvermogen instellen.
+        Dit bepaalt hoeveel uur de batterij op vol vermogen moet laden om van leeg naar volledig vol te gaan.
+        Effectief verandert dit schuifje daarom het totale opslagvolume, gegeven een bepaalde hoeveelheid 
+        geïnstalleerd vermogen. </br></br>
+        Het totale opslagvolume kun je zien in de 'Technische parameters en kosten' hieronder. Als het snel wilt
+        vergelijken met andere opslagtechnologieën kun je ook
+        <a href="#" class="open_chart" data-chart-key="storage_specifications" data-chart-location="side">
+        deze tabel</a> openen.
     wtp_of_transport_car_flexibility_p2p_electricity:
       title: Willingness-to-pay
       short_description:
@@ -723,10 +756,12 @@ nl:
         <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
         deze grafiek</a>.
     capacity_of_energy_flexibility_pumped_storage_electricity:
-      title: Stuwmeren
+      title: Geïnstalleerd vermogen
       short_description:
       description: |
-        Met dit schuifje kun je het geïnstalleerd inputvermogen van stuwmeren bepalen. </br></br>
+        Met dit schuifje kun je het geïnstalleerd inputvermogen van stuwmeren bepalen. 
+        De efficiëntie van stuwmeren kan
+        <a href="/scenario/costs/costs_flexibility/electricity-storage">hier</a> worden aangepast. </br></br>
         Er zijn een aantal grafieken beschikbaar om je te helpen bepalen wat het effect is
         van de inzet van stuwmeren: </br></br>
         <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
@@ -742,6 +777,18 @@ nl:
         je met de onderstaande schuifjes veranderen. De uurlijkse elektriciteitsprijs is te zien in
         <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
         deze grafiek</a>.
+    volume_of_energy_flexibility_pumped_storage_electricity:
+      title: Relatief opslagvolume
+      short_description:
+      description: |
+        Met dit schuifje kun je het opslagvolume van de stuwmeren relatief ten opzichte van het inputvermogen instellen.
+        Dit bepaalt hoeveel uur de stuwmeren op vol vermogen elektriciteit moeten consumeren om van leeg naar volledig vol te gaan.
+        Effectief verandert dit schuifje daarom het totale opslagvolume, gegeven een bepaalde hoeveelheid 
+        opgesteld vermogen. </br></br>
+        Het totale opslagvolume kun je zien in de 'Technische parameters en kosten' hieronder. Als het snel wilt
+        vergelijken met andere opslagtechnologieën kun je ook
+        <a href="#" class="open_chart" data-chart-key="storage_specifications" data-chart-location="side">
+        deze tabel</a> openen.
     wtp_of_energy_flexibility_pumped_storage_electricity:
       title: Willingness-to-pay
       short_description:
@@ -793,7 +840,7 @@ nl:
       short_description:
       description: |
         Met dit schuifje kun je het geïnstalleerd inputvermogen van Ondergrondse Pomp Accumulatie Centrales (OPAC) bepalen.
-        De investeringskosten van OPAC kunnen <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">
+        De efficiëntie en investeringskosten van OPAC kunnen <a href="/scenario/costs/costs_flexibility/electricity-storage">
         hier</a> worden aangepast. <br></br>
         Er zijn een aantal grafieken beschikbaar om je te helpen bepalen wat het effect is
         van de inzet van OPAC: </br></br>
@@ -814,24 +861,14 @@ nl:
       title: Relatief opslagvolume
       short_description:
       description: |
-        Met dit schuifje kun je het opslagvolume van Ondergrondse Pomp Accumulatie Centrales (OPAC) bepalen.
-        De investeringskosten van OPAC kunnen <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">
-        hier</a> worden aangepast. <br></br>
-        Er zijn een aantal grafieken beschikbaar om je te helpen bepalen wat het effect is
-        van de inzet van OPAC: </br></br>
-        <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
-        De jaarlijkse inzet van elektriciteit geconsumeerd door flexible vraagtechnologieën.</a></li>
-        <li><a href="#" class="open_chart" data-chart-key="hourly_flexibility_electricity" data-chart-location="side">
-        De uurlijkse elektriciteitsvraag en -aanbod van flexibele technologieën.</a></li>
-        <li><a href="#" class="open_chart" data-chart-key="flexibility_integral_costs" data-chart-location="side">
-        De integrale kosten van flexible vraagtechnnologieën</a></li>
-        <li><a href="#" class="open_chart" data-chart-key="storage_options" data-chart-location="side">
-        Een overzicht van de inzet van flexibele vraagtechnologieën in tabelvorm.</a></li></ul> </br>
-        Als je geen effect ziet van veranderingen in dit schuifje, dan kan het zijn dat de uurlijkse elektriciteitsprijs
-        nooit onder de willingness-to-pay zakt, of nooit boven de willingness-to-accept uitkomt. Deze parameters kun
-        je met de onderstaande schuifjes veranderen. De uurlijkse elektriciteitsprijs is te zien in
-        <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
-        deze grafiek</a>.
+        Met dit schuifje kun je het opslagvolume van de Ondergrondse Pomp Accumulatie Centrales (OPAC) relatief ten opzichte van het inputvermogen instellen.
+        Dit bepaalt hoeveel uur de OPAC op vol vermogen elektriciteit moeten consumeren om van leeg naar volledig vol te gaan.
+        Effectief verandert dit schuifje daarom het totale opslagvolume, gegeven een bepaalde hoeveelheid 
+        opgesteld vermogen. </br></br>
+        Het totale opslagvolume kun je zien in de 'Technische parameters en kosten' hieronder. Als het snel wilt
+        vergelijken met andere opslagtechnologieën kun je ook
+        <a href="#" class="open_chart" data-chart-key="storage_specifications" data-chart-location="side">
+        deze tabel</a> openen.
     wtp_of_energy_flexibility_hv_opac_electricity:
       title: Willingness-to-pay
       short_description:
@@ -883,7 +920,7 @@ nl:
       short_description:
       description: |
         Met dit schuifje kun je het geïnstalleerd inputvermogen van grootschalige batterijopslag bepalen.
-        De investeringskosten van grootschalige batterijopslag kunnen <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">
+        De efficiëntie en investeringskosten van grootschalige batterijopslag kunnen <a href="/scenario/costs/costs_flexibility/electricity-storage">
         hier</a> worden aangepast. <br></br>
         Er zijn een aantal grafieken beschikbaar om je te helpen bepalen wat het effect is
         van de inzet van grootschalige batterijopslag: </br></br>
@@ -904,24 +941,14 @@ nl:
       title: Relatief opslagvolume
       short_description:
       description: |
-        Met dit schuifje kun je het relatieve opslagvolume van grootschalige batterijopslag bepalen.
-        De investeringskosten van grootschalige batterijopslag kunnen <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">
-        hier</a> worden aangepast. <br></br>
-        Er zijn een aantal grafieken beschikbaar om je te helpen bepalen wat het effect is
-        van de inzet van grootschalige batterijopslag: </br></br>
-        <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
-        De jaarlijkse inzet van elektriciteit geconsumeerd door flexible vraagtechnologieën.</a></li>
-        <li><a href="#" class="open_chart" data-chart-key="hourly_flexibility_electricity" data-chart-location="side">
-        De uurlijkse elektriciteitsvraag en -aanbod van flexibele technologieën.</a></li>
-        <li><a href="#" class="open_chart" data-chart-key="flexibility_integral_costs" data-chart-location="side">
-        De integrale kosten van flexible vraagtechnnologieën</a></li>
-        <li><a href="#" class="open_chart" data-chart-key="storage_options" data-chart-location="side">
-        Een overzicht van de inzet van flexibele vraagtechnologieën in tabelvorm.</a></li></ul> </br>
-        Als je geen effect ziet van veranderingen in dit schuifje, dan kan het zijn dat de uurlijkse elektriciteitsprijs
-        nooit onder de willingness-to-pay zakt, of nooit boven de willingness-to-accept uitkomt. Deze parameters kun
-        je met de onderstaande schuifjes veranderen. De uurlijkse elektriciteitsprijs is te zien in
-        <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
-        deze grafiek</a>.
+        Met dit schuifje kun je het opslagvolume van de batterij relatief ten opzichte van het inputvermogen instellen.
+        Dit bepaalt hoeveel uur de batterij op vol vermogen moet laden om van leeg naar volledig vol te gaan.
+        Effectief verandert dit schuifje daarom het totale opslagvolume, gegeven een bepaalde hoeveelheid 
+        geïnstalleerd vermogen. </br></br>
+        Het totale opslagvolume kun je zien in de 'Technische parameters en kosten' hieronder. Als het snel wilt
+        vergelijken met andere opslagtechnologieën kun je ook
+        <a href="#" class="open_chart" data-chart-key="storage_specifications" data-chart-location="side">
+        deze tabel</a> openen.
     wtp_of_energy_flexibility_mv_batteries_electricity:
       title: Willingness-to-pay
       short_description:
@@ -974,8 +1001,8 @@ nl:
       description: |
         Met dit schuifje kun je het geïnstalleerd inputvermogen van flowbatterijen bepalen. Omdat het inputvermogen en het
         opslagvolume van flowbatterijen afzonderlijk gevarieerd kunnen worden, bestaan de investeringskosten
-        ook uit twee componenten. Je kunt de investeringskosten per MW inputvermogen
-        <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">
+        ook uit twee componenten. Je kunt de efficiëntie van flowbatterijen en investeringskosten per MW en per MWh
+        <a href="/scenario/costs/costs_flexibility/electricity-storage">
         hier</a> aanpassen. <br></br>
         Er zijn een aantal grafieken beschikbaar om je te helpen bepalen wat het effect is
         van de inzet van flowbatterijen: </br></br>
@@ -996,11 +1023,13 @@ nl:
       title: Relatief opslagvolume
       short_description:
       description: |
-        Met dit schuifje kun je het relatieve opslagvolume van flowbatterijen ten opzichte van het inputvermogen bepalen.
-        Effectief bepaalt dit schuifje hoeveel uur je een lege fowbatterij op vol vermogen kan opladen tot het vol is.
-        Het totale opslagvolume kun je vervolgens zien in de 'Technische parameters en kosten' hieronder. Als het snel wilt
+        Met dit schuifje kun je het opslagvolume van de batterij relatief ten opzichte van het inputvermogen instellen.
+        Dit bepaalt hoeveel uur de batterij op vol vermogen moet laden om van leeg naar volledig vol te gaan.
+        Effectief verandert dit schuifje daarom het totale opslagvolume, gegeven een bepaalde hoeveelheid 
+        geïnstalleerd vermogen. </br></br>
+        Het totale opslagvolume kun je zien in de 'Technische parameters en kosten' hieronder. Als het snel wilt
         vergelijken met andere opslagtechnologieën kun je ook
-        <a href="#" class="open_chart" data-chart-key="storage_options" data-chart-location="side">
+        <a href="#" class="open_chart" data-chart-key="storage_specifications" data-chart-location="side">
         deze tabel</a> openen.
         </br></br>
         Omdat het inputvermogen en het opslagvolume van flowbatterijen afzonderlijk gevarieerd kunnen worden, bestaan
@@ -1352,7 +1381,9 @@ nl:
         Er is een vaste verhouding aangenomen van het opslagvolume ten opzichte van het laadvermogen.
         Dit betekent dat als je dit schuifje verandert, het opslagvolume ook zal veranderen. Klik op
         de 'Technische parameters en kosten' om het effect van dit schuifje op het totale vermogen
-        en opslagvolume van de batterij te zien.
+        en opslagvolume van de batterij te zien. </br></br>
+        De efficiëntie van de batterij kan
+        <a href="/scenario/costs/costs_flexibility/electricity-storage">hier</a> worden aangepast.
     battery_capacity_always_on_solar_pv_solar_radiation:
       title: Relatief batterijvermogen
       short_description:
@@ -1370,7 +1401,33 @@ nl:
         Er is een vaste verhouding aangenomen van het opslagvolume ten opzichte van het laadvermogen.
         Dit betekent dat als je dit schuifje verandert, het opslagvolume ook zal veranderen. Klik op
         de 'Technische parameters en kosten' om het effect van dit schuifje op het totale vermogen
-        en opslagvolume van de batterij te zien.
+        en opslagvolume van de batterij te zien.  </br></br>
+        De efficiëntie van de batterij kan
+        <a href="/scenario/costs/costs_flexibility/electricity-storage">hier</a> worden aangepast.
+    volume_of_energy_flexibility_wind_batteries_electricity:
+      title: Relatief opslagvolume
+      short_description:
+      description: |
+        Met dit schuifje kun je het opslagvolume van de batterij relatief ten opzichte van het inputvermogen instellen.
+        Dit bepaalt hoeveel uur de batterij op vol vermogen moet laden om van leeg naar volledig vol te gaan.
+        Effectief verandert dit schuifje daarom het totale opslagvolume, gegeven een bepaalde hoeveelheid 
+        geïnstalleerd vermogen. </br></br>
+        Het totale opslagvolume kun je zien in de 'Technische parameters en kosten' hieronder. Als het snel wilt
+        vergelijken met andere opslagtechnologieën kun je ook
+        <a href="#" class="open_chart" data-chart-key="storage_specifications" data-chart-location="side">
+        deze tabel</a> openen.
+    volume_of_energy_flexibility_solar_batteries_electricity:
+      title: Relatief opslagvolume
+      short_description:
+      description: |
+        Met dit schuifje kun je het opslagvolume van de batterij relatief ten opzichte van het inputvermogen instellen.
+        Dit bepaalt hoeveel uur de batterij op vol vermogen moet laden om van leeg naar volledig vol te gaan.
+        Effectief verandert dit schuifje daarom het totale opslagvolume, gegeven een bepaalde hoeveelheid 
+        geïnstalleerd vermogen. </br></br>
+        Het totale opslagvolume kun je zien in de 'Technische parameters en kosten' hieronder. Als het snel wilt
+        vergelijken met andere opslagtechnologieën kun je ook
+        <a href="#" class="open_chart" data-chart-key="storage_specifications" data-chart-location="side">
+        deze tabel</a> openen.
     flexibility_residual_load_curve_moving_average:
       title: Voortschrijdend gemiddelde tijdsperiode
       short_description:

--- a/config/locales/interface/input_elements/nl_flexibility.yml
+++ b/config/locales/interface/input_elements/nl_flexibility.yml
@@ -565,7 +565,7 @@ nl:
         <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
         deze grafiek</a>.
     transport_car_using_electricity_availability:
-      title: Batterijen in elektrische auto's
+      title: Inzetbaar vermogen
       short_description:
       description: |
         Niet al het opslagvolume van elektrische auto's kan worden gebruikt om opslagdiensten te verlenen aan het elektriciteitsnet,
@@ -588,8 +588,12 @@ nl:
         je met de onderstaande schuifjes veranderen. De uurlijkse elektriciteitsprijs is te zien in
         <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
         deze grafiek</a>.
+    volume_of_transport_car_using_electricity:
+      title: Relatief opslagvolume
+      short_description:
+      description:
     transport_bus_using_electricity_availability:
-      title: Batterijen in elektrische bussen
+      title: Inzetbaar vermogen
       short_description:
       description: |
         Niet al het opslagvolume van elektrische bussen kan worden gebruikt om opslagdiensten te verlenen aan het elektriciteitsnet,
@@ -612,8 +616,12 @@ nl:
         je met de onderstaande schuifjes veranderen. De uurlijkse elektriciteitsprijs is te zien in
         <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
         deze grafiek</a>.
+    volume_of_transport_bus_using_electricity:
+      title: Relatief opslagvolume
+      short_description:
+      description:
     transport_truck_using_electricity_availability:
-      title: Batterijen in elektrische vrachtwagens
+      title: Inzetbaar vermogen
       short_description:
       description: |
         Niet al het opslagvolume van elektrische vrachtwagens kan worden gebruikt om opslagdiensten te verlenen aan het elektriciteitsnet,
@@ -636,8 +644,12 @@ nl:
         je met de onderstaande schuifjes veranderen. De uurlijkse elektriciteitsprijs is te zien in
         <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
         deze grafiek</a>.
+    volume_of_transport_truck_using_electricity:
+      title: Relatief opslagvolume
+      short_description:
+      description:
     transport_van_using_electricity_availability:
-      title: Batterijen in elektrische bestelbussen
+      title: Inzetbaar vermogen
       short_description:
       description: |
         Niet al het opslagvolume van elektrische bestelbussen kan worden gebruikt om opslagdiensten te verlenen aan het elektriciteitsnet,
@@ -660,6 +672,10 @@ nl:
         je met de onderstaande schuifjes veranderen. De uurlijkse elektriciteitsprijs is te zien in
         <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
         deze grafiek</a>.
+    volume_of_transport_van_using_electricity:
+      title: Relatief opslagvolume
+      short_description:
+      description:
     wtp_of_transport_car_flexibility_p2p_electricity:
       title: Willingness-to-pay
       short_description:
@@ -710,7 +726,7 @@ nl:
       title: Stuwmeren
       short_description:
       description: |
-        Met dit schuifje kun je het inputvermogen van stuwmeren bepalen. </br></br>
+        Met dit schuifje kun je het geïnstalleerd inputvermogen van stuwmeren bepalen. </br></br>
         Er zijn een aantal grafieken beschikbaar om je te helpen bepalen wat het effect is
         van de inzet van stuwmeren: </br></br>
         <ul><li><a href="#" class="open_chart" data-chart-key="use_of_excess_electricity" data-chart-location="side">
@@ -776,7 +792,7 @@ nl:
       title: Geïnstalleerd vermogen
       short_description:
       description: |
-        Met dit schuifje kun je het inputvermogen van Ondergrondse Pomp Accumulatie Centrales (OPAC) bepalen.
+        Met dit schuifje kun je het geïnstalleerd inputvermogen van Ondergrondse Pomp Accumulatie Centrales (OPAC) bepalen.
         De investeringskosten van OPAC kunnen <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">
         hier</a> worden aangepast. <br></br>
         Er zijn een aantal grafieken beschikbaar om je te helpen bepalen wat het effect is
@@ -866,7 +882,7 @@ nl:
       title: Geïnstalleerd vermogen
       short_description:
       description: |
-        Met dit schuifje kun je het inputvermogen van grootschalige batterijopslag bepalen.
+        Met dit schuifje kun je het geïnstalleerd inputvermogen van grootschalige batterijopslag bepalen.
         De investeringskosten van grootschalige batterijopslag kunnen <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">
         hier</a> worden aangepast. <br></br>
         Er zijn een aantal grafieken beschikbaar om je te helpen bepalen wat het effect is
@@ -953,10 +969,10 @@ nl:
         <a href="#" class="open_chart" data-chart-key="merit_order_price_curve" data-chart-location="side">
         deze grafiek</a>.
     capacity_of_energy_flexibility_flow_batteries_electricity:
-      title: Flowbatterijen
+      title: Geïnstalleerd vermogen
       short_description:
       description: |
-        Met dit schuifje kun je het inputvermogen van flowbatterijen bepalen. Omdat het inputvermogen en het
+        Met dit schuifje kun je het geïnstalleerd inputvermogen van flowbatterijen bepalen. Omdat het inputvermogen en het
         opslagvolume van flowbatterijen afzonderlijk gevarieerd kunnen worden, bestaan de investeringskosten
         ook uit twee componenten. Je kunt de investeringskosten per MW inputvermogen
         <a href="/scenario/costs/costs_flexibility/investment-costs-storage-electricity">

--- a/config/locales/interface/nl_sidebar_items.yml
+++ b/config/locales/interface/nl_sidebar_items.yml
@@ -107,7 +107,7 @@ nl:
         andere dingen.
     costs_flexibility:
       short_title: Flexibiliteit
-      title: Kosten flexibiliteit
+      title: Flexibiliteit
       short_description: ''
       description: ''
     costs_heat:

--- a/config/locales/interface/slides/en_costs.yml
+++ b/config/locales/interface/slides/en_costs.yml
@@ -54,7 +54,7 @@ en:
         electricity consumers attribute to receiving an uninterupted electricity supply, or 
         in other words, the costs they would incur for a supply disruption.
     costs_flexibility_conversion:
-      title: Investment costs conversion electricity
+      title: Electricity conversion
       short_description:
       description: |
         Electricity can be <a href="/scenario/flexibility/flexibility_conversion/conversion-by-flexible-demand-technologies">
@@ -62,7 +62,7 @@ en:
         will change for power-to-heat boilers. The investment costs for power-to-gas can be adjusted on the 
         <a href="/scenario/costs/costs_hydrogen/hydrogen-production">hydrogen production costs</a> page.
     costs_flexibility_storage:
-      title: Investment costs storage electricity
+      title: Electricity storage
       short_description:
       description: Excess electricity can temporarily be stored in for example household
         batteries. Below, you can specify how much the investment costs of this technology

--- a/config/locales/interface/slides/en_costs.yml
+++ b/config/locales/interface/slides/en_costs.yml
@@ -64,9 +64,10 @@ en:
     costs_flexibility_storage:
       title: Electricity storage
       short_description:
-      description: Excess electricity can temporarily be stored in for example household
-        batteries. Below, you can specify how much the investment costs of this technology
-        will change in the future.
+      description: |
+        Electricity can be <a href="/scenario/flexibility/flexibility_storage/behaviour-of-storage-technologies">
+        stored</a> in different technologies. Below you can specify how the investment costs and the 
+        round-trip efficiency of electricity storage will change in the future.
     costs_heat_network:
       title: Costs district heating infrastructure
       short_description:

--- a/config/locales/interface/slides/nl_costs.yml
+++ b/config/locales/interface/slides/nl_costs.yml
@@ -67,9 +67,11 @@ nl:
     costs_flexibility_storage:
       title: Opslag elektriciteit
       short_description:
-      description: Overschotten aan elektriciteit kunnen tijdelijk worden opgeslagen
-        in bijvoorbeeld batterijen in huizen. Hieronder kun je aangeven hoeveel de
-        investeringskosten van deze technologie in de toekomst zullen veranderen.
+      description: |
+        Elektriciteit kan in verschillende technologieën worden
+        <a href="/scenario/flexibility/flexibility_storage/behaviour-of-storage-technologies">
+        opgeslagen</a>. Hieronder kun je bepalen hoeveel de investeringskosten en retourefficiëntie 
+        van elektriciteitsoplag zullen veranderen.
     costs_heat_network:
       title: Kosten warmtenetinfrastructuur
       short_description:

--- a/config/locales/interface/slides/nl_costs.yml
+++ b/config/locales/interface/slides/nl_costs.yml
@@ -55,7 +55,7 @@ nl:
         toekennen aan een ononderbroken elektriciteitslevering, of in andere woorden, de kosten die 
         ze zouden maken als het aanbod verstoord wordt.
     costs_flexibility_conversion:
-      title: Investeringskosten conversie elektriciteit
+      title: Conversie elektriciteit
       short_description:
       description: |
         Elektriciteit kan worden 
@@ -65,7 +65,7 @@ nl:
         De investeringskosten voor power-to-gas elektrolysers kunnen worden aangepast op de
         <a href="/scenario/costs/costs_hydrogen/hydrogen-production">waterstofproductie</a> pagina.
     costs_flexibility_storage:
-      title: Investeringskosten opslag elektriciteit
+      title: Opslag elektriciteit
       short_description:
       description: Overschotten aan elektriciteit kunnen tijdelijk worden opgeslagen
         in bijvoorbeeld batterijen in huizen. Hieronder kun je aangeven hoeveel de

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -491,6 +491,10 @@ nl:
     must_run_chps: "Must-run vermogen"
     flexible_chps: "Regelbaar vermogen"
     technical_specifications: "Technische specificaties"
+    technical_specifications_cars: "Technische specificaties auto's"
+    technical_specifications_buses: "Technische specificaties bussen"
+    technical_specifications_trucks: "Technische specificaties vrachtwagens"
+    technical_specifications_vans: "Technische specificaties bestelbussen"
     investment_costs: "Investeringskosten"
     roundtrip_efficiency: "Retourefficiëntie"
 

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -491,6 +491,8 @@ nl:
     must_run_chps: "Must-run vermogen"
     flexible_chps: "Regelbaar vermogen"
     technical_specifications: "Technische specificaties"
+    investment_costs: "Investeringskosten"
+    roundtrip_efficiency: "Retourefficiëntie"
 
   "or": "of"
   "go": "ga"

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -490,6 +490,7 @@ nl:
     fertilizer_production_route: "Ammoniak productieroute"
     must_run_chps: "Must-run vermogen"
     flexible_chps: "Regelbaar vermogen"
+    technical_specifications: "Technische specificaties"
 
   "or": "of"
   "go": "ga"


### PR DESCRIPTION
https://github.com/quintel/etsource/pull/2894 adds inputs for each electricity storage technology that allow user to:

- Change the roundtrip efficiency
- Change the storage volume relative to the installed input capacity

This PR adds those inputs to the frontend with appropriate texts.

**Note**
One point is still up for discussion, which is that the costs of the flow batteries have a component that scales with MW and a component that scales with MWh. This is mentioned specifically in the texts for flow batteries.

The other storage technologies currently only scale with MW. It has yet to be decided whether a MWh component will be assigned to the some or all of the other storage technologies. Only after that choice has been made, will the text about the component for flow batteries be updated.