### PR TITLE
Add local household storage optimization as an option for household battery

### DIFF
--- a/app/assets/javascripts/lib/models/input_element.coffee
+++ b/app/assets/javascripts/lib/models/input_element.coffee
@@ -105,6 +105,18 @@ class @InputElement extends Backbone.Model
   additional_callbacks: ->
     if @get('key') == 'settings_enable_merit_order'
       App.update_merit_order_checkbox()
+    if @get('unit') == 'radio'
+      this.handle_radio_callbacks()
+
+  handle_radio_callbacks: ->
+    enabled = @get('user_value') || false
+
+    # Handle when_true, when_false config
+    { when_not_default } = (@get('config') || {})
+
+    if when_not_default && when_not_default.disables
+      for key in when_not_default.disables
+        @collection.markInputDisabled(key, @get('key'), enabled)
 
   handle_boolean_callbacks: ->
     enabled = @get('user_value') || false

--- a/app/assets/javascripts/lib/models/input_element.coffee
+++ b/app/assets/javascripts/lib/models/input_element.coffee
@@ -183,7 +183,7 @@ class @InputElementList extends Backbone.Collection
           # accounts for this.
           i.set(step_value: values.step)
 
-      v = +values.user
+      v = if values.unit == "enum" then values.user else +values.user
       def = if (v? && !_.isNaN(v)) then v else values.default
       # Disable if ET-Model *or* ET-Engine disable the input.
       dis = this.isDisabled(i.get('key')) || i.get('disabled') || values.disabled

--- a/app/assets/javascripts/lib/models/input_element.coffee
+++ b/app/assets/javascripts/lib/models/input_element.coffee
@@ -109,7 +109,7 @@ class @InputElement extends Backbone.Model
       this.handle_radio_callbacks()
 
   handle_radio_callbacks: ->
-    enabled = @get('user_value') || false
+    enabled = @get('user_value') != "default"
 
     # Handle when_true, when_false config
     { when_not_default } = (@get('config') || {})

--- a/app/assets/javascripts/lib/views/radio_collection_view.js
+++ b/app/assets/javascripts/lib/views/radio_collection_view.js
@@ -72,6 +72,8 @@
 
       this.updateSelected();
 
+      this.model.handle_radio_callbacks();
+
       return this;
     },
 

--- a/config/interface/input_elements/flexibility_flexibility_power_storage.yml
+++ b/config/interface/input_elements/flexibility_flexibility_power_storage.yml
@@ -46,7 +46,7 @@
   position: 14
   slide_key: flexibility_power_storage_households_flexibility_p2p_electricity
   config:
-    when_true:
+    when_not_default:
       disables:
         - wtp_of_households_flexibility_p2p_electricity
         - wta_of_households_flexibility_p2p_electricity

--- a/config/interface/input_elements/flexibility_flexibility_power_storage.yml
+++ b/config/interface/input_elements/flexibility_flexibility_power_storage.yml
@@ -41,7 +41,7 @@
       timeframe: i_h_d_w
 - key: settings_enable_storage_optimisation_households_flexibility_p2p_electricity
   step_value: 1.0
-  unit: boolean
+  unit: radio
   interface_group: storage_optimisation
   position: 14
   slide_key: flexibility_power_storage_households_flexibility_p2p_electricity

--- a/config/interface/output_element_series/flexibility_hourly_carriers_inflexible_imbalance.yml
+++ b/config/interface/output_element_series/flexibility_hourly_carriers_inflexible_imbalance.yml
@@ -3,7 +3,7 @@
   dependent_on:
   gquery: electricity_imbalance_inflexible_curve
   key: electricity_imbalance_inflexible_curve_flexiblity_hourly_carriers_inflexible_imbalance
-  label: electricity
+  label: electricity_total_system
   order_by: 100
   output_element_key: flexibility_hourly_carriers_inflexible_imbalance
 - color: "#4169E1"

--- a/config/interface/output_element_series/flexibility_hourly_carriers_inflexible_imbalance.yml
+++ b/config/interface/output_element_series/flexibility_hourly_carriers_inflexible_imbalance.yml
@@ -4,7 +4,14 @@
   gquery: electricity_imbalance_inflexible_curve
   key: electricity_imbalance_inflexible_curve_flexiblity_hourly_carriers_inflexible_imbalance
   label: electricity
