### PR TITLE
Hybrid oil heat pumps in ETM

### DIFF
--- a/config/interface/input_elements/costs_heat_built_environment.yml
+++ b/config/interface/input_elements/costs_heat_built_environment.yml
@@ -70,6 +70,13 @@
   related_node: households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity
   position: 14
   slide_key: costs_heat_built_environment
+- key: efficiency_households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity
+  interface_group: cop_households
+  step_value: 1.0
+  unit: "%"
+  related_node: households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity
+  position: 14
+  slide_key: costs_heat_built_environment  
 - key: efficiency_buildings_space_heater_network_gas
   interface_group: efficiency_buildings
   step_value: 1.0
@@ -134,6 +141,14 @@
   related_node: buildings_space_heater_hybrid_hydrogen_heatpump_air_water_electricity
   position: 33
   slide_key: costs_heat_built_environment
+- key: efficiency_buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity
+  interface_group: cop_buildings
+  step_value: 1.0
+  unit: "%"
+  related_node: buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity
+  position: 33
+  dependent_on: has_coal_oil_for_heating_built_environment
+  slide_key: costs_heat_built_environment  
 - key: efficiency_agriculture_heatpump_water_water_electricity
   interface_group: cop_agriculture
   step_value: 0.1

--- a/config/interface/input_elements/demand_buildings_heating.yml
+++ b/config/interface/input_elements/demand_buildings_heating.yml
@@ -5,7 +5,7 @@
   unit: "%"
   interface_group: space_heating_technologies
   related_node: buildings_space_heater_network_gas
-  position: 1
+  position: 10
   slide_key: demand_buildings_heating
 - key: buildings_space_heater_combined_hydrogen_share
   share_group: heating_buildings
@@ -13,7 +13,7 @@
   unit: "%"
   interface_group: space_heating_technologies
   related_node: buildings_space_heater_combined_hydrogen
-  position: 2
+  position: 20
   slide_key: demand_buildings_heating
 - key: buildings_space_heater_district_heating_ht_steam_hot_water_share
   share_group: heating_buildings
@@ -21,7 +21,7 @@
   unit: "%"
   interface_group: space_heating_technologies
   related_node: buildings_space_heater_district_heating_ht_steam_hot_water
-  position: 3
+  position: 30
   slide_key: demand_buildings_heating
 - key: buildings_space_heater_district_heating_mt_steam_hot_water_share
   share_group: heating_buildings
@@ -29,7 +29,7 @@
   unit: "%"
   interface_group: space_heating_technologies
   related_node: buildings_space_heater_district_heating_mt_steam_hot_water
-  position: 4
+  position: 40
   slide_key: demand_buildings_heating
 - key: buildings_space_heater_district_heating_lt_steam_hot_water_share
   share_group: heating_buildings
@@ -37,7 +37,7 @@
   unit: "%"
   interface_group: space_heating_technologies
   related_node: buildings_space_heater_district_heating_lt_steam_hot_water
-  position: 5
+  position: 50
   slide_key: demand_buildings_heating
 - key: buildings_space_heater_heatpump_air_water_network_gas_share
   share_group: heating_buildings
@@ -46,7 +46,7 @@
   interface_group: space_heating_technologies
   command_type: value
   related_node: buildings_space_heater_heatpump_air_water_network_gas
-  position: 6
+  position: 60
   slide_key: demand_buildings_heating
 - key: buildings_space_heater_heatpump_air_water_electricity_share
   share_group: heating_buildings
@@ -54,7 +54,7 @@
   unit: "%"
   interface_group: space_heating_technologies
   related_node: buildings_space_heater_heatpump_air_water_electricity
-  position: 7
+  position: 70
   slide_key: demand_buildings_heating
 - key: buildings_space_heater_hybrid_heatpump_air_water_electricity_share
   share_group: heating_buildings
@@ -62,7 +62,7 @@
   unit: "%"
   interface_group: space_heating_technologies
   related_node: buildings_space_heater_hybrid_heatpump_air_water_electricity
-  position: 8
+  position: 80
   slide_key: demand_buildings_heating
 - key: buildings_space_heater_hybrid_hydrogen_heatpump_air_water_electricity_share
   share_group: heating_buildings
@@ -70,15 +70,24 @@
   unit: "%"
   interface_group: space_heating_technologies
   related_node: buildings_space_heater_hybrid_hydrogen_heatpump_air_water_electricity
-  position: 9
+  position: 90
   slide_key: demand_buildings_heating
+- key: buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_share
+  share_group: heating_buildings
+  step_value: 0.1
+  unit: "%"
+  interface_group: space_heating_technologies
+  related_node: buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity
+  position: 95
+  dependent_on: has_coal_oil_for_heating_built_environment
+  slide_key: demand_buildings_heating  
 - key: buildings_space_heater_collective_heatpump_water_water_ts_electricity_share
   share_group: heating_buildings
   step_value: 0.1
   unit: "%"
   interface_group: space_heating_technologies
   related_node: buildings_space_heater_collective_heatpump_water_water_ts_electricity
-  position: 10
+  position: 100
   slide_key: demand_buildings_heating
 - key: buildings_space_heater_heatpump_surface_water_water_ts_electricity_share
   share_group: heating_buildings
@@ -86,7 +95,7 @@
   unit: "%"
   interface_group: space_heating_technologies
   related_node: buildings_space_heater_heatpump_surface_water_water_ts_electricity
-  position: 11
+  position: 110
   slide_key: demand_buildings_heating
 - key: buildings_space_heater_electricity_share
   share_group: heating_buildings
@@ -94,7 +103,7 @@
   unit: "%"
   interface_group: space_heating_technologies
   related_node: buildings_space_heater_electricity
-  position: 12
+  position: 120
   slide_key: demand_buildings_heating
 - key: buildings_space_heater_wood_pellets_share
   share_group: heating_buildings
@@ -102,7 +111,7 @@
   unit: "%"
   interface_group: space_heating_technologies
   related_node: buildings_space_heater_wood_pellets
-  position: 13
+  position: 130
   slide_key: demand_buildings_heating
 - key: buildings_space_heater_crude_oil_share
   share_group: heating_buildings
@@ -110,7 +119,7 @@
   unit: "%"
   interface_group: space_heating_technologies
   related_node: buildings_space_heater_crude_oil
-  position: 14
+  position: 140
   dependent_on: has_coal_oil_for_heating_built_environment
   slide_key: demand_buildings_heating
 - key: buildings_space_heater_coal_share
@@ -119,18 +128,9 @@
   unit: "%"
   interface_group: space_heating_technologies
   related_node: buildings_space_heater_coal
-  position: 15
+  position: 150
   dependent_on: has_coal_oil_for_heating_built_environment
   slide_key: demand_buildings_heating
-- key: buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_share
-  share_group: heating_buildings
-  step_value: 0.1
-  unit: "%"
-  interface_group: space_heating_technologies
-  related_node: buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity
-  position: 16
-  dependent_on: has_coal_oil_for_heating_built_environment
-  slide_key: demand_buildings_heating  
 
 - key: buildings_space_heater_solar_thermal_share
   step_value: 0.1

--- a/config/interface/input_elements/demand_buildings_heating.yml
+++ b/config/interface/input_elements/demand_buildings_heating.yml
@@ -122,6 +122,15 @@
   position: 15
   dependent_on: has_coal_oil_for_heating_built_environment
   slide_key: demand_buildings_heating
+- key: buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_share
+  share_group: heating_buildings
+  step_value: 0.1
+  unit: "%"
+  interface_group: space_heating_technologies
+  related_node: buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity
+  position: 16
+  dependent_on: has_coal_oil_for_heating_built_environment
+  slide_key: demand_buildings_heating  
 
 - key: buildings_space_heater_solar_thermal_share
   step_value: 0.1

--- a/config/interface/input_elements/demand_households_heating.yml
+++ b/config/interface/input_elements/demand_households_heating.yml
@@ -5,7 +5,7 @@
   unit: "%"
   interface_group: space_and_water_heating_technologies
   related_node: households_space_heater_combined_network_gas
-  position: 1
+  position: 10
   slide_key: demand_households_heating
 - key: households_heater_combined_hydrogen_share
   share_group: heating_households
@@ -13,28 +13,28 @@
   unit: "%"
   interface_group: space_and_water_heating_technologies
   related_node: households_space_heater_combined_hydrogen
-  position: 2
+  position: 20
   slide_key: demand_households_heating
 - key: households_heater_district_heating_ht_steam_hot_water_share
   share_group: heating_households
   step_value: 0.1
   unit: "%"
   interface_group: space_and_water_heating_technologies
-  position: 3
+  position: 30
   slide_key: demand_households_heating
 - key: households_heater_district_heating_mt_steam_hot_water_share
   share_group: heating_households
   step_value: 0.1
   unit: "%"
   interface_group: space_and_water_heating_technologies
-  position: 4
+  position: 40
   slide_key: demand_households_heating
 - key: households_heater_district_heating_lt_steam_hot_water_share
   share_group: heating_households
   step_value: 0.1
   unit: "%"
   interface_group: space_and_water_heating_technologies
-  position: 5
+  position: 50
   slide_key: demand_households_heating
 - key: households_heater_heatpump_air_water_electricity_share
   share_group: heating_households
@@ -42,7 +42,7 @@
   unit: "%"
   interface_group: space_and_water_heating_technologies
   related_node: households_space_heater_heatpump_air_water_electricity
-  position: 6
+  position: 60
   slide_key: demand_households_heating
 - key: households_heater_heatpump_ground_water_electricity_share
   share_group: heating_households
@@ -50,7 +50,7 @@
   unit: "%"
   interface_group: space_and_water_heating_technologies
   related_node: households_space_heater_heatpump_ground_water_electricity
-  position: 7
+  position: 70
   slide_key: demand_households_heating
 - key: households_heater_heatpump_surface_water_water_ts_electricity_share
   share_group: heating_households
@@ -58,7 +58,7 @@
   unit: "%"
   interface_group: space_and_water_heating_technologies
   related_node: households_space_heater_heatpump_surface_water_water_ts_electricity
-  position: 8
+  position: 80
   slide_key: demand_households_heating
 - key: households_heater_hybrid_heatpump_air_water_electricity_share
   share_group: heating_households
@@ -66,7 +66,7 @@
   unit: "%"
   interface_group: space_and_water_heating_technologies
   related_node: households_space_heater_hybrid_heatpump_air_water_electricity
