### PR TITLE
Add agriculture to p2h costs slider

### DIFF
--- a/config/locales/interface/input_elements/en_costs.yml
+++ b/config/locales/interface/input_elements/en_costs.yml
@@ -142,8 +142,9 @@ en:
       description: |
         Power-to-heat boilers convert electricity to heat. In the ETM power-to-heat boilers can be used
         for <a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-district-heating">
-        district heating</a> and for the 
-        <a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-industry"> industry</a>.
+        district heating</a>, for the 
+        <a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-industry"> industry</a>
+        and for <a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-agriculture"> agriculture</a>.
         This slider determines the future change in investment costs of electric boilers.
     investment_costs_hydrogen_electrolysis:
       title: Investment costs power-to-gas

--- a/config/locales/interface/input_elements/en_costs.yml
+++ b/config/locales/interface/input_elements/en_costs.yml
@@ -142,8 +142,8 @@ en:
       description: |
         Power-to-heat boilers convert electricity to heat. In the ETM power-to-heat boilers can be used
         for <a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-district-heating">
-        district heating</a>, for the industry (
-        <a href="/scenario/demand/industry/refineries"> refineries</a>,
+        district heating</a>, for the industry 
+        (<a href="/scenario/demand/industry/refineries">refineries</a>,
         <a href="/scenario/demand/industry/fertilizers"> fertilizers</a>,
         <a href="/scenario/demand/industry/chemicals"> chemicals</a>,
         <a href="/scenario/demand/industry/food"> food</a>, and

--- a/config/locales/interface/input_elements/en_costs.yml
+++ b/config/locales/interface/input_elements/en_costs.yml
@@ -142,9 +142,13 @@ en:
       description: |
         Power-to-heat boilers convert electricity to heat. In the ETM power-to-heat boilers can be used
         for <a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-district-heating">
-        district heating</a>, for the 
-        <a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-industry"> industry</a>
-        and for <a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-agriculture"> agriculture</a>.
+        district heating</a>, for the industry (
+        <a href="/scenario/demand/industry/refineries"> refineries</a>,
+        <a href="/scenario/demand/industry/fertilizers"> fertilizers</a>,
+        <a href="/scenario/demand/industry/chemicals"> chemicals</a>,
+        <a href="/scenario/demand/industry/food"> food</a>, and
+        <a href="/scenario/demand/industry/paper"> paper</a>), and for the
+        <a href="/scenario/demand/agriculture/heat"> agriculture</a>.
         This slider determines the future change in investment costs of electric boilers.
     investment_costs_hydrogen_electrolysis:
       title: Investment costs power-to-gas

--- a/config/locales/interface/input_elements/nl_costs.yml
+++ b/config/locales/interface/input_elements/nl_costs.yml
@@ -150,9 +150,13 @@ nl:
       description: |
         Power-to-heat boilers converteren elektriciteit naar warmte. In het ETM kan power-to-heat worden ingezet 
         voor <a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-district-heating">
-        warmtenetten</a>, voor de 
-        <a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-industry"> industrie</a>
-        en voor de <a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-agriculture"> landbouw</a>.
+        warmtenetten</a>, voor de industrie (
+        <a href="/scenario/demand/industry/refineries"> raffinaderijen</a>,
+        <a href="/scenario/demand/industry/fertilizers"> kunstmest</a>,
+        <a href="/scenario/demand/industry/chemicals"> chemie</a>,
+        <a href="/scenario/demand/industry/food"> voedsel</a>, en
+        <a href="/scenario/demand/industry/paper"> papier</a>) en voor de landbouw
+        <a href="/scenario/demand/agriculture/heat"> agriculture</a>.
         Dit schuifje bepaalt hoeveel de investeringskosten voor elektrische boilers
         in de toekomst gaan veranderen.
     investment_costs_hydrogen_electrolysis:

--- a/config/locales/interface/input_elements/nl_costs.yml
+++ b/config/locales/interface/input_elements/nl_costs.yml
@@ -150,8 +150,9 @@ nl:
       description: |
         Power-to-heat boilers converteren elektriciteit naar warmte. In het ETM kan power-to-heat worden ingezet 
         voor <a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-district-heating">
-        warmtenetten</a> en voor de 
-        <a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-industry"> industrie</a>.
+        warmtenetten</a>, voor de 
+        <a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-industry"> industrie</a>
+        en voor de <a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-agriculture"> landbouw</a>.
         Dit schuifje bepaalt hoeveel de investeringskosten voor elektrische boilers
         in de toekomst gaan veranderen.
     investment_costs_hydrogen_electrolysis:

--- a/config/locales/interface/input_elements/nl_costs.yml
+++ b/config/locales/interface/input_elements/nl_costs.yml
@@ -150,8 +150,8 @@ nl:
       description: |
         Power-to-heat boilers converteren elektriciteit naar warmte. In het ETM kan power-to-heat worden ingezet 
         voor <a href="/scenario/flexibility/flexibility_conversion/conversion-to-heat-for-district-heating">
-        warmtenetten</a>, voor de industrie (
-        <a href="/scenario/demand/industry/refineries"> raffinaderijen</a>,
+        warmtenetten</a>, voor de industrie 
+        (<a href="/scenario/demand/industry/refineries">raffinaderijen</a>,
         <a href="/scenario/demand/industry/fertilizers"> kunstmest</a>,
         <a href="/scenario/demand/industry/chemicals"> chemie</a>,
         <a href="/scenario/demand/industry/food"> voedsel</a>, en


### PR DESCRIPTION
Agriculture p2h boilers were missing from the investment costs of p2h boilers. This PR adds them.

Goes with https://github.com/quintel/etsource/pull/2925