-  order_by: 1
+  order_by: 100
+  output_element_key: flexibility_hourly_carriers_inflexible_imbalance
+- color: "#4169E1"
+  dependent_on:
+  gquery: electricity_local_households_imbalance_inflexible_curve
+  key: electricity_local_households_imbalance_inflexible_curve_flexibility_hourly_carriers_inflexible_imbalance
+  label: electricity_local_households
+  order_by: 100
   output_element_key: flexibility_hourly_carriers_inflexible_imbalance
 
 - color: "#B22222"
@@ -12,7 +19,7 @@
   gquery: heat_network_imbalance_inflexible_curve
   key: heat_network_imbalance_inflexible_curve_flexiblity_hourly_carriers_inflexible_imbalance
   label: heat
-  order_by: 2
+  order_by: 200
   output_element_key: flexibility_hourly_carriers_inflexible_imbalance
 
 - color: "#CCCCCC"
@@ -20,7 +27,7 @@
   gquery: network_gas_imbalance_inflexible_curve
   key: network_gas_imbalance_inflexible_curve_flexiblity_hourly_carriers_inflexible_imbalance
   label: gas
-  order_by: 30
+  order_by: 300
   output_element_key: flexibility_hourly_carriers_inflexible_imbalance
 
 - color: "#999999"
@@ -28,7 +35,7 @@
   gquery: network_gas_imbalance_inflexible_smoothed_curve
   key: network_gas_imbalance_inflexible_smoothed_curve_flexiblity_hourly_carriers_inflexible_imbalance
   label: gas_smoothed
-  order_by: 31
+  order_by: 305
   output_element_key: flexibility_hourly_carriers_inflexible_imbalance
 
 - color: "#87CEEB"
@@ -36,7 +43,7 @@
   gquery: hydrogen_imbalance_inflexible_curve
   key: hydrogen_imbalance_inflexible_curve_flexiblity_hourly_carriers_inflexible_imbalance
   label: hydrogen
-  order_by: 40
+  order_by: 400
   output_element_key: flexibility_hourly_carriers_inflexible_imbalance
 
 - color: "#69a2b8"
@@ -44,5 +51,5 @@
   gquery: hydrogen_imbalance_inflexible_smoothed_curve
   key: hydrogen_imbalance_inflexible_smoothed_curve_flexiblity_hourly_carriers_inflexible_imbalance
   label: hydrogen_smoothed
-  order_by: 41
+  order_by: 405
   output_element_key: flexibility_hourly_carriers_inflexible_imbalance

--- a/config/locales/en_radio_elements.yml
+++ b/config/locales/en_radio_elements.yml
@@ -40,11 +40,17 @@ en:
           Celsius)
     settings_enable_storage_optimisation_households_flexibility_p2p_electricity:
       default:
-        title: 'Off'
-        description: The battery shows price sensitive behaviour
+        title: 'No forecasting algorithm'
+        description: |
+          Battery behaviour is price-sensitive, meaning that its behaviour is determined by the 
+          willingness-to-pay and willingness-to-accepts sliders above.
       optimizing_storage:
-        title: 'Forecasting on the full energy system'
-        description: '...'
+        title: 'System forecasting algorithm'
+        description: |
+          Battery behaviour is determined by a forecasting algorithm that looks at the supply and 
+          demand of the electricity system as a whole.
       optimizing_storage_households:
-        title: 'Forecasting only for households'
-        description: '...'
+        title: 'Local forecasting algorithm'
+        description: |
+          Battery behaviour is determined by a forecasting algorithm that looks at local household
+          electricity supply and demand.

--- a/config/locales/en_radio_elements.yml
+++ b/config/locales/en_radio_elements.yml
@@ -38,3 +38,13 @@ en:
           (Full load hours: wind onshore / coastal = 1937, wind offshore = 3334,
           solar pv = 933, solar thermal = 604. Average temperature difference compared to 2015 = -0.5 degrees
           Celsius)
+    settings_enable_storage_optimisation_households_flexibility_p2p_electricity:
+      default:
+        title: 'Off'
+        description: The battery shows price sensitive behaviour
+      optimizing_storage:
+        title: 'Forecasting on the full energy system'
+        description: '...'
+      optimizing_storage_households:
+        title: 'Forecasting only for households'
+        description: '...'

--- a/config/locales/interface/output_element_series/en_labels.yml
+++ b/config/locales/interface/output_element_series/en_labels.yml
@@ -455,6 +455,7 @@ en:
         electricity_stored_in_opac: "Stored in underground pumped hydro storage"
         electricity_stored_in_mv_batteries: "Stored in large-scale batteries"
         electricity_stored_in_flow_batteries: "Stored in flow batteries"