-  position: 9
+  position: 90
   slide_key: demand_households_heating
 - key: households_heater_hybrid_hydrogen_heatpump_air_water_electricity_share
   share_group: heating_households
@@ -74,15 +74,24 @@
   unit: "%"
   interface_group: space_and_water_heating_technologies
   related_node: households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity
-  position: 10
+  position: 100
   slide_key: demand_households_heating
+- key: households_heater_hybrid_crude_oil_heatpump_air_water_electricity_share
+  share_group: heating_households
+  step_value: 0.1
+  unit: "%"
+  interface_group: space_and_water_heating_technologies
+  related_node: households_space_heater_crude_oil_hydrogen_heatpump_air_water_electricity
+  position: 105
+  dependent_on: has_coal_oil_for_heating_built_environment
+  slide_key: demand_households_heating  
 - key: households_heater_heatpump_pvt_electricity_share
   share_group: heating_households
   step_value: 0.1
   unit: "%"
   interface_group: space_and_water_heating_technologies
   related_node: households_space_heater_heatpump_pvt_electricity
-  position: 12
+  position: 120
   slide_key: demand_households_heating
 - key: households_heater_wood_pellets_share
   share_group: heating_households
@@ -90,7 +99,7 @@
   unit: "%"
   interface_group: space_and_water_heating_technologies
   related_node: households_space_heater_wood_pellets
-  position: 13
+  position: 130
   slide_key: demand_households_heating
 - key: households_heater_electricity_share
   share_group: heating_households
@@ -98,7 +107,7 @@
   unit: "%"
   interface_group: space_and_water_heating_technologies
   related_node: households_space_heater_electricity
-  position: 14
+  position: 140
   slide_key: demand_households_heating
 - key: households_heater_network_gas_share
   share_group: heating_households
@@ -106,7 +115,7 @@
   unit: "%"
   interface_group: space_and_water_heating_technologies
   related_node: households_space_heater_network_gas
-  position: 15
+  position: 150
   slide_key: demand_households_heating
 - key: households_heater_crude_oil_share
   share_group: heating_households
@@ -114,7 +123,7 @@
   unit: "%"
   interface_group: space_and_water_heating_technologies
   related_node: households_space_heater_crude_oil
-  position: 16
+  position: 160
   dependent_on: has_coal_oil_for_heating_built_environment
   slide_key: demand_households_heating
 - key: households_heater_coal_share
@@ -123,18 +132,9 @@
   unit: "%"
   interface_group: space_and_water_heating_technologies
   related_node: households_space_heater_coal
-  position: 17
+  position: 170
   dependent_on: has_coal_oil_for_heating_built_environment
   slide_key: demand_households_heating
-- key: households_heater_hybrid_crude_oil_heatpump_air_water_electricity_share
-  share_group: heating_households
-  step_value: 0.1
-  unit: "%"
-  interface_group: space_and_water_heating_technologies
-  related_node: households_space_heater_crude_oil_hydrogen_heatpump_air_water_electricity
-  position: 18
-  dependent_on: has_coal_oil_for_heating_built_environment
-  slide_key: demand_households_heating  
 
 - key: households_water_heater_solar_thermal_share
   step_value: 0.1

--- a/config/interface/input_elements/demand_households_heating.yml
+++ b/config/interface/input_elements/demand_households_heating.yml
@@ -82,7 +82,7 @@
   unit: "%"
   interface_group: space_and_water_heating_technologies
   related_node: households_space_heater_heatpump_pvt_electricity
-  position: 11
+  position: 12
   slide_key: demand_households_heating
 - key: households_heater_wood_pellets_share
   share_group: heating_households
@@ -90,7 +90,7 @@
   unit: "%"
   interface_group: space_and_water_heating_technologies
   related_node: households_space_heater_wood_pellets
-  position: 12
+  position: 13
   slide_key: demand_households_heating
 - key: households_heater_electricity_share
   share_group: heating_households
@@ -98,7 +98,7 @@
   unit: "%"
   interface_group: space_and_water_heating_technologies
   related_node: households_space_heater_electricity
-  position: 13
+  position: 14
   slide_key: demand_households_heating
 - key: households_heater_network_gas_share
   share_group: heating_households
@@ -106,7 +106,7 @@
   unit: "%"
   interface_group: space_and_water_heating_technologies
   related_node: households_space_heater_network_gas
-  position: 14
+  position: 15
   slide_key: demand_households_heating
 - key: households_heater_crude_oil_share
   share_group: heating_households
@@ -114,7 +114,7 @@
   unit: "%"
   interface_group: space_and_water_heating_technologies
   related_node: households_space_heater_crude_oil
-  position: 15
+  position: 16
   dependent_on: has_coal_oil_for_heating_built_environment
   slide_key: demand_households_heating
 - key: households_heater_coal_share
@@ -123,9 +123,18 @@
   unit: "%"
   interface_group: space_and_water_heating_technologies
   related_node: households_space_heater_coal
-  position: 16
+  position: 17
   dependent_on: has_coal_oil_for_heating_built_environment
   slide_key: demand_households_heating
+- key: households_heater_hybrid_crude_oil_heatpump_air_water_electricity_share
+  share_group: heating_households
+  step_value: 0.1
+  unit: "%"
+  interface_group: space_and_water_heating_technologies
+  related_node: households_space_heater_crude_oil_hydrogen_heatpump_air_water_electricity
+  position: 18
+  dependent_on: has_coal_oil_for_heating_built_environment
+  slide_key: demand_households_heating  
 
 - key: households_water_heater_solar_thermal_share
   step_value: 0.1

--- a/config/interface/input_elements/demand_households_heating_technologies.yml
+++ b/config/interface/input_elements/demand_households_heating_technologies.yml
@@ -83,6 +83,13 @@
   related_node: households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity
   position: 80
   slide_key: demand_households_heating_technologies   
+- key: households_heater_hybrid_crude_oil_heatpump_air_water_electricity_heat_output_capacity
+  step_value: 0.1
+  unit: "kW"
+  related_node: households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity
+  position: 85
+  dependent_on: has_coal_oil_for_heating_built_environment
+  slide_key: demand_households_heating_technologies     
 - key: households_heater_coal_heat_output_capacity
   step_value: 0.1
   unit: "kW"

--- a/config/interface/input_elements/flexibility_flexibility_demand_response_hhp.yml
+++ b/config/interface/input_elements/flexibility_flexibility_demand_response_hhp.yml
@@ -1,5 +1,11 @@
 ---
-- key: flexibility_heat_pump_space_heating_cop_cutoff
+- key: flexibility_heat_pump_space_heating_cop_cutoff_gas
+  step_value: 0.1
+  unit: "#"
+  interface_group: flexibility_cop
+  position: 1
+  slide_key: flexibility_flexibility_demand_response_hhp
+- key: flexibility_heat_pump_space_heating_cop_cutoff_crude_oil
   step_value: 0.1
   unit: "#"
   interface_group: flexibility_cop

--- a/config/interface/input_elements/flexibility_flexibility_demand_response_hhp.yml
+++ b/config/interface/input_elements/flexibility_flexibility_demand_response_hhp.yml
@@ -20,13 +20,13 @@
   slide_key: flexibility_flexibility_demand_response_hhp
 - key: households_flexibility_consumer_gas_price
   step_value: 0.1
-  unit: ct/m3
+  unit: €ct/m3
   interface_group: consumer_price
   position: 20
   slide_key: flexibility_flexibility_demand_response_hhp
 - key: households_flexibility_consumer_electricity_price
   step_value: 0.1
-  unit: ct/kWh
+  unit: €ct/kWh
   interface_group: consumer_price
   position: 25
   slide_key: flexibility_flexibility_demand_response_hhp

--- a/config/interface/input_elements/flexibility_flexibility_demand_response_hhp.yml
+++ b/config/interface/input_elements/flexibility_flexibility_demand_response_hhp.yml
@@ -3,29 +3,30 @@
   step_value: 0.1
   unit: "#"
   interface_group: flexibility_cop
-  position: 1
+  position: 5
   slide_key: flexibility_flexibility_demand_response_hhp
 - key: flexibility_heat_pump_space_heating_cop_cutoff_crude_oil
   step_value: 0.1
   unit: "#"
   interface_group: flexibility_cop
-  position: 1
+  position: 10
   slide_key: flexibility_flexibility_demand_response_hhp
+  dependent_on: has_coal_oil_for_heating_built_environment
 - key: flexibility_heat_pump_water_heating_cop_cutoff
   step_value: 0.1
   unit: "#"
   interface_group: flexibility_cop
-  position: 2
+  position: 15
   slide_key: flexibility_flexibility_demand_response_hhp
 - key: households_flexibility_consumer_gas_price
   step_value: 0.1
   unit: ct/m3
   interface_group: consumer_price
-  position: 3
+  position: 20
   slide_key: flexibility_flexibility_demand_response_hhp
 - key: households_flexibility_consumer_electricity_price
   step_value: 0.1
   unit: ct/kWh
   interface_group: consumer_price
-  position: 4
+  position: 25
   slide_key: flexibility_flexibility_demand_response_hhp

--- a/config/interface/output_elements/cost.yml
+++ b/config/interface/output_elements/cost.yml
@@ -146,7 +146,7 @@
   description:
   output_element_type_name: vertical_stacked_bar
 - under_construction: false
-  unit: "€/MJ heat"
+  unit: "€ct/MJ heat"
   percentage: false
   group: Cost
   sub_group:

--- a/config/interface/output_elements/demand_households.yml
+++ b/config/interface/output_elements/demand_households.yml
@@ -138,7 +138,7 @@
   key: hybrid_heat_pump
   max_axis_value:
   min_axis_value:
-  hidden: false
+  hidden: true
   requires_merit_order: false
   dependent_on: ''
   output_element_type_name: html_table

--- a/config/locales/interface/input_elements/en_costs.yml
+++ b/config/locales/interface/input_elements/en_costs.yml
@@ -1071,6 +1071,14 @@ en:
       To view the yearly average COP, the so-called seasonal COP (SCOP), you can click on the 'Technical and financial properties'.
       It is not possible to set the absolute value of the future SCOP of hybrid heat pumps with a slider as this is a result of hourly
       calculations based on the hourly outside temperature curve."
