### PR TITLE
 Adding geothermal to heat in energy flow overview sankey

### DIFF
--- a/app/assets/javascripts/d3/sankey.coffee
+++ b/app/assets/javascripts/d3/sankey.coffee
@@ -11,7 +11,7 @@ D3.sankey =
           {id: 'biomass_products',             column: 0, label: 'biomass_products',                  color: '#2ca02c'},
           {id: 'coal_and_coal_products',       column: 0, label: 'coal_and_coal_products',            color: '#252525'},
           {id: 'ambient_heat',                 column: 0, label: 'ambient_heat',                      color: '#ADDE4C'},
-          {id: 'geothermal',                   column: 0, label: 'geothermal',                        color: '#787821'},
+          {id: 'geothermal',                   column: 0, label: 'geothermal',                        color: '#FF8400'},
           {id: 'imported_heat',                column: 0, label: 'imported_heat',                     color: '#cc0000'},
           {id: 'residual_heat',                column: 0, label: 'residual_heat',                     color: '#cc0000'},          
           {id: 'natural_gas',                  column: 0, label: 'natural_gas',                       color: '#7f7f7f'},
@@ -53,6 +53,7 @@ D3.sankey =
           {left: 'biomass_products',             right: 'electricity',               gquery: 'sankey_0_to_1_biomass_products_to_electricity',          color: '#2ca02c'},
           {left: 'coal_and_coal_products',       right: 'electricity',               gquery: 'sankey_0_to_1_coal_and_coal_products_to_electricity',    color: '#252525'},
           {left: 'natural_gas',                  right: 'electricity',               gquery: 'sankey_0_to_1_natural_gas_to_electricity',               color: '#7f7f7f'},
+          {left: 'geothermal',                   right: 'electricity',               gquery: 'sankey_0_to_1_geothermal_to_electricity',                color: '#FF8400'},
         
           {left: 'biomass_products',             right: 'heat',                      gquery: 'sankey_0_to_1_biomass_products_to_heat',                 color: '#2ca02c'},
           {left: 'natural_gas',                  right: 'heat',                      gquery: 'sankey_0_to_1_natural_gas_to_heat',                      color: '#7f7f7f'},
@@ -62,6 +63,7 @@ D3.sankey =
           {left: 'ambient_heat',                 right: 'heat',                      gquery: 'sankey_0_to_1_ambient_heat_to_heat',                     color: '#ADDE4C'},
           {left: 'residual_heat',                right: 'heat',                      gquery: 'sankey_0_to_1_residual_heat_to_heat',                    color: '#cc0000'},
           {left: 'imported_heat',                right: 'heat',                      gquery: 'sankey_0_to_1_imported_heat_to_heat',                    color: '#cc0000'},
+          {left: 'geothermal',                   right: 'heat',                      gquery: 'sankey_0_to_1_geothermal_to_heat',                       color: '#FF8400'},
 
           {left: 'biomass_products',             right: 'hydrogen',                  gquery: 'sankey_0_to_1_biomass_products_to_hydrogen',             color: '#2ca02c'},
           {left: 'natural_gas',                  right: 'hydrogen',                  gquery: 'sankey_0_to_1_natural_gas_to_hydrogen',                  color: '#7f7f7f'},

--- a/config/locales/interface/output_elements/labels_groups/nl_labels.yml
+++ b/config/locales/interface/output_elements/labels_groups/nl_labels.yml
@@ -180,6 +180,7 @@ nl:
       biomass_products: "biomassaproducten"
       captured: "afgevangen"
       coal: "kolen"
+      coal_households: "Kolen voor huishoudens"
       coal_and_coal_products: "kool en koolproducten"
       coal_and_derivatives: "kool en koolproducten"
       crude_oil_and_derivatives: "olie en olieproducten"
@@ -247,6 +248,8 @@ nl:
       solar: "zon"
       solar_electricity: "zonne-elektriciteit"
       wind: "wind"
+      wind_electricity : "elektricitieit uit wind"
+      hydro_electricty: "elektriciteit uit waterkracht"
       hydrogen_production: "waterstof"
       hydrogen_import: "waterstof import"
       geo_ambient: "geothermisch & omgeving"
@@ -259,6 +262,7 @@ nl:
       biogenic_waste: 'biogeen afval'
       non_biogenic_waste: 'niet-biogeen afval'
       oil_and_oil_products : "olie en olie producten"
+      oil_products : "olieproducten"
       imported_oil: "geïmporteerde olie en olieproducten"
       biogas: 'biogas'
       greengas: 'groen gas'


### PR DESCRIPTION
Closing issue #4211. 

Queries were set, added this to the Sankey.
Tested the results with the graph "District heating supply and demand per temperature level" in a scenario with geothermal must run production in LT, MT & HT heat.

Results can be found underneath:
<img width="432" alt="Screenshot 2024-03-07 at 11 19 36" src="https://github.com/quintel/etmodel/assets/150331345/4a5df605-4ace-439a-9df6-03a925866949">

<img width="293" alt="Screenshot 2024-03-07 at 11 20 27" src="https://github.com/quintel/etmodel/assets/150331345/b62fb92e-c421-41e3-8557-57bc175d1e65">

Both flows in the graphs are equal with the geothermal source node:

<img width="1411" alt="Screenshot 2024-03-07 at 11 36 11" src="https://github.com/quintel/etmodel/assets/150331345/819e80b1-3133-4ba2-a47c-c1437797e166">

@mabijkerk I think I remember this query was not added for a reason but can't remember why at the moment. Do you have an idea? 
