### PR TITLE
Add brief clarification on scenario compatibility

### DIFF
--- a/app/helpers/scenario_helper.rb
+++ b/app/helpers/scenario_helper.rb
@@ -143,11 +143,14 @@ module ScenarioHelper
   def previous_version_scenario_warning(scenario, current_release_date)
     return if scenario.updated_at >= current_release_date
 
-    t(
-      'scenario.warning.message',
-      last_updated: l(scenario.updated_at.to_date, format: :long),
-      release_date: l(current_release_date.to_date, format: :long)
-    )
+    <<~WARNING.chomp
+      #{t(
+        'scenario.warning.message',
+        last_updated: l(scenario.updated_at.to_date, format: :long),
+        release_date: l(current_release_date.to_date, format: :long)
+      )}
+      #{t('scenario.warning.explanation')}
+    WARNING
   end
 
   # Classes for the scenario row on the scenario listing.

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -289,6 +289,9 @@ en:
       message: |
         This scenario was last updated on %{last_updated}, in an earlier version of the model. The
         most recent release of the model was on %{release_date}.
+      explanation: |
+        This could potentially mean the scenario has values set for (slider) inputs that have been altered
+        or no longer exist, and is therefore no longer compatible with the current model.
       effect: How do updates to the model affect scenarios?
       outcomes_explanation: |
         Scenario outcomes may change due to improvements in the model, better quality data, or the


### PR DESCRIPTION
## What?
This PR adds a brief line explaining what it means if the scenario version is different from the current model version.

## Why?
To make the user aware of the possible implications of older scenario versions.

## How?
See changes.

Closes #4145 