+    efficiency_households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity:
+      title: Hybrid air heat pump (crude oil)
+      short_description: ''
+      description: "How will the coefficient of performance (COP) of hybrid heat pumps running on oil change in the future?
+      With this slider you can adjust with which percentage the COP of hybrid heat pumps for space heating will change in the future.
+      To view the yearly average COP, the so-called seasonal COP (SCOP), you can click on the 'Technical and financial properties'.
+      It is not possible to set the absolute value of the future SCOP of hybrid heat pumps with a slider as this is a result of hourly
+      calculations based on the hourly outside temperature curve."  
     efficiency_households_space_heater_combined_hydrogen:
       title: Condensing combi boiler (hydrogen)
       short_description: ''
@@ -1125,6 +1133,15 @@ en:
         To view the yearly average COP, the so-called seasonal COP (SCOP), you can click on the 'Technical and financial properties'.
         It is not possible to set the absolute value of the future SCOP of hybrid heat pumps with a slider as this is a result of hourly
         calculations based on the hourly outside temperature curve.
+    efficiency_buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity:
+      title: Hybrid air heat pump (crude oil)
+      short_description:
+      description: |
+        How will the coefficient of performance (COP) of hybrid heat pumps running on oil change in the future?
+        With this slider you can adjust with which percentage the COP of hybrid heat pumps for space heating will change in the future.
+        To view the yearly average COP, the so-called seasonal COP (SCOP), you can click on the 'Technical and financial properties'.
+        It is not possible to set the absolute value of the future SCOP of hybrid heat pumps with a slider as this is a result of hourly
+        calculations based on the hourly outside temperature curve.    
     efficiency_agriculture_heatpump_water_water_electricity:
       title: Water heat pump
       short_description:

--- a/config/locales/interface/input_elements/en_demand_buildings.yml
+++ b/config/locales/interface/input_elements/en_demand_buildings.yml
@@ -474,11 +474,11 @@ en:
         <a href=/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps
         >Demand response - behavior of hybrid heat pumps</a>.
     buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_share:
-      title: Hybrid air heat pump (crude oil)
+      title: Hybrid air heat pump (oil)
       short_description:
       description: |
         This heater is a combination of an electric heat pump that draws its heat 
-        from the outside air and an efficient conventional crude oil-fired boiler. <br/><br/>
+        from the outside air and an efficient conventional oil-fired boiler. <br/><br/>
         This works as follows: <br/> 
         The oil-fired part takes over all of the heating of the building on cold 
         winter days, when heat demand peaks. Because of this clever trick, the heat 
@@ -498,6 +498,12 @@ en:
         more use of the heat pump. <br/><br/>
         The COP of the electric part of the hybrid oil heat pump depends on ambient 
         temperature. When the COP drops below the threshold value the hybrid heat pump 
-        switches to oil. The threshold value can be adjusted in the section 
+        switches to oil. 
+        <b>Note that by default, the oil-fired part
+        provides  most if not all of the required heat for space heating.</b> 
+        This is because the default threshold COP is set at a relatively high value of 3.7
+        based on the consumer prices for oil and electricity.
+        <br/><br/>
+        The threshold value can be adjusted in the section 
         <a href=/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps
         >Demand response - behavior of hybrid heat pumps</a>.    

--- a/config/locales/interface/input_elements/en_demand_buildings.yml
+++ b/config/locales/interface/input_elements/en_demand_buildings.yml
@@ -473,3 +473,31 @@ en:
         switches to hydrogen. The threshold value can be adjusted in the section 
         <a href=/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps
         >Demand response - behavior of hybrid heat pumps</a>.
+    buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_share:
+      title: Hybrid air heat pump (crude oil)
+      short_description:
+      description: |
+        This heater is a combination of an electric heat pump that draws its heat 
+        from the outside air and an efficient conventional crude oil-fired boiler. <br/><br/>
+        This works as follows: <br/> 
+        The oil-fired part takes over all of the heating of the building on cold 
+        winter days, when heat demand peaks. Because of this clever trick, the heat 
+        pump has less impact on the electricity grid than an all-electric heat pump does. 
+        Smart use of hybrid crude oil heat pumps may therefore avoid the need to reinforce 
+        local power grids. <br/><br/>
+        Heat pumps move heat from one place to another. Refrigerators use heat pumps, 
+        for example, but buildings can use them for
+        heating and cooling too. For optimal results with <em>most</em> types of heat
+        pump, installation of under-floor and wall heating instead of radiators is
+        often required, as well as good levels of insulation. The <em>hybrid</em>
+        crude oil heat pump is an exception, because of its oil-fired heater as
+        a fall-back option. Hybrid crude oil heat pumps can intelligently use whichever
+        part (heat pump or oil-fired heater) is the most efficient or cost-effective
+        given the weather conditions and insulation level. Buildings with limited insulation
+        will rely on the oil-fired part more, better insulated ones will make
+        more use of the heat pump. <br/><br/>
+        The COP of the electric part of the hybrid oil heat pump depends on ambient 
+        temperature. When the COP drops below the threshold value the hybrid heat pump 
+        switches to oil. The threshold value can be adjusted in the section 
+        <a href=/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps
+        >Demand response - behavior of hybrid heat pumps</a>.    

--- a/config/locales/interface/input_elements/en_demand_households.yml
+++ b/config/locales/interface/input_elements/en_demand_households.yml
@@ -1056,6 +1056,31 @@ en:
         drops below the threshold value the hybrid heat pump switches to hydrogen.
         The threshold value can be adjusted in the section <a href=\"/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps\"
         >Demand response - behavior of hybrid heat pumps</a>. \r\n\r\n"
+    households_heater_hybrid_crude_oil_heatpump_air_water_electricity_share:
+      title: Hybrid air heat pump (crude oil)
+      short_description:
+      description: "This heater is a combination of an electric heat pump that draws
+        its heat from the outside air and an efficient conventional oil-fired
+        boiler.\r\n<br/><br/>\r\nThis works as follows:<br/>\r\nThe oil-fired
+        part takes over all of the heating of the building on cold winter days, when
+        heat demand peaks. Because of this clever trick, the heat pump has less impact
+        on the electricity grid than an all-electric heat pump does. Smart use of
+        hybrid oil heat pumps may therefore avoid the need to reinforce local
+        power grids. \r\n<br/><br/>\r\nHeat pumps move heat from one place to another.
+        Refrigerators use heat pumps, for example, but buildings can use them for
+        heating and cooling too. For optimal results with <em>most</em> types of heat
+        pump, installation of under-floor and wall heating instead of radiators is
+        often required, as well as good levels of insulation. The <em>hybrid</em>
+        oil heat pump is an exception, because of its oil-fired heater as
+        a fall-back option. Hybrid oil heat pumps can intelligently use whichever
+        part (heat pump or oil-fired heater) is the most efficient or cost-effective
+        given the weather conditions and insulation level. Houses with limited insulation
+        will rely on the oil-fired part more, better insulated ones will make
+        more use of the heat pump.\r\n<br/><br/>\r\nThe COP of the electric part of
+        the hybrid oil heat pump depends on ambient temperature. When the COP
+        drops below the threshold value the hybrid heat pump switches to oil.
+        The threshold value can be adjusted in the section <a href=\"/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps\"
+        >Demand response - behavior of hybrid heat pumps</a>. \r\n\r\n"    
     households_cooker_network_gas_share:
       title: Gas
       short_description:
@@ -1183,5 +1208,9 @@ en:
       title: Hybrid air heat pump (hydrogen)
       short_description: ''
       description: ''       
+    households_heater_hybrid_crude_oil_heatpump_air_water_electricity_heat_output_capacity:
+      title: Hybrid air heat pump (crude oil)
+      short_description: ''
+      description: ''         
 
 

--- a/config/locales/interface/input_elements/en_demand_households.yml
+++ b/config/locales/interface/input_elements/en_demand_households.yml
@@ -1088,8 +1088,8 @@ en:
         This is because the default threshold COP is set at a relatively high value of 3.7
         based on the consumer prices for oil and electricity.
         <br/><br/>
-        The threshold value can be adjusted in the section <a href=\"/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps\"
-        >Demand response - behavior of hybrid heat pumps</a>.     
+        The threshold value can be adjusted in the section <a href="/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps">
+        Demand response - behavior of hybrid heat pumps</a>.     
     households_cooker_network_gas_share:
       title: Gas
       short_description:

--- a/config/locales/interface/input_elements/en_demand_households.yml
+++ b/config/locales/interface/input_elements/en_demand_households.yml
@@ -1057,16 +1057,20 @@ en:
         The threshold value can be adjusted in the section <a href=\"/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps\"
         >Demand response - behavior of hybrid heat pumps</a>. \r\n\r\n"
     households_heater_hybrid_crude_oil_heatpump_air_water_electricity_share:
-      title: Hybrid air heat pump (crude oil)
+      title: Hybrid air heat pump (oil)
       short_description:
-      description: "This heater is a combination of an electric heat pump that draws
+      description: |
+        This heater is a combination of an electric heat pump that draws
         its heat from the outside air and an efficient conventional oil-fired
-        boiler.\r\n<br/><br/>\r\nThis works as follows:<br/>\r\nThe oil-fired
-        part takes over all of the heating of the building on cold winter days, when
+        boiler.
+        <br/><br/>
+        This works as follows:
+        <br/>
+        The oil-fired part takes over all of the heating of the building on cold winter days, when
         heat demand peaks. Because of this clever trick, the heat pump has less impact
         on the electricity grid than an all-electric heat pump does. Smart use of
         hybrid oil heat pumps may therefore avoid the need to reinforce local
-        power grids. \r\n<br/><br/>\r\nHeat pumps move heat from one place to another.
+        power grids. <br/><br/>Heat pumps move heat from one place to another.
         Refrigerators use heat pumps, for example, but buildings can use them for
         heating and cooling too. For optimal results with <em>most</em> types of heat
         pump, installation of under-floor and wall heating instead of radiators is
@@ -1076,11 +1080,16 @@ en:
         part (heat pump or oil-fired heater) is the most efficient or cost-effective
         given the weather conditions and insulation level. Houses with limited insulation
         will rely on the oil-fired part more, better insulated ones will make
-        more use of the heat pump.\r\n<br/><br/>\r\nThe COP of the electric part of
+        more use of the heat pump.<br/><br/>The COP of the electric part of
         the hybrid oil heat pump depends on ambient temperature. When the COP
-        drops below the threshold value the hybrid heat pump switches to oil.
+        drops below the threshold value the hybrid heat pump switches to oil. 
+        <b>Note that by default, the oil-fired part
+        provides  most if not all of the required heat for space heating.</b> 
+        This is because the default threshold COP is set at a relatively high value of 3.7
+        based on the consumer prices for oil and electricity.
+        <br/><br/>
         The threshold value can be adjusted in the section <a href=\"/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps\"
