### PR TITLE
Update buildings chart

### DIFF
--- a/config/interface/output_element_series/use_of_final_demand_in_buildings.yml
+++ b/config/interface/output_element_series/use_of_final_demand_in_buildings.yml
@@ -11,7 +11,7 @@
   dependent_on: 
   output_element_key: use_of_final_demand_in_buildings
   key: cooling_demand_use_of_final_demand_in_buildings
-- label: electrical_appliances
+- label: appliances
   color: "#4169E1"
   order_by: 1
   group: ''

--- a/config/locales/interface/output_elements/en_demand.yml
+++ b/config/locales/interface/output_elements/en_demand.yml
@@ -247,14 +247,13 @@ en:
         of energy saved. \r\n\r\n<br/><br/>\r\nYou can click '<u>Change chart</u>'
         above the graph, to select different graphs about energy demand.\r\n"
     use_of_final_demand_in_buildings:
-      title: Final energy demand in buildings
-      short_description: Buildings
-      description: "This chart shows how much of the heat and electricity that is
-        used in buildings is produced using combined heat and power (CHP) units. If
-        it is not generated using CHP units, heat is produced with the other options
-        available on the Buildings 'Heating' page, and electricity is taken from the
-        electricity grid.\r\n<br/><br/>\r\nYou can click '<u>Change chart</u>' above
-        the graph, to select different graphs about energy demand."
+      title: Final energy demand in buildings per application
+      short_description:
+      description: |
+        This graph shows how buildings final demand for energy will change
+        as a result of the choices you make in this section. <br/><br/>
+        You can click <u>Change chart</u> above the graph, to select different graphs
+        about energy demand.
     effect_of_insulation_in_buildings:
       title: Heating demand with insulation in buildings
       short_description: Buildings
@@ -433,12 +432,13 @@ en:
       short_description: ''
       description: ''
     households_final_demand_per_application:
-      title: Final demand households per application
-      short_description: Households, by application
-      description: "This graph shows how household final demand for energy will change
-        as a result of the choices you make in this section. \r\n<br/><br/>\r\nYou
-        can click '<u>Change chart</u>' above the graph, to select different graphs
-        about energy demand."
+      title: Final energy demand in households per application
+      short_description:
+      description: |
+        This graph shows how households final demand for energy will change
+        as a result of the choices you make in this section. <br/><br/>
+        You can click <u>Change chart</u> above the graph, to select different graphs
+        about energy demand.
     household_space_heater_hhp_hourly_demand:
       title: Demand curve of hybrid heat pump (gas) in households
       short_description:

--- a/config/locales/interface/output_elements/nl_demand.yml
+++ b/config/locales/interface/output_elements/nl_demand.yml
@@ -256,14 +256,13 @@ nl:
         energiebesparing.\r\n\r\n<br/><br/>\r\nKies '<u>Wijzig grafiek</u>' boven
         de grafiek om andere grafieken te tonen over energiegebruik.\r\n"
     use_of_final_demand_in_buildings:
-      title: Eindgebruik energie in gebouwen
-      short_description: Gebouwen
-      description: "Deze grafiek toont hoeveel van het warmte- en elektriciteitsgebruik
-        in de gebouwensector door warmte-kracht koppelingen (WKK's) wordt ingevuld.
-        Warmte die niet met WKK is gemaakt wordt geproduceerd met de opties op de
-        Gebouwen 'Verwarming' pagina. Elektriciteit die niet decentraal wordt gemaakt,
-        komt van het elektriciteitsnet. \r\n<br/><br/>\r\nKies '<u>Wijzig grafiek</u>'
-        boven de grafiek om andere grafieken te tonen over industrieel energiegebruik."
+      title: Eindgebruik energie in gebouwen per applicatie
+      short_description:
+      description: |
+        Deze grafiek toont hoe de finale vraag naar energie in gebouwen verandert 
+        als gevolg van de keuzes en aannames die je in dit onderdeel maakt. <br/><br/>
+        Kies <u>Wijzig grafiek</u> om andere grafieken te tonen
+        over energiegebruik.
     effect_of_insulation_in_buildings:
       title: Warmtevraag met isolatie in gebouwen
       short_description: Gebouwen
@@ -444,12 +443,13 @@ nl:
       short_description: ''
       description: ''
     households_final_demand_per_application:
-      title: Eindgebruik energie in huishoudens
+      title: Eindgebruik energie in huishoudens per applicatie
       short_description: Huishoudelijk, naar toepassing
-      description: "Deze grafiek toont hoe de huishoudelijke finale vraag naar energie
-        verandert als gevolg van de keuzes en aannames die je in dit onderdeel maakt.
-        \r\n<br/><br/>\r\nKies '<u>Wijzig grafiek</u>' om andere grafieken te tonen
-        over energiegebruik."
+      description: |
+        Deze grafiek toont hoe de finale vraag naar energie in huishoudens verandert 
+        als gevolg van de keuzes en aannames die je in dit onderdeel maakt. <br/><br/>
+        Kies <u>Wijzig grafiek</u> om andere grafieken te tonen
+        over energiegebruik.
     household_space_heater_hhp_hourly_demand:
       title: Vraagprofiel van hybride warmtepomp (gas) voor huishoudens
       short_description:


### PR DESCRIPTION
This PR consists of the following minor improvements:

- Changes label of "Electrical appliances" to "Appliances" to indicate that energy demand for buildings appliances can also consist of other carriers than electricity
- Changes label of household and buildings chart to add "per application" to facilitate easier chart identification
- Update buildings chart description to remove outdated information about CHPs 