+        electricity_local_households: "Electricity (local households)"
         electricity_load_shifting_in_industry_use_of_excess_electricity: "Load shifting in industry"
         electricity_converted_to_heat_district_heating_heatpump: "Converted to heat for district heating (heat pump)"
         electricity_converted_to_heat_district_heating_boiler: "Converted to heat for district heating (boiler)"

--- a/config/locales/interface/output_element_series/en_labels.yml
+++ b/config/locales/interface/output_element_series/en_labels.yml
@@ -455,6 +455,7 @@ en:
         electricity_stored_in_opac: "Stored in underground pumped hydro storage"
         electricity_stored_in_mv_batteries: "Stored in large-scale batteries"
         electricity_stored_in_flow_batteries: "Stored in flow batteries"
+        electricity_total_system: "Electricity (total system)"
         electricity_local_households: "Electricity (local households)"
         electricity_load_shifting_in_industry_use_of_excess_electricity: "Load shifting in industry"
         electricity_converted_to_heat_district_heating_heatpump: "Converted to heat for district heating (heat pump)"

--- a/config/locales/interface/output_element_series/nl_labels.yml
+++ b/config/locales/interface/output_element_series/nl_labels.yml
@@ -436,6 +436,7 @@ nl:
         electricity_stored_in_opac: "Opgeslagen in OPAC"
         electricity_stored_in_mv_batteries: "Opgeslagen in grootschalige batterijen"
         electricity_stored_in_flow_batteries: "Opgeslagen in flowbatterijen"
+        electricity_total_system: "Elektriciteit (totaal systeem)"
         electricity_local_households: "Elektriciteit (lokaal huishoudens)"
         electricity_load_shifting_in_industry_use_of_excess_electricity: "Vraagverschuiving in industrie"
         electricity_converted_to_heat_district_heating_heatpump: "Omgezet in warmte voor warmtenetten (warmtepomp)"

--- a/config/locales/interface/output_element_series/nl_labels.yml
+++ b/config/locales/interface/output_element_series/nl_labels.yml
@@ -436,6 +436,7 @@ nl:
         electricity_stored_in_opac: "Opgeslagen in OPAC"
         electricity_stored_in_mv_batteries: "Opgeslagen in grootschalige batterijen"
         electricity_stored_in_flow_batteries: "Opgeslagen in flowbatterijen"
+        electricity_local_households: "Elektriciteit (lokaal huishoudens)"
         electricity_load_shifting_in_industry_use_of_excess_electricity: "Vraagverschuiving in industrie"
         electricity_converted_to_heat_district_heating_heatpump: "Omgezet in warmte voor warmtenetten (warmtepomp)"
         electricity_converted_to_heat_district_heating_boiler: "Omgezet in warmte voor warmtenetten (boiler)"

--- a/config/locales/interface/output_elements/en_flexibility.yml
+++ b/config/locales/interface/output_elements/en_flexibility.yml
@@ -221,7 +221,10 @@ en:
         the original residual load curve. This is used to split the curve into two timescales and analyse the 
         need for flexibility. You can change the period of the moving average 
         <a href="/scenario/flexibility/flexibility_overview/the-need-for-flexibility-timescales">here</a>. </br></br>
-        For an analysis of the residual load curves of network gas and hydorgen you can open
+        For electricity an additional line is plotted as well. This shows the local residual load of households, 
+        which can be used by households batteries to apply a forecasting algorithm to (see the 
+        <a href="/scenario/flexibility/flexibility_storage/batteries-in-households"> Flexibility</a> section). </br></br>
+        For an analysis of the residual load curves of network gas and hydrogen you can open
         <a href="#" class="open_chart" data-chart-key="need_for_flexibility" data-chart-location="side">
         this table</a>. You can also download the curves in the 
         <a href="/scenario/data/data_export/hourly-curves-for-residual-load">Data export</a> section.

--- a/config/locales/interface/output_elements/labels_groups/en_labels.yml
+++ b/config/locales/interface/output_elements/labels_groups/en_labels.yml
@@ -79,7 +79,7 @@ en:
       energy_flexibility_mv_batteries_electricity: Large-scale batteries
       energy_flexibility_pumped_storage_electricity: Reservoirs
       households_flexibility_p2p_electricity: Batteries in households