-        >Demand response - behavior of hybrid heat pumps</a>. \r\n\r\n"    
+        >Demand response - behavior of hybrid heat pumps</a>.     
     households_cooker_network_gas_share:
       title: Gas
       short_description:

--- a/config/locales/interface/input_elements/en_demand_households.yml
+++ b/config/locales/interface/input_elements/en_demand_households.yml
@@ -1008,54 +1008,30 @@ en:
     households_heater_hybrid_heatpump_air_water_electricity_share:
       title: Hybrid air heat pump (gas)
       short_description:
-      description: "This heater is a combination of an electric heat pump that draws
+      description: |
+        This heater is a combination of an electric heat pump that draws
         its heat from the outside air and an efficient conventional gas-fired boiler.
-        Essentially, the hybrid heat pump offers a way to strongly reduce natural
-        gas demand for heating, while buying time for grid management companies to
-        reinforce grids. \r\n<br/><br/>\r\nThis works as follows:<br/>\r\nThe gas-fired
-        part takes over all of the heating of the building on cold winter days, when
-        heat demand peaks. Because of this clever trick, the heat pump has less impact
-        on the electricity grid than an all-electric heat pump does. Smart use of
-        hybrid heat pumps may therefore avoid the need to reinforce local power grids.
-        \r\n<br/><br/>\r\nHeat pumps move heat from one place to another. Refrigerators
-        use heat pumps, for example, but buildings can use them for heating and cooling
-        too. For optimal results with <em>most</em> types of heat pump, installation
-        of under-floor and wall heating instead of radiators is often required, as
-        well as good levels of insulation. The <em>hybrid</em> heat pump is an exception,
-        because of its gas-fired heater as a fall-back option. Hybrid heat pumps can
-        intelligently use whichever part (heat pump or gas-fired heater) is the most
-        efficient or cost-effective given the weather conditions and insulation level.
-        Houses with limited insulation will rely on the gas-fired part more, better
-        insulated ones will make more use of the heat pump.\r\n<br/><br/>\r\nThe COP
-        of the electric part of the hybrid heat pump depends on ambient temperature.
+        <br/><br/>
+        The COP of the electric part of the hybrid heat pump depends on ambient temperature.
         When the COP drops below the threshold value the hybrid heat pump switches
-        to gas. The threshold value can be adjusted in the section <a href=\"/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps\"
-        >Demand response - behavior of hybrid heat pumps</a>. \r\n\r\n"
+        to gas. The threshold value can be adjusted in the section <a href="/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps"
+        >Demand response - behavior of hybrid heat pumps</a>.
+        <br/><br/>
+        More information on how hybrid heat pumps work can be found in the <a href="https://docs.energytransitionmodel.com/main/heat-pumps" target="_blank\">documentation</a>
     households_heater_hybrid_hydrogen_heatpump_air_water_electricity_share:
       title: Hybrid air heat pump (hydrogen)
       short_description:
-      description: "This heater is a combination of an electric heat pump that draws
+      description: |
+        This heater is a combination of an electric heat pump that draws
         its heat from the outside air and an efficient conventional hydrogen-fired
-        boiler.\r\n<br/><br/>\r\nThis works as follows:<br/>\r\nThe hydrogen-fired
-        part takes over all of the heating of the building on cold winter days, when
-        heat demand peaks. Because of this clever trick, the heat pump has less impact
-        on the electricity grid than an all-electric heat pump does. Smart use of
-        hybrid hydrogen heat pumps may therefore avoid the need to reinforce local
-        power grids. \r\n<br/><br/>\r\nHeat pumps move heat from one place to another.
-        Refrigerators use heat pumps, for example, but buildings can use them for
-        heating and cooling too. For optimal results with <em>most</em> types of heat
-        pump, installation of under-floor and wall heating instead of radiators is
-        often required, as well as good levels of insulation. The <em>hybrid</em>
-        hydrogen heat pump is an exception, because of its hydrogen-fired heater as
-        a fall-back option. Hybrid hydrogen heat pumps can intelligently use whichever
-        part (heat pump or hydrogen-fired heater) is the most efficient or cost-effective
-        given the weather conditions and insulation level. Houses with limited insulation
-        will rely on the hydrogen-fired part more, better insulated ones will make
-        more use of the heat pump.\r\n<br/><br/>\r\nThe COP of the electric part of
-        the hybrid hydrogen heat pump depends on ambient temperature. When the COP
+        boiler.
+        <br/><br/>
+        The COP of the electric part of the hybrid hydrogen heat pump depends on ambient temperature. When the COP
         drops below the threshold value the hybrid heat pump switches to hydrogen.
-        The threshold value can be adjusted in the section <a href=\"/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps\"
-        >Demand response - behavior of hybrid heat pumps</a>. \r\n\r\n"
+        The threshold value can be adjusted in the section <a href="/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps"
+        >Demand response - behavior of hybrid heat pumps</a>.
+        <br/><br/>
+        More information on how hybrid heat pumps work can be found in the <a href="https://docs.energytransitionmodel.com/main/heat-pumps" target="_blank\">documentation</a>
     households_heater_hybrid_crude_oil_heatpump_air_water_electricity_share:
       title: Hybrid air heat pump (oil)
       short_description:
@@ -1064,32 +1040,18 @@ en:
         its heat from the outside air and an efficient conventional oil-fired
         boiler.
         <br/><br/>
-        This works as follows:
-        <br/>
-        The oil-fired part takes over all of the heating of the building on cold winter days, when
-        heat demand peaks. Because of this clever trick, the heat pump has less impact
-        on the electricity grid than an all-electric heat pump does. Smart use of
-        hybrid oil heat pumps may therefore avoid the need to reinforce local
-        power grids. <br/><br/>Heat pumps move heat from one place to another.
-        Refrigerators use heat pumps, for example, but buildings can use them for
-        heating and cooling too. For optimal results with <em>most</em> types of heat
-        pump, installation of under-floor and wall heating instead of radiators is
-        often required, as well as good levels of insulation. The <em>hybrid</em>
-        oil heat pump is an exception, because of its oil-fired heater as
-        a fall-back option. Hybrid oil heat pumps can intelligently use whichever
-        part (heat pump or oil-fired heater) is the most efficient or cost-effective
-        given the weather conditions and insulation level. Houses with limited insulation
-        will rely on the oil-fired part more, better insulated ones will make
-        more use of the heat pump.<br/><br/>The COP of the electric part of
+        The COP of the electric part of
         the hybrid oil heat pump depends on ambient temperature. When the COP
         drops below the threshold value the hybrid heat pump switches to oil. 
         <b>Note that by default, the oil-fired part
         provides  most if not all of the required heat for space heating.</b> 
-        This is because the default threshold COP is set at a relatively high value of 3.7
+        This is because the default threshold COP is set at a relatively high value
         based on the consumer prices for oil and electricity.
         <br/><br/>
         The threshold value can be adjusted in the section <a href="/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps">
-        Demand response - behavior of hybrid heat pumps</a>.     
+        Demand response - behavior of hybrid heat pumps</a>.    
+        <br/><br/>
+        More information on how hybrid heat pumps work can be found in the <a href="https://docs.energytransitionmodel.com/main/heat-pumps" target="_blank\">documentation</a> 
     households_cooker_network_gas_share:
       title: Gas
       short_description:

--- a/config/locales/interface/input_elements/en_flexibility.yml
+++ b/config/locales/interface/input_elements/en_flexibility.yml
@@ -378,23 +378,34 @@ en:
         The integral costs of flexible demand technologies.</a></li>
         <li><a href="#" class="open_chart" data-chart-key="storage_options" data-chart-location="side">
         A table overview of the use of flexible demand technologies.</a></li></ul>
-    flexibility_heat_pump_space_heating_cop_cutoff:
-      title: Space heating
+    flexibility_heat_pump_space_heating_cop_cutoff_gas:
+      title: Space heating (gas)
       short_description:
       description: "Here you indicate the threshold COP of hybrid heat pumps for space
-        heating. \r\n<p>\r\nThe default setting is that the electric part of the HHP
-        is used maximally for space heating. With the current gas and electricity
+        heating. This applies to both network gas-based and hydrogen-based hybrid heat pumps \r\n<p>\r\n
+        The default setting is that the electric part of the HHP
+        is used maximally for space heating. With the current network gas and electricity
         price financial optimization for the user is achieved with a threshold COP
-        of  2.6, this can be concluded from the chart on the right.\r\nFor more information
+        of 2.6, this can be concluded from the chart on the right.\r\nFor more information
         about (hybrid) heat pumps see our <a href=\"https://docs.energytransitionmodel.com/main/heat-pumps\" target=\"_blank\">documentation</a>."
+    flexibility_heat_pump_space_heating_cop_cutoff_crude_oil:
+      title: Space heating (oil)
+      short_description:
+      description: |
+        Here you indicate the threshold COP of hybrid oil heat pumps for space
+        heating. </br></br>
+        The default setting is that the electric part of the HHP
+        is used maximally for space heating. With the current oil and electricity
+        price financial optimization for the user is achieved with a threshold COP
+        of  3.7. </br></br>
+        For more information about (hybrid) heat pumps see our <a href=\"https://docs.energytransitionmodel.com/main/heat-pumps\" target=\"_blank\">documentation</a>.
     flexibility_heat_pump_water_heating_cop_cutoff:
       title: Hot water
       short_description:
       description: "Here you indicate the threshold COP of hybrid heat pumps for hot
-        water.\r\n<p>\r\nThe default setting is that the gas part of the HHP is used
-        for hot water.\r\n<p>\r\nWith the current gas and electricity price financial
-        optimization for the user is achieved with a threshold COP of  3.1.\r\nFor
-        calculations see <a href=\"https://docs.energytransitionmodel.com/main/heat-pumps\" target=\"_blank\">documentation</a>"
+        water.\r\n<p>\r\nThe default setting is that the fuel-fired part of the HHP (using network gas, hydrogen or oil) is used
+        for hot water. The threshold COP is therefore set at its maximum value of 6.0 so that the fuel-fired part is always enabled. \r\n<p>\r\n
+        For calculations on the threshold COP see <a href=\"https://docs.energytransitionmodel.com/main/heat-pumps\" target=\"_blank\">documentation</a>"
     households_flexibility_consumer_gas_price:
       title: Gas price
       short_description:

