### PR TITLE
Disallow setting old scenarios as active for a saved_scenario

### DIFF
--- a/app/models/saved_scenario.rb
+++ b/app/models/saved_scenario.rb
@@ -127,7 +127,7 @@ class SavedScenario < ApplicationRecord
     incoming_id = params[:scenario_id]
     add_id_to_history(scenario_id) if incoming_id && scenario_id != incoming_id
 
-    # "Manual versioning" by the user, e.g. setting an earlier used scenario-id
+    # "Manual scenario reverting" by the user, e.g. setting an earlier used scenario-id
     # as the current active scenario, is not allowed.
     if scenario_id_history.include?(incoming_id)
       errors.add(

--- a/app/models/saved_scenario.rb
+++ b/app/models/saved_scenario.rb
@@ -127,6 +127,17 @@ class SavedScenario < ApplicationRecord
     incoming_id = params[:scenario_id]
     add_id_to_history(scenario_id) if incoming_id && scenario_id != incoming_id
 
+    # "Manual versioning" by the user, e.g. setting an earlier used scenario-id
+    # as the current active scenario, is not allowed.
+    if scenario_id_history.include?(incoming_id)
+      errors.add(
+        :scenario_id,
+        "Given scenario id #{incoming_id} is already present in this saved scenario's history."
+      )
+
+      return false
+    end
+
     self.attributes = params.except(:discarded)
 
     if params.key?(:discarded)

--- a/app/services/update_saved_scenario.rb
+++ b/app/services/update_saved_scenario.rb
@@ -22,6 +22,15 @@ class UpdateSavedScenario
   def call
     return api_response if failure?
 
+    # "Manual versioning" by the user, e.g. setting an earlier used scenario-id
+    # as the current active scenario, is not allowed.
+    if saved_scenario.scenario_id_history.include?(api_scenario.id)
+      return ServiceResult.failure(
+        "Scenario id #{api_scenario} is already present in this saved scenario's history.",
+        saved_scenario
+      )
+    end
+
     saved_scenario.tap do |ss|
       ss.add_id_to_history(ss.scenario_id)
       ss.scenario_id = api_scenario.id

--- a/app/services/update_saved_scenario.rb
+++ b/app/services/update_saved_scenario.rb
@@ -22,7 +22,7 @@ class UpdateSavedScenario
   def call
     return api_response if failure?
 
-    # "Manual versioning" by the user, e.g. setting an earlier used scenario-id
+    # "Manual scenario reverting" by the user, e.g. setting an earlier used scenario-id
     # as the current active scenario, is not allowed.
     if saved_scenario.scenario_id_history.include?(api_scenario.id)
       return ServiceResult.failure(


### PR DESCRIPTION
## What?
This PR makes it impossible to set a previously used `Scenario` as the active scenario for a `SavedScenario`.

## Why?
We no longer want to allow our users to manually revert a saved scenario to an older version/scenario. For this specific use-case we will add a new dedicated endpoint to our API, such as `api/v1/saved_scenario/:id/revert_to_scenario/:scenario_id` or so, to do this in a more explicit and controlled manner.

## How?
When updating a `SavedScenario` the given `scenario_id` is checked against the `scenario_id_history`, and an error is returned if it is found.

Closes quintel/etengine#1320