-      not_sortable: Forecasting not enabled
+      not_sortable: system forecasting not enabled
       transport_bus_flexibility_p2p_electricity: Batteries in electric buses
       transport_car_flexibility_p2p_electricity: Batteries in electric cars
       transport_truck_flexibility_p2p_electricity: Batteries in electric trucks

--- a/config/locales/interface/output_elements/labels_groups/nl_labels.yml
+++ b/config/locales/interface/output_elements/labels_groups/nl_labels.yml
@@ -77,7 +77,7 @@ nl:
       energy_flexibility_mv_batteries_electricity: Grootschalige batterijopslag
       energy_flexibility_pumped_storage_electricity: Stuwmeren
       households_flexibility_p2p_electricity: Batterijen in huishoudens
-      not_sortable: Prognose-algoritme niet ingeschakeld
+      not_sortable: Systeemprognose-algoritme niet ingeschakeld
       transport_bus_flexibility_p2p_electricity: Batteries in elektrische bussen
       transport_car_flexibility_p2p_electricity: Batteries in elektrische auto's
       transport_truck_flexibility_p2p_electricity: Batteries in elektrische vrachtwagens

--- a/config/locales/interface/output_elements/nl_flexibility.yml
+++ b/config/locales/interface/output_elements/nl_flexibility.yml
@@ -191,17 +191,21 @@ nl:
         Meer informatie over flexibiliteit is te vinden in onze
         <a href="https://docs.energytransitionmodel.com/main/flexibility/" target=\"_blank\">documentatie</a>.
     flexibility_hourly_carriers_inflexible_imbalance:
-      title: Onbalans ("residual load") per uur
+      title: Onbalans (<i>residual load</i>) per uur
       description: |
         Deze grafiek laat de onbalans in basislastvraag en inflexibel aanbod zien voor elektriciteit, gas, waterstof 
         en warmte per uur. De onbalans is berekend door het inflexibele aanbod af te trekken van de basislastvraag, 
-        dit heet de "residual load". Negatieve waarden betekenen "overschotten" aan energie en positieve waarden 
+        dit heet de <i>residual load</i>. Negatieve waarden betekenen "overschotten" aan energie en positieve waarden 
         "tekorten". </br></br>
         Voor netwerkgas en waterstof is een extra lijn toegevoegd, waarmee het voortschrijdend gemiddelde 
         wordt getoond. Dit wordt gebruikt om de originele residual load curve op te splitsen in twee tijdschalen 
         en daarmee de flexibiliteitsbehoefte te analyseren. Je kunt de periode van het voortschrijdend gemiddelde 
         <a href="/scenario/flexibility/flexibility_overview/the-need-for-flexibility-timescales">hier</a> veranderen. </br></br>
-        Voor een analyse van de residual load van netwerkgas en waterstof kun je
+        Voor elektriciteit is ook een additionele lijn toegevoegd. Deze lijn toont de lokale <i>residual load</i> van 
+        huishoudens, die door batterijen in huishoudens gebruikt kan worden om een prognose-algoritme voor in te zetten 
+        (zie de sectie <a href="/scenario/flexibility/flexibility_storage/batteries-in-households"> 
+        Flexibiliteit</a>). </br></br>
+        Voor een analyse van de <i>residual load</i> van netwerkgas en waterstof kun je
         <a href="#" class="open_chart" data-chart-key="need_for_flexibility" data-chart-location="side">
         deze tabel</a> openen. Je kunt ook de curves downloaden in de 
         <a href="/scenario/data/data_export/hourly-curves-for-residual-load">Data-export</a> sectie.

--- a/config/locales/interface/slides/en_flexibility.yml
+++ b/config/locales/interface/slides/en_flexibility.yml
@@ -175,7 +175,7 @@ en:
         <a href="https://docs.energytransitionmodel.com/main/battery-forecasting/" target=\"_blank\"> 
         forecasting algorithm</a> to determine the behaviour of electricity storage technologies. 
         Below you can change the merit order of storage technologies 
-        for which the forecasting algorithm is enabled. </br></br>
+        for which the system forecasting algorithm is enabled. </br></br>
         The first technology in this merit order will try to flatten the 
         <a href="/scenario/flexibility/flexibility_overview/residual-load-curves">residual load curve</a>.
         Each following technology will then use the resulting curve of the previous technology to try and 