--- a/config/locales/interface/input_elements/nl_costs.yml
+++ b/config/locales/interface/input_elements/nl_costs.yml
@@ -1108,6 +1108,15 @@ nl:
         ook wel de seasonal COP (SCOP), kun je vinden in de "Technische parameters en kosten".
         Het is niet mogelijk om de absolute waarde van de SCOP van de hybride warmtepompen in te stellen, omdat het een resultaat is van uurlijkse berekeningen o.b.v.
         het uurlijkse profiel van de buitentemperatuur.
+    efficiency_households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity:
+      title: Hybride luchtwarmtepomp (ruwe olie)
+      short_description:
+      description: |
+        Hoeveel zal de coefficient of performance (COP) van hybride warmtepompen op olie veranderen in de toekomst?
+        Met deze schuif kun je aangeven met hoeveel procent de COP zal veranderen. De huidige jaarlijkse gemiddelde COP,
+        ook wel de seasonal COP (SCOP), kun je vinden in de "Technische parameters en kosten".
+        Het is niet mogelijk om de absolute waarde van de SCOP van de hybride warmtepompen in te stellen, omdat het een resultaat is van uurlijkse berekeningen o.b.v.
+        het uurlijkse profiel van de buitentemperatuur.    
     efficiency_households_space_heater_combined_hydrogen:
       title: HR combiketel (waterstof)
       short_description: ''
@@ -1163,6 +1172,15 @@ nl:
         ook wel de seasonal COP (SCOP), kun je vinden in de "Technische parameters en kosten".
         Het is niet mogelijk om de absolute waarde van de SCOP van de hybride warmtepompen in te stellen, omdat het een resultaat is van uurlijkse berekeningen o.b.v.
         het uurlijkse profiel van de buitentemperatuur.
+    efficiency_buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity:
+      title: Hybride luchtwarmtepomp (ruwe olie)
+      short_description:
+      description: |
+        Hoeveel zal de coefficient of performance (COP) van hybride warmtepompen op olie veranderen in de toekomst?
+        Met deze schuif kun je aangeven met hoeveel procent de COP zal veranderen. De huidige jaarlijkse gemiddelde COP,
+        ook wel de seasonal COP (SCOP), kun je vinden in de "Technische parameters en kosten".
+        Het is niet mogelijk om de absolute waarde van de SCOP van de hybride warmtepompen in te stellen, omdat het een resultaat is van uurlijkse berekeningen o.b.v.
+        het uurlijkse profiel van de buitentemperatuur.    
     efficiency_agriculture_heatpump_water_water_electricity:
       title: Water warmtepomp
       short_description:

--- a/config/locales/interface/input_elements/nl_demand_buildings.yml
+++ b/config/locales/interface/input_elements/nl_demand_buildings.yml
@@ -464,7 +464,7 @@ nl:
         <a href=/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps
         >Vraagsturing - gedrag van hybride warmtepompen</a> aan te passen.
     buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_share:
-      title: Hybride luchtwarmtepomp (ruwe olie)
+      title: Hybride luchtwarmtepomp (olie)
       short_description:
       description: |
         Deze verwarmingsoptie is een combinatie van een elektrische warmtepomp
@@ -487,6 +487,12 @@ nl:
         de warmtepomp. <br/><br/>
         De COP van het elektrische deel van de hybride oliewarmtepomp is afhankelijk van 
         de buitentemperatuur. Als de COP onder de drempelwaarde zakt schakelt de hybride 
-        warmtepomp volledig over op gas. Deze omslag-COP is in de sectie 
+        warmtepomp volledig over op olie. 
+        <b>Merk op dat in de standaardinstelling het oliedeel van de hybride warmtepomp
+        het overgrote deel of zelfs alle warmtevraag voor ruimteverwarming invult.</b> 
+        Dit komt doordat de de standaard drempelwaarde voor de COP ingesteld is op een relatief hoge waarde
+        van 3,7 gebaseerd op de consumentenprijzen voor olie en elektriciteit.
+        <br/><br/>
+        Deze omslag-COP is in de sectie 
         <a href=/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps
         >Vraagsturing - gedrag van hybride warmtepompen</a> aan te passen.    

--- a/config/locales/interface/input_elements/nl_demand_buildings.yml
+++ b/config/locales/interface/input_elements/nl_demand_buildings.yml
@@ -463,3 +463,30 @@ nl:
         warmtepomp volledig over op gas. Deze omslag-COP is in de sectie 
         <a href=/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps
         >Vraagsturing - gedrag van hybride warmtepompen</a> aan te passen.
+    buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_share:
+      title: Hybride luchtwarmtepomp (ruwe olie)
+      short_description:
+      description: |
+        Deze verwarmingsoptie is een combinatie van een elektrische warmtepomp
+        met een oliegestookte HR-ketel. <br/><br/>
+        Het werkt zo:<br/>
+        De olieketel verwarmt het gebouw op koude dagen, als de warmtevraag het hoogst
+        is. Deze slimme truc zorgt ervoor dat een hybride oliewarmtepomp het
+        stroomnet minder belast dan een elektrische warmtepomp alleen. Door slim gebruik
+        te maken van zulke hybride oliewarmtepompen kan de noodzaak om stroomnetten
+        te verzwaren vermeden worden. <br/><br/>
+        Warmtepompen verplaatsen warmte van de ene plek naar de andere. Koelkasten gebruiken 
+        bijvoorbeeld warmtepompen, maar gebouwen kunnen ze ook gebruiken voor verwarming of 
+        koelen. Dit werkt het beste als gebouwen goed geïsoleerd zijn en als ze bijvoorbeeld 
+        vloer- en muurverwarming hebben in plaats van radiatoren. Hybride oliefwarmtepompen
+        zijn een uitzondering op deze regel doordat de olieketel ingezet kan
+        worden. Ze kunnen slim kiezen welk deel (de warmtepomp of de olieketel)
+        het meest efficiënt of kosteneffectief is om aan te zetten, afhankelijk van
+        het weer en hoe goed een huis geïsoleerd is. Minder geïsoleerde gebouwen zullen
+        de olieketel vaker nodig hebben, beter geïsoleerde gebouwen gebruiken vooral
+        de warmtepomp. <br/><br/>
+        De COP van het elektrische deel van de hybride oliewarmtepomp is afhankelijk van 
+        de buitentemperatuur. Als de COP onder de drempelwaarde zakt schakelt de hybride 
+        warmtepomp volledig over op gas. Deze omslag-COP is in de sectie 
+        <a href=/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps
+        >Vraagsturing - gedrag van hybride warmtepompen</a> aan te passen.    

--- a/config/locales/interface/input_elements/nl_demand_households.yml
+++ b/config/locales/interface/input_elements/nl_demand_households.yml
@@ -1289,6 +1289,30 @@ nl:
         de drempelwaarde zakt schakelt de hybride warmtepomp volledig over op gas.
         Deze omslag-COP is in de sectie <a href=\"/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps\"
         >Vraagsturing - gedrag van hybride warmtepompen</a> aan te passen. \r\n"
+    households_heater_hybrid_crude_oil_heatpump_air_water_electricity_share:
+      title: Hybride luchtwarmtepomp (ruwe olie)
+      short_description:
+      description: "Deze verwarmingsoptie is een combinatie van een elektrische warmtepomp
+        met een oliegestookte HR-ketel.\r\n<br/><br/>\r\nHet werkt zo:<br/>\r\nDe
+        olieketel verwarmt het huis op koude dagen, als de warmtevraag het hoogst
+        is. Deze slimme truc zorgt ervoor dat een hybride oliewarmtepomp het
+        stroomnet minder belast dan een elektrische warmtepomp alleen. Door slim gebruik
+        te maken van zulke hybride oliewarmtepompen kan de noodzaak om stroomnetten
+        te verzwaren vermeden worden. \r\n<br/><br/>\r\nWarmtepompen verplaatsen warmte
+        van de ene plek naar de andere. Koelkasten gebruiken bijvoorbeeld warmtepompen,
+        maar huizen kunnen dat ook doen voor verwarming of koelen. Dit werkt eigenlijk
+        alleen als gebouwen goed geïsoleerd zijn en als ze bijvoorbeeld vloer- en
+        muurverwarming hebben in plaats van radiatoren. Hybride oliewarmtepompen
+        zijn een uitzondering op deze regel doordat de olieketel ingezet kan
+        worden. Ze kunnen slim kiezen welk deel (de warmtepomp of de olieketel)
+        het meest efficiënt of kosteneffectief is om aan te zetten, afhankelijk van
+        het weer en hoe goed een huis geïsoleerd is. Minder geïsoleerde huizen zullen
+        de olieketel vaker nodig hebben, beter geïsoleerde huizen gebruiken vooral
+        de warmtepomp.  \r\n<br/><br/>\r\nDe COP van het elektrische deel van de hybride
+        oliewarmtepomp is afhankelijk van de buitentemperatuur. Als de COP onder
+        de drempelwaarde zakt schakelt de hybride warmtepomp volledig over op gas.
+        Deze omslag-COP is in de sectie <a href=\"/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps\"
+        >Vraagsturing - gedrag van hybride warmtepompen</a> aan te passen. \r\n"    
     households_cooker_network_gas_share:
       title: Gas
       short_description: ''
@@ -1410,6 +1434,10 @@ nl:
       description: ''       
     households_heater_hybrid_hydrogen_heatpump_air_water_electricity_heat_output_capacity:
       title: Hybride luchtwarmtepomp (waterstof)
+      short_description: ''
+      description: ''       
+    households_heater_hybrid_crude_oil_heatpump_air_water_electricity_heat_output_capacity:
+      title: Hybride luchtwarmtepomp (ruwe olie)
       short_description: ''
       description: ''       
 

--- a/config/locales/interface/input_elements/nl_demand_households.yml
+++ b/config/locales/interface/input_elements/nl_demand_households.yml
@@ -1243,52 +1243,30 @@ nl:
     households_heater_hybrid_heatpump_air_water_electricity_share:
       title: Hybride luchtwarmtepomp (gas)
       short_description:
