### PR TITLE
Emit postMessage when performing a request in litui mode

### DIFF
--- a/app/assets/javascripts/lib/app.coffee
+++ b/app/assets/javascripts/lib/app.coffee
@@ -190,8 +190,7 @@ class @AppView extends Backbone.View
   handle_ajax_error: (jqXHR, textStatus, error) ->
     console.log("Something went wrong: " + textStatus)
 
-    if globals.env == 'development' ||
-        (globals.env == 'staging' && globals.debug_js)
+    if globals.env == 'development' || (globals.env == 'staging' && globals.debug_js)
       body = $('body')
 
       if !body.hasClass('has-api-error')
@@ -231,6 +230,11 @@ class @AppView extends Backbone.View
   # Get the value of all changed sliders. Get the chart. Sends those values to
   # the server.
   doUpdateRequest: =>
+    # LiteUI means we're rendering in an iframe.
+    # Let the parent window know we're processing a request
+    if $('body').hasClass('liteui')
+      parent.postMessage('request-started', '*')
+
     dirtyInputElements = @input_elements.dirty()
     return if dirtyInputElements.length == 0
     input_params = @input_elements.api_update_params()
@@ -247,6 +251,10 @@ class @AppView extends Backbone.View
   hideLoading: ->
     $(".chart_holder").busyBox('close')
     $("#dashboard .loading").hide()
+
+    # Done! Also let the parent know
+    if $('body').hasClass('liteui')
+      parent.postMessage('request-stopped', '*')
 
   debug: (t) ->
     console.log(t) if globals.debug_js

--- a/app/assets/stylesheets/_liteui.sass
+++ b/app/assets/stylesheets/_liteui.sass
@@ -7,6 +7,13 @@ body.liteui
 
   #wrapper, #content
     min-width: initial
+    padding-top: 0
 
   #content #active-content
     padding-bottom: 20px
+
+  #content .flex-wrapper
+    padding-top: 0
+
+  #content #sidebar
+    height: 100%


### PR DESCRIPTION
For a full **What?**, **Why?** and **How?** of the changes in this PR please see the description here:
https://github.com/quintel/multi-year-charts/pull/41

TL;DR:
To implement the third solution as suggested [here](https://github.com/quintel/multi-year-charts/issues/36#issuecomment-1660565860) this PR makes ETModel emit a [postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) when it fires a request while in `liteui` mode. Other applications, such as the MYC, can listen for this postMessage event to alter their UI as required.

Closes https://github.com/quintel/multi-year-charts/issues/36