--- a/config/locales/interface/slides/en_flexibility.yml
+++ b/config/locales/interface/slides/en_flexibility.yml
@@ -221,14 +221,16 @@ en:
       title: Batteries in households
       short_description:
       description: |
-        It is possible to install batteries in households. These can then be charged by electricity from the grid,
-        or by solar power if the household has solar panels installed. </br></br>
-        Batteries in the ETM are flexible technologies, which 
-        means that they can choose at which moments to charge or discharge. By default, if the electricity price is lower than the willingness to pay of the battery in a given hour, it
-        will charge electricity in that hour. If the electricity price exceeds the willingness to accept, it will 
-        discharge the stored electricity. <br/><br/>Optionally, you can override this behaviour by switching the toggle below and use a forecasting algorithm to determine battery behaviour. In both cases the ETM respects the storage volume limits of the battery.
-        See our <a href="https://docs.energytransitionmodel.com/main/electricity-storage" target=\"_blank\">
-        documentation</a> for more information.
+        It is possible to install batteries in households. By default, if the electricity price is lower than the willingness 
+        to pay of the battery in a given hour, it will charge electricity in that hour. If the electricity price exceeds the 
+        willingness to accept, it will discharge the stored electricity. <br/><br/>
+        Optionally, you can override this behaviour by switching to a 
+        <a href="https://docs.energytransitionmodel.com/main/battery-forecasting" target=\"_blank\">
+        forecasting algorithm</a>. Two types of forecasting are available for household batteries. The first type uses
+        them to balance the electricity system as a whole, while the second type aims to balance local household demand with 
+        local production from solar PV. In
+        <a href="#" class="open_chart" data-chart-key="flexibility_hourly_carriers_inflexible_imbalance" data-chart-location="side">
+        this chart</a> you can compare the curves to which both types of forecasting are applied.
     flexibility_power_storage_transport_car_flexibility_p2p_electricity:
       title: Batteries in electric vehicles
       short_description:

--- a/config/locales/interface/slides/nl_flexibility.yml
+++ b/config/locales/interface/slides/nl_flexibility.yml
@@ -289,14 +289,14 @@ nl:
         <br/><br/>Optioneel kun je ervoor kiezen dit gedrag te overschrijven en in plaats daarvan het gedrag te laten bepalen door een prognose-algoritme. Dit kan door de toggle hieronder op 'aan' te zetten. In beide gevallen houdt het ETM rekening met het opslagvolume van de batterij. Zie onze <a href="https://docs.energytransitionmodel.com/main/electricity-storage" target=\"_blank\">
         documentatie</a> voor meer informatie.
     flexibility_power_storage_forecast_order:
-      title: Inzetvolgorde prognose opslag
+      title: Inzetvolgorde elektriciteitsopslagtechnologieën
       short_description:
       description: |
         In de sectie <a href="/scenario/flexibility/flexibility_storage/behaviour-of-storage-technologies">
         Opslag elektriciteit</a> kun je ervoor kiezen een 
         <a href="https://docs.energytransitionmodel.com/main/battery-forecasting/" target=\"_blank\"> 
         prognose-algoritme</a> in te zetten om het gedrag van opslagtechnologieën te bepalen. Hieronder kun je 
-        de inzetvolgorde bepalen voor technologieën waarvoor het prognose-algoritme is ingeschakeld. </br></br>
+        de inzetvolgorde bepalen voor technologieën waarvoor het systeemprognose-algoritme is ingeschakeld. </br></br>
         De eerste technologie zal proberen de 
         <a href="/scenario/flexibility/flexibility_overview/residual-load-curves">residual load curve</a> af te 
         vlakken. Elke daaropvolgende technologie gebruikt vervolgens de resulterende curve van de voorgaande 

--- a/config/locales/interface/slides/nl_flexibility.yml
+++ b/config/locales/interface/slides/nl_flexibility.yml
@@ -193,14 +193,16 @@ nl:
       title: Batterijen in huishoudens
       short_description:
       description: |