-      description: "Deze verwarmingsoptie is een combinatie van een elektrische warmtepomp
-        met een gasgestookte HR-ketel. Een hybride warmtepomp maakt het mogelijk om
-        snel veel gas voor verwarming te besparen en geeft netbeheerders bovendien
-        meer tijd om stroomnetten te verzwaren.\r\n<br/><br/>\r\nHet werkt zo:<br/>\r\nDe
-        gasketel verwarmt het huis op koude dagen, als de warmtevraag het hoogst is.
-        Deze slimme truc zorgt ervoor dat een hybride warmtepomp het stroomnet minder
-        belast dan een elektrische warmtepomp alleen. Door slim gebruik te maken van
-        zulke hybride warmtepompen kan de noodzaak om stroomnetten te verzwaren vermeden
-        worden. \r\n<br/><br/>\r\nWarmtepompen verplaatsen warmte van de ene plek
-        naar de andere. Koelkasten gebruiken bijvoorbeeld warmtepompen, maar huizen
-        kunnen dat ook doen voor verwarming of koelen. Dit werkt eigenlijk alleen
-        als gebouwen goed geïsoleerd zijn en als ze vloer- en muurverwarming hebben
-        in plaats van radiatoren. Hybride warmtepompen zijn een uitzondering op deze
-        regel doordat de gasketel ingezet kan worden. Ze kunnen slim kiezen welk deel
-        (de warmtepomp of de gasketel) het meest efficiënt of kosteneffectief is om
-        aan te zetten, afhankelijk van het weer en hoe goed een huis geïsoleerd is.
-        Minder geïsoleerde huizen zullen de gasketel vaker nodig hebben, beter geïsoleerde
-        huizen gebruiken vooral de warmtepomp.  \r\n<br/><br/>\r\nDe COP van het elektrische
+      description: |
+        Deze verwarmingsoptie is een combinatie van een elektrische warmtepomp
+        met een gasgestookte HR-ketel.
+        <br/><br/>
+        De COP van het elektrische
         deel van de hybride warmtepomp is afhankelijk van de buitentemperatuur. Als
         de COP onder de drempelwaarde zakt schakelt de hybride warmtepomp volledig
-        over op gas. De omslag-COP is in de sectie <a href=\"/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps\"
-        >Vraagsturing - gedrag van hybride warmtepompen</a> aan te passen. \r\n"
+        over op gas. De omslag-COP is in de sectie <a href="/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps"
+        >Vraagsturing - gedrag van hybride warmtepompen</a> aan te passen.
+        <br/><br/>
+        Meer informatie over hoe hybride warmtepompen werken is te vinden in de <a href="https://docs.energytransitionmodel.com/main/heat-pumps" target="_blank\">documentatie</a>
     households_heater_hybrid_hydrogen_heatpump_air_water_electricity_share:
       title: Hybride luchtwarmtepomp (waterstof)
       short_description:
-      description: "Deze verwarmingsoptie is een combinatie van een elektrische warmtepomp
-        met een waterstofgestookte HR-ketel.\r\n<br/><br/>\r\nHet werkt zo:<br/>\r\nDe
-        waterstofketel verwarmt het huis op koude dagen, als de warmtevraag het hoogst
-        is. Deze slimme truc zorgt ervoor dat een hybride waterstofwarmtepomp het
-        stroomnet minder belast dan een elektrische warmtepomp alleen. Door slim gebruik
-        te maken van zulke hybride waterstofwarmtepompen kan de noodzaak om stroomnetten
-        te verzwaren vermeden worden. \r\n<br/><br/>\r\nWarmtepompen verplaatsen warmte
-        van de ene plek naar de andere. Koelkasten gebruiken bijvoorbeeld warmtepompen,
-        maar huizen kunnen dat ook doen voor verwarming of koelen. Dit werkt eigenlijk
-        alleen als gebouwen goed geïsoleerd zijn en als ze bijvoorbeeld vloer- en
-        muurverwarming hebben in plaats van radiatoren. Hybride waterstofwarmtepompen
-        zijn een uitzondering op deze regel doordat de waterstofketel ingezet kan
-        worden. Ze kunnen slim kiezen welk deel (de warmtepomp of de waterstofketel)
-        het meest efficiënt of kosteneffectief is om aan te zetten, afhankelijk van
-        het weer en hoe goed een huis geïsoleerd is. Minder geïsoleerde huizen zullen
-        de waterstofketel vaker nodig hebben, beter geïsoleerde huizen gebruiken vooral
-        de warmtepomp.  \r\n<br/><br/>\r\nDe COP van het elektrische deel van de hybride
+      description: |
+        Deze verwarmingsoptie is een combinatie van een elektrische warmtepomp
+        met een waterstofgestookte HR-ketel.<br/><br/>
+        De COP van het elektrische deel van de hybride
         waterstofwarmtepomp is afhankelijk van de buitentemperatuur. Als de COP onder
         de drempelwaarde zakt schakelt de hybride warmtepomp volledig over op gas.
-        Deze omslag-COP is in de sectie <a href=\"/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps\"
-        >Vraagsturing - gedrag van hybride warmtepompen</a> aan te passen. \r\n"
+        Deze omslag-COP is in de sectie <a href="/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps"
+        >Vraagsturing - gedrag van hybride warmtepompen</a> aan te passen.
+        <br/><br/>
+        Meer informatie over hoe hybride warmtepompen werken is te vinden in de <a href="https://docs.energytransitionmodel.com/main/heat-pumps" target="_blank\">documentatie</a>
     households_heater_hybrid_crude_oil_heatpump_air_water_electricity_share:
       title: Hybride luchtwarmtepomp (olie)
       short_description:
@@ -1296,35 +1274,17 @@ nl:
         Deze verwarmingsoptie is een combinatie van een elektrische warmtepomp
         met een oliegestookte HR-ketel.
         <br/><br/>
-        Het werkt zo:
-        <br/>
-        De olieketel verwarmt het huis op koude dagen, als de warmtevraag het hoogst
-        is. Deze slimme truc zorgt ervoor dat een hybride oliewarmtepomp het
-        stroomnet minder belast dan een elektrische warmtepomp alleen. Door slim gebruik
-        te maken van zulke hybride oliewarmtepompen kan de noodzaak om stroomnetten
-        te verzwaren vermeden worden.
-        <br/><br/>
-        Warmtepompen verplaatsen warmte
-        van de ene plek naar de andere. Koelkasten gebruiken bijvoorbeeld warmtepompen,
-        maar huizen kunnen dat ook doen voor verwarming of koelen. Dit werkt eigenlijk
-        alleen als gebouwen goed geïsoleerd zijn en als ze bijvoorbeeld vloer- en
-        muurverwarming hebben in plaats van radiatoren. Hybride oliewarmtepompen
-        zijn een uitzondering op deze regel doordat de olieketel ingezet kan
-        worden. Ze kunnen slim kiezen welk deel (de warmtepomp of de olieketel)
-        het meest efficiënt of kosteneffectief is om aan te zetten, afhankelijk van
-        het weer en hoe goed een huis geïsoleerd is. Minder geïsoleerde huizen zullen
-        de olieketel vaker nodig hebben, beter geïsoleerde huizen gebruiken vooral
-        de warmtepomp.  <br/><br/>
         De COP van het elektrische deel van de hybride
         oliewarmtepomp is afhankelijk van de buitentemperatuur. Als de COP onder
         de drempelwaarde zakt schakelt de hybride warmtepomp volledig over op olie.
         <b>Merk op dat in de standaardinstelling het oliedeel van de hybride warmtepomp
         het overgrote deel of zelfs alle warmtevraag voor ruimteverwarming invult.</b> 
-        Dit komt doordat de de standaard drempelwaarde voor de COP ingesteld is op een relatief hoge waarde
-        van 3,7 gebaseerd op de consumentenprijzen voor olie en elektriciteit.
+        Dit komt doordat de de standaard drempelwaarde voor de COP ingesteld is op een relatief hoge waarde gebaseerd op de consumentenprijzen voor olie en elektriciteit.
         <br/><br/>
-        Deze omslag-COP is in de sectie <a href=\"/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps\"
+        Deze omslag-COP is in de sectie <a href="/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps"
         >Vraagsturing - gedrag van hybride warmtepompen</a> aan te passen.
+        <br/><br/>
+        Meer informatie over hoe hybride warmtepompen werken is te vinden in de <a href="https://docs.energytransitionmodel.com/main/heat-pumps" target="_blank\">documentatie</a>
     households_cooker_network_gas_share:
       title: Gas
       short_description: ''

--- a/config/locales/interface/input_elements/nl_demand_households.yml
+++ b/config/locales/interface/input_elements/nl_demand_households.yml
@@ -1279,7 +1279,7 @@ nl:
         de drempelwaarde zakt schakelt de hybride warmtepomp volledig over op olie.
         <b>Merk op dat in de standaardinstelling het oliedeel van de hybride warmtepomp
         het overgrote deel of zelfs alle warmtevraag voor ruimteverwarming invult.</b> 
-        Dit komt doordat de de standaard drempelwaarde voor de COP ingesteld is op een relatief hoge waarde gebaseerd op de consumentenprijzen voor olie en elektriciteit.
+        Dit komt doordat de standaard drempelwaarde voor de COP ingesteld is op een relatief hoge waarde gebaseerd op de consumentenprijzen voor olie en elektriciteit.
         <br/><br/>
         Deze omslag-COP is in de sectie <a href="/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps"
         >Vraagsturing - gedrag van hybride warmtepompen</a> aan te passen.

--- a/config/locales/interface/input_elements/nl_demand_households.yml
+++ b/config/locales/interface/input_elements/nl_demand_households.yml
@@ -1290,15 +1290,21 @@ nl:
         Deze omslag-COP is in de sectie <a href=\"/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps\"
         >Vraagsturing - gedrag van hybride warmtepompen</a> aan te passen. \r\n"
     households_heater_hybrid_crude_oil_heatpump_air_water_electricity_share:
-      title: Hybride luchtwarmtepomp (ruwe olie)
+      title: Hybride luchtwarmtepomp (olie)
       short_description:
-      description: "Deze verwarmingsoptie is een combinatie van een elektrische warmtepomp
-        met een oliegestookte HR-ketel.\r\n<br/><br/>\r\nHet werkt zo:<br/>\r\nDe
-        olieketel verwarmt het huis op koude dagen, als de warmtevraag het hoogst
+      description: |
+        Deze verwarmingsoptie is een combinatie van een elektrische warmtepomp
+        met een oliegestookte HR-ketel.
+        <br/><br/>
+        Het werkt zo:
+        <br/>
+        De olieketel verwarmt het huis op koude dagen, als de warmtevraag het hoogst
         is. Deze slimme truc zorgt ervoor dat een hybride oliewarmtepomp het
         stroomnet minder belast dan een elektrische warmtepomp alleen. Door slim gebruik
         te maken van zulke hybride oliewarmtepompen kan de noodzaak om stroomnetten
