### PR TITLE
Add interface-group name to slide inputs

### DIFF
--- a/app/models/slide_presenter.rb
+++ b/app/models/slide_presenter.rb
@@ -39,8 +39,9 @@ class SlidePresenter
   def inputs
     # Sort in Ruby to avoid N+1 query.
     @slide.sliders.sort_by(&:position).map do |ie|
-      ie.as_json(only: %w[key unit]).merge(
-        'name' => translate_item(:input_elements, ie)
+      ie.as_json(only: %w[key unit interface_group]).merge(
+        'name' => translate_item(:input_elements, ie),
+        'group_name' => ie.interface_group.present? ? I18n.t("accordion.#{ie.interface_group}") : nil
       )
     end
   end


### PR DESCRIPTION
For a full **What?**, **Why?** and **How?** of the changes in this PR please see the description here:
https://github.com/quintel/multi-year-charts/pull/42

TL;DR:
This PR adds the interface-group name to inputs so that they can be distinguished in MYC Slider settings.

Closes https://github.com/quintel/multi-year-charts/issues/39