-        Batterijen kunnen in huishoudens geïnstalleerd worden. Deze kunnen vervolgens worden opgeladen
-        door het elektriciteitsnet of door zonnepanelen, als huishoudens deze op hun daken hebben liggen. </br></br>
-        Batterijen zijn flexibele technologieën in het ETM, wat betekent dat het regelbaar is wanneer ze laden en ontladen. Als de elektriciteitsprijs
-        in een bepaald uur lager is dan de willingness-to-pay, gaat de batterij in dat uur opladen. Wanneer
-        de elektriciteitsprijs groter is dan de willingness-to-accept, zal de opslagen elektriciteit worden
-        ontladen.
-        <br/><br/>Optioneel kun je ervoor kiezen dit gedrag te overschrijven en in plaats daarvan het gedrag te laten bepalen door een prognose-algoritme. Dit kan door de toggle hieronder op 'aan' te zetten. In beide gevallen houdt het ETM rekening met het opslagvolume van de batterij. Zie onze <a href="https://docs.energytransitionmodel.com/main/electricity-storage" target=\"_blank\">
-        documentatie</a> voor meer informatie.
+        Batterijen kunnen in huishoudens geïnstalleerd worden. Als de elektriciteitsprijs in een bepaald uur 
+        lager is dan de <i>willingness-to-pay</i>, gaat de batterij in dat uur opladen. Wanneer de elektriciteitsprijs 
+        groter is dan de <i>willingness-to-accept</i>, zal de opslagen elektriciteit worden ontladen. <br/><br/>
+        Optioneel kun je ervoor kiezen dit gedrag te overschrijven door een
+        <a href="https://docs.energytransitionmodel.com/main/battery-forecasting" target=\"_blank\">
+        prognose-algoritme</a> in te zetten. Er zijn twee typen prognoses beschikbaar voor batterijen in huishoudens.
+        Het eerste type gebruikt ze om het elektriciteitssysteem als geheel te balanceren, terwijl het tweede type 
+        probeert lokale vraag te balanceren met lokaal aanbod van zon-PV. In
+        <a href="#" class="open_chart" data-chart-key="flexibility_hourly_carriers_inflexible_imbalance" data-chart-location="side">
+        deze grafiek</a> kun je de curves vergelijken waarvoor beide typen prognoses worden ingezet.
     flexibility_power_storage_wind_turbine_inland:
       title: Windmolens met opslagsystemen
       short_description:

--- a/config/locales/nl_radio_elements.yml
+++ b/config/locales/nl_radio_elements.yml
@@ -38,3 +38,13 @@ nl:
           (Vollasturen: wind op land / aan de kust = 1937, wind offshore = 3334,
           zon pv = 933, zonthermie = 604. Gemiddelde temperatuursverschil t.o.v. 2015 = -0,5 graden
           Celsius)
+    settings_enable_storage_optimisation_households_flexibility_p2p_electricity:
+      default:
+        title: 'Off'
+        description: The battery shows price sensitive behaviour
+      optimizing_storage:
+        title: 'Forecasting on the full energy system'
+        description: '...'
+      optimizing_storage_households:
+        title: 'Forecasting only for households'
+        description: '...'

--- a/config/locales/nl_radio_elements.yml
+++ b/config/locales/nl_radio_elements.yml
@@ -40,11 +40,17 @@ nl:
           Celsius)
     settings_enable_storage_optimisation_households_flexibility_p2p_electricity:
       default:
-        title: 'Off'
-        description: The battery shows price sensitive behaviour
+        title: 'Geen prognose-algoritme'
+        description: |
+          Het batterijgedrag is prijs-gestuurd, wat betekent dat het gedrag bepaald wordt door 
+          de bovenstaande <i>willingness-to-pay</i> en <i>willingness-to-accept</i> schuifjes.
       optimizing_storage:
-        title: 'Forecasting on the full energy system'
-        description: '...'
+        title: 'Systeemprognose-algoritme'
+        description: |
+          Het batterijgedrag wordt bepaald door een prognose-algoritme dat reageert op vraag en 
+          aanbod van het gehele elektriciteitssysteem.
       optimizing_storage_households:
-        title: 'Forecasting only for households'
-        description: '...'
+        title: 'Lokaal prognose-algoritme'
+        description: |
+          Het batterijgedrag wordt bepaald door een prognose-algoritme dat reageert op de lokale elektriciteitsvraag
+          en het lokale aanbod van huishoudens.


### PR DESCRIPTION
Adds a cute radio button to select the new option for using forecasting locally: forecast only on the residual load curve for households.
<img width="465" alt="Screenshot 2023-12-22 at 10 02 40" src="https://github.com/quintel/etmodel/assets/14875123/a6673eba-9596-44ed-8d10-109ac25c401e">

As well as adding the residual load curve for the household sector to the flexibility_hourly_carriers_inflexible_imbalance chart