-        te verzwaren vermeden worden. \r\n<br/><br/>\r\nWarmtepompen verplaatsen warmte
+        te verzwaren vermeden worden.
+        <br/><br/>
+        Warmtepompen verplaatsen warmte
         van de ene plek naar de andere. Koelkasten gebruiken bijvoorbeeld warmtepompen,
         maar huizen kunnen dat ook doen voor verwarming of koelen. Dit werkt eigenlijk
         alleen als gebouwen goed geïsoleerd zijn en als ze bijvoorbeeld vloer- en
@@ -1308,11 +1314,17 @@ nl:
         het meest efficiënt of kosteneffectief is om aan te zetten, afhankelijk van
         het weer en hoe goed een huis geïsoleerd is. Minder geïsoleerde huizen zullen
         de olieketel vaker nodig hebben, beter geïsoleerde huizen gebruiken vooral
-        de warmtepomp.  \r\n<br/><br/>\r\nDe COP van het elektrische deel van de hybride
+        de warmtepomp.  <br/><br/>
+        De COP van het elektrische deel van de hybride
         oliewarmtepomp is afhankelijk van de buitentemperatuur. Als de COP onder
-        de drempelwaarde zakt schakelt de hybride warmtepomp volledig over op gas.
+        de drempelwaarde zakt schakelt de hybride warmtepomp volledig over op olie.
+        <b>Merk op dat in de standaardinstelling het oliedeel van de hybride warmtepomp
+        het overgrote deel of zelfs alle warmtevraag voor ruimteverwarming invult.</b> 
+        Dit komt doordat de de standaard drempelwaarde voor de COP ingesteld is op een relatief hoge waarde
+        van 3,7 gebaseerd op de consumentenprijzen voor olie en elektriciteit.
+        <br/><br/>
         Deze omslag-COP is in de sectie <a href=\"/scenario/flexibility/flexibility_net_load/demand-response-behavior-of-hybrid-heat-pumps\"
-        >Vraagsturing - gedrag van hybride warmtepompen</a> aan te passen. \r\n"    
+        >Vraagsturing - gedrag van hybride warmtepompen</a> aan te passen.
     households_cooker_network_gas_share:
       title: Gas
       short_description: ''

--- a/config/locales/interface/input_elements/nl_flexibility.yml
+++ b/config/locales/interface/input_elements/nl_flexibility.yml
@@ -387,25 +387,36 @@ nl:
         De integrale kosten van flexible vraag.technnologieën</a></li>
         <li><a href="#" class="open_chart" data-chart-key="storage_options" data-chart-location="side">
         Een overzicht van de inzet van flexibele vraagtechnologieën in tabelvorm.</a></li></ul>
-    flexibility_heat_pump_space_heating_cop_cutoff:
-      title: Ruimteverwarming
+    flexibility_heat_pump_space_heating_cop_cutoff_gas:
+      title: Ruimteverwarming (gas)
       short_description:
-      description: "Geef hier aan wat de omslag-COP van het hybride warmtepompen is
+      description: "Geef hier aan wat de omslag-COP van hybride warmtepompen op gas is
         voor ruimteverwarming.\r\n<p>\r\nMet de standaardinstelling voor de omslag-COP
-        wordt het elektrische deel van de hybride warmtepomp maximal gebruikt voor
+        wordt het elektrische deel van de hybride warmtepomp maximaal gebruikt voor
         ruimteverwarming. Met de huidige gas- en elektriciteitsprijs wordt financiële
-        optimalisatie voor de gebruiker bereikt met een omslag-COP van 2.6, dit is
-        te zien in de grafiek rechts weergegeven. Voor meer informatie over (hybride)
+        optimalisatie voor de gebruiker bereikt met een omslag-COP van 2.6. Dit is
+        te zien in de grafiek rechts. Voor meer informatie over (hybride)
+        warmtepompen zie onze <a href=\"https://docs.energytransitionmodel.com/main/heat-pumps\"target=\"_blank\">documentatie</a>."
+    flexibility_heat_pump_space_heating_cop_cutoff_crude_oil:
+      title: Ruimteverwarming (olie)
+      short_description:
+      description: |
+        Geef hier aan wat de omslag-COP van hybride warmtepompen op olie is voor ruimteverwarming. </br></br>
+        Met de standaardinstelling voor de omslag-COP
+        wordt het elektrische deel van de hybride warmtepomp maximaal gebruikt voor
+        ruimteverwarming. Met de huidige gas- en elektriciteitsprijs wordt financiële
+        optimalisatie voor de gebruiker bereikt met een omslag-COP van 3.7.
+        </br></br>
+        Voor meer informatie over (hybride)
         warmtepompen zie onze <a href=\"https://docs.energytransitionmodel.com/main/heat-pumps\"target=\"_blank\">documentatie</a>."
     flexibility_heat_pump_water_heating_cop_cutoff:
       title: Warm water
       short_description:
       description: "Geef hier aan wat de omslag-COP van het hybride warmtepompen is
         voor warm water.\r\n<p>\r\nMet de standaardinstelling voor de omslag-COP wordt
-        het gasdeel van de hybride warmtepomp maximal gebruikt voor verwarmen van
-        tapwater.\r\n<p>\r\nMet de huidige gas- en elektriciteitsprijs wordt financiële
-        optimalisatie voor de gebruiker bereikt met een omslag-COP van 3.1. Voor meer
-        informatie zie: <a href=\"https://docs.energytransitionmodel.com/main/heat-pumps\" target=\"_blank\">documentatie</a>"
+        het brandstofdeel van de hybride warmtepomp (op netwerkgas, waterstof of olie) maximaal gebruikt voor verwarmen van
+        tapwater. De omslag-COP staat daarom ingesteld op de maximale waarde van 6,0, zodat het brandstofdeel altijd ingeschakeld is voor tapwater.\r\n<p>\r\n
+        Voor meer informatie zie: <a href=\"https://docs.energytransitionmodel.com/main/heat-pumps\" target=\"_blank\">documentatie</a>"
     households_flexibility_consumer_gas_price:
       title: Gasprijs
       short_description:

--- a/config/locales/interface/output_elements/labels_groups/en_labels.yml
+++ b/config/locales/interface/output_elements/labels_groups/en_labels.yml
@@ -136,7 +136,7 @@ en:
       households_space_heater_wood_pellets: "Wood pellet boiler"
     hhp_cop_cost:
       x_axis: COP
-      y_axis: "ct/MJ heat"
+      y_axis: "€ct / MJ heat"
     block_chart:
       costs: "Cost of power production"
       investment_costs: "Investment costs"

--- a/config/locales/interface/output_elements/labels_groups/en_labels.yml
+++ b/config/locales/interface/output_elements/labels_groups/en_labels.yml
@@ -131,6 +131,7 @@ en:
       households_space_heater_heatpump_surface_water_water_ts_electricity: "Aquathermal heat pump with TS (surface water)"
       households_space_heater_hybrid_heatpump_air_water_electricity: "Hybrid air heat pump (gas)"
       households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity: "Hybrid air heat pump (hydrogen)"
+      households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity: "Hybrid air heat pump (oil)"
       households_space_heater_network_gas: "Gas-fired heater"
       households_space_heater_wood_pellets: "Wood pellet boiler"
     hhp_cop_cost:

--- a/config/locales/interface/output_elements/labels_groups/nl_labels.yml
+++ b/config/locales/interface/output_elements/labels_groups/nl_labels.yml
@@ -129,6 +129,7 @@ nl:
       households_space_heater_heatpump_surface_water_water_ts_electricity: "Warmtepomp met aquathermie (TEO) en WKO"
       households_space_heater_hybrid_heatpump_air_water_electricity: "Hybride luchtwarmtepomp (gas)"
       households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity: "Hybride luchtwarmtepomp (waterstof)"
+      households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity: "Hybride luchtwarmtepomp (ruwe olie)"
       households_space_heater_network_gas: "Gasketel"
       households_space_heater_wood_pellets: "Houtpelletkachel"
     hhp_cop_cost:

--- a/config/locales/interface/slides/en_flexibility.yml
+++ b/config/locales/interface/slides/en_flexibility.yml
@@ -104,39 +104,21 @@ en:
       title: Demand response - behavior of hybrid heat pumps
       short_description:
       description: |
-        The efficiency of hybrid heat pumps (HHP) is dependent on the
-        ambient temperature and is depicted by the coefficient of performance (COP).
+        The efficiency of hybrid heat pumps (HHP) depends on the
+        ambient temperature and is represented by the coefficient of performance (COP).
         The COP becomes lower as the outside temperature decreases. Below you can
-        set the so-called 'threshold COP': if the COP of the heat pump is below this
-        threshold then the HHP switches from electricity to a 'backup fuel'. This can be network gas, hydrogen or oil. 
+        set the so-called 'threshold COP': if the COP of the heat pump falls below this
+        threshold then the HHP switches from electricity to a backup fuel. This can be network gas, hydrogen or oil. 
         You can choose a setting that is most financially attractive for the consumer, but you can
-        also choose a setting that produces less impact on the electricity network.
+        also choose a setting that produces less impact on the electricity network. 
+        See the <a href="https://docs.energytransitionmodel.com/main/heat-pumps" target=\"_blank\">documentation</a>
+        for more information on the threshold COP.
         </br></br>
-        To help you decide the cost-optimal threshold COP setting
-        from a consumer perspective, have a look at the chart on the right. It shows
-        how much it costs to make a unit of heat with the HHP for space heating for network gas. For
-        the gas part, these costs are independent of the COP (and therefore the outside
-        temperature). The costs for the electrical part are decreasing with increasing
-        COP (and increasing outside temperature). The intersection of the two curves
-        is the cost-optimal COP setting for the given cost price gas and electricity.
-        This cost price of gas and electricity can be adjusted below. The start value
-        of the treshold COP slider matches the calculated cost-optimal threshold COP
-        for space heating.
-        </br></br>
-        Specifically for network gas-fired hybrid heat pumps two charts may provide relevant insights. 
-        The chart
+        Specifically for gas HHPs the chart
         <a
         href="#" class="open_chart" data-chart-key="household_space_heater_hhp_hourly_demand" data-chart-location="side">
         Demand curve of hybrid heat pump (gas) in households
-        </a>
-        shows the hourly gas and electricity demand and is useful for determining
-        the impact of network gas-fired HHPs on infrastructure.
-        The table
-        <a
-          href="#" class="open_chart" data-chart-key="hybrid_heat_pump" data-chart-location="side">
-        Electricity and gas shares of hybrid heat pump in households
-        </a>
-        will show a breakdown of how hybrid heat pumps use energy in households."
+        </a> might help determine the impact of network gas-fired HHPs on infrastructure.
     flexibility_flexibility_demand_response_load_shifting:
       title: Demand response - load shifting in industry
       short_description:

--- a/config/locales/interface/slides/en_flexibility.yml
+++ b/config/locales/interface/slides/en_flexibility.yml
@@ -103,17 +103,18 @@ en:
     flexibility_flexibility_demand_response_hhp:
       title: Demand response - behavior of hybrid heat pumps
       short_description:
-      description: "The efficiency of hybrid heat pumps (HHP) is dependent on the
+      description: |
+        The efficiency of hybrid heat pumps (HHP) is dependent on the
         ambient temperature and is depicted by the coefficient of performance (COP).
         The COP becomes lower as the outside temperature decreases. Below you can
         set the so-called 'threshold COP': if the COP of the heat pump is below this
-        threshold then the HHP switches from electricity to gas. You can choose a
-        setting that is most financially attractive for the consumer, but you can
+        threshold then the HHP switches from electricity to a 'backup fuel'. This can be network gas, hydrogen or oil. 
+        You can choose a setting that is most financially attractive for the consumer, but you can
         also choose a setting that produces less impact on the electricity network.
         </br></br>
         To help you decide the cost-optimal threshold COP setting
         from a consumer perspective, have a look at the chart on the right. It shows
-        how much it costs to make a unit of heat with the HHP for space heating. For
+        how much it costs to make a unit of heat with the HHP for space heating for network gas. For
         the gas part, these costs are independent of the COP (and therefore the outside
         temperature). The costs for the electrical part are decreasing with increasing
         COP (and increasing outside temperature). The intersection of the two curves
@@ -122,18 +123,19 @@ en:
         of the treshold COP slider matches the calculated cost-optimal threshold COP
         for space heating.
         </br></br>
+        Specifically for network gas-fired hybrid heat pumps two charts may provide relevant insights. 
         The chart
         <a
-          href=\"#\" class=\"open_chart\"
-          \ data-chart-key=\"household_space_heater_hhp_hourly_demand\"
-        >Demand curve of hybrid heat pump (gas) in households</a>
+        href="#" class="open_chart" data-chart-key="household_space_heater_hhp_hourly_demand" data-chart-location="side">
+        Demand curve of hybrid heat pump (gas) in households
+        </a>
         shows the hourly gas and electricity demand and is useful for determining
-        the impact of HHPs on infrastructure.
+        the impact of network gas-fired HHPs on infrastructure.
         The table
         <a
-          href=\"#\" class=\"open_chart\"
-          \ data-chart-key=\"hybrid_heat_pump\"
-        >Electricity and gas shares of hybrid heat pump in households</a>
+          href="#" class="open_chart" data-chart-key="hybrid_heat_pump" data-chart-location="side">
+        Electricity and gas shares of hybrid heat pump in households
+        </a>
         will show a breakdown of how hybrid heat pumps use energy in households."
     flexibility_flexibility_demand_response_load_shifting:
       title: Demand response - load shifting in industry

--- a/config/locales/interface/slides/nl_flexibility.yml
+++ b/config/locales/interface/slides/nl_flexibility.yml
@@ -117,33 +117,12 @@ nl:
         naar een brandstof. Dit kan netwerkgas, waterstof of olie zijn.
         Je kan deze instellen op de financieel meest aantrekkelijke voor
         de consument, maar kan ook een instelling kiezen die minder netwerkimpact
-        oplevert. </br></br>
-        Bekijk de grafiek aan de rechterkant voor advies
-        bij het kiezen van de kostenoptimale omslag-COP instelling vanuit een consumentenperspectief. 
-        Deze laat zien hoeveel het kost om een eenheid warmte te maken met de gasgestookte hybride warmtepomp
-        voor ruimteverwarming. Voor gas zijn die kosten onafhankelijk van de COP (en
-        dus de buitentemperatuur). Voor elektriciteit nemen de kosten af met toenemende
-        COP (en toenemende buitentemperatuur). Het snijpunt van de twee curves is
-        de kosten-optimale COP-instelling voor de gegeven kostprijs van gas en elektriciteit.
-        Deze kostprijs van gas en elektriciteit is hieronder in te stellen. De startwaarde
-        van het omslag-COP schuifje staat gelijk aan de kostenoptimale omslag-COP
-        bij de ingestelde kosten.
+        oplevert. 
         </br></br>
-        Specifiek voor gasgestookte hybride warmtepompen bieden twee grafieken mogelijk relevante inzichten. 
-        De grafiek
-        <a
-          href="#" class="open_chart" data-chart-key="household_space_heater_hhp_hourly_demand" data-chart-location="side">
-        Vraagprofiel van hybride warmtepomp (gas) voor huishoudens
-        </a>
-        laat de gas- en elektriciteitsvraag per uur zien en is handig voor het
-        bepalen van de impact van hybride warmtepompen op de infrastructuur.
-        De tabel
-        <a
-          href="#" class="open_chart"
-           data-chart-key="hybrid_heat_pump" data-chart-location="side">
-        Elektriciteit en gas aandeel van hybride warmtepomp voor huishoudens
-        </a>
-        laat de jaarlijkse verdeling van gas en elektriciteit zien.
+        Specifiek voor gasgestookte hybride warmtepompen helpt de grafiek
+        <a href="#" class="open_chart" data-chart-key="household_space_heater_hhp_hourly_demand" data-chart-location="side">
+        Vraagprofiel van hybride warmtepomp (gas) voor huishoudens </a>
+        bij het bepalen van de impact van hybride warmtepompen op de netwerkinfrastructuur.
     flexibility_flexibility_demand_response_load_shifting:
       title: Vraagsturing - vraagverschuiving in industrie
       short_description:

--- a/config/locales/interface/slides/nl_flexibility.yml
+++ b/config/locales/interface/slides/nl_flexibility.yml
@@ -108,37 +108,42 @@ nl:
     flexibility_flexibility_demand_response_hhp:
       title: Vraagsturing - gedrag van hybride warmtepompen
       short_description:
-      description: "De efficiëntie van (hybride) warmtepompen is afhankelijk van de
+      description: |
+        De efficiëntie van (hybride) warmtepompen is afhankelijk van de
         buitentemperatuur en wordt aangegeven met de 'coefficient of performance'
         (COP). De COP wordt lager als de buitentemperatuur afneemt. Hieronder kan
         je de zogenaamde 'omslag-COP' instellen: wanneer de COP van de warmtepomp
         onder de omslag-COP ligt dan schakelt de hybride warmtepomp van elektriciteit
-        naar gas. Je kan deze instellen op de financieel meest aantrekkelijke voor
+        naar een brandstof. Dit kan netwerkgas, waterstof of olie zijn.
+        Je kan deze instellen op de financieel meest aantrekkelijke voor
         de consument, maar kan ook een instelling kiezen die minder netwerkimpact
-        oplevert. \r\n</br></br>\r\n Bekijk de grafiek aan de rechterkant voor advies
-        bij het kiezen van de kostenoptimale omslag-COP instelling vanuit een consumentenperspectief.
-        Deze laat zien hoeveel het kost om een eenheid warmte te maken met de HWP
+        oplevert. </br></br>
+        Bekijk de grafiek aan de rechterkant voor advies
+        bij het kiezen van de kostenoptimale omslag-COP instelling vanuit een consumentenperspectief. 
+        Deze laat zien hoeveel het kost om een eenheid warmte te maken met de gasgestookte hybride warmtepomp
         voor ruimteverwarming. Voor gas zijn die kosten onafhankelijk van de COP (en
         dus de buitentemperatuur). Voor elektriciteit nemen de kosten af met toenemende
-        COP (en toenemende buitentemperatuur). Het kruispunt van de twee curves is
+        COP (en toenemende buitentemperatuur). Het snijpunt van de twee curves is
         de kosten-optimale COP-instelling voor de gegeven kostprijs van gas en elektriciteit.
         Deze kostprijs van gas en elektriciteit is hieronder in te stellen. De startwaarde
         van het omslag-COP schuifje staat gelijk aan de kostenoptimale omslag-COP
         bij de ingestelde kosten.
         </br></br>
+        Specifiek voor gasgestookte hybride warmtepompen bieden twee grafieken mogelijk relevante inzichten. 
         De grafiek
         <a
-          href=\"#\" class=\"open_chart\"
-          \ data-chart-key=\"household_space_heater_hhp_hourly_demand\"
-        >Vraagprofiel van hybride warmtepomp (gas) voor huishoudens</a>
+          href="#" class="open_chart" data-chart-key="household_space_heater_hhp_hourly_demand" data-chart-location="side">
+        Vraagprofiel van hybride warmtepomp (gas) voor huishoudens
+        </a>
         laat de gas- en elektriciteitsvraag per uur zien en is handig voor het
         bepalen van de impact van hybride warmtepompen op de infrastructuur.
         De tabel
         <a
-          href=\"#\" class=\"open_chart\"
-          \ data-chart-key=\"hybrid_heat_pump\"
-        >Elektriciteit en gas aandeel van hybride warmtepomp voor huishoudens</a>
-        laat de jaarlijkse verdeling van gas en elektriciteit zien."
+          href="#" class="open_chart"
+           data-chart-key="hybrid_heat_pump" data-chart-location="side">
+        Elektriciteit en gas aandeel van hybride warmtepomp voor huishoudens
+        </a>
+        laat de jaarlijkse verdeling van gas en elektriciteit zien.
     flexibility_flexibility_demand_response_load_shifting:
       title: Vraagsturing - vraagverschuiving in industrie
       short_description:


### PR DESCRIPTION
This PR adds oil-based hybrid heat pumps to the front end. It includes the following additions:

1. Oil HHP slider for households and for buildings;
2. Threshold COP slider for oil HHP

The PR also includes the following changes to existing material:

- Updates of the `Demand response - behavior of hybrid heat pumps` slide text to refer to general HHPs (instead of only gas-based ones)
- Update of threshold COP slider texts for space heating & for hot water with additional explanation;
- Hides the `hybrid_heat_pump` table for electricity & gas shares (see [corresponding new issue](https://github.com/quintel/etmodel/issues/4237))
- label update for HHP gas & electricity consumer prices (closes [#4219](https://github.com/quintel/etmodel/issues/4219))