### PR TITLE
Show and alter scenario version history

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,7 +328,7 @@ GEM
     minitest (5.22.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)
-    mysql2 (0.5.3)
+    mysql2 (0.5.6)
     net-imap (0.4.10)
       date
       net-protocol

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -33,3 +33,4 @@
 //= require copy_link_box
 //= require header
 //= require featured_scenario
+//= require saved_scenario_history

--- a/app/assets/javascripts/saved_scenario_history.js
+++ b/app/assets/javascripts/saved_scenario_history.js
@@ -14,15 +14,24 @@
       this.descriptionEl = this.el.querySelector('.description');
       this.descriptionEditEl = this.el.querySelector('.description-field');
       this.iconsEl = this.el.querySelector('.scenario-version');
+      this.formControl = this.el.querySelector('.control');
     },
     showTextArea: function (event) {
       $(this.iconsEl).hide();
       $(this.descriptionEl).hide();
+      $(this.formControl).show();
       $(this.descriptionEditEl).show();
+      this.descriptionEditEl.querySelector('textarea').focus();
     },
 
     updateDescription: function(event) {
       let newText = this.descriptionEditEl.querySelector('textarea').value;
+
+      if (newText == ''){
+        this.hideTextArea();
+        return;
+      }
+
       let self = this;
 
       $.ajax({
@@ -44,6 +53,7 @@
     hideTextArea: function (event) {
       $(this.iconsEl).show();
       $(this.descriptionEl).show();
+      $(this.formControl).hide();
       $(this.descriptionEditEl).hide();
     },
   });

--- a/app/assets/javascripts/saved_scenario_history.js
+++ b/app/assets/javascripts/saved_scenario_history.js
@@ -5,7 +5,7 @@
       'click .edit-description': 'showTextArea',
       'click .submit-description': 'updateDescription',
       'click .cancel-description': 'hideTextArea',
-      // 'click .restore': 'restore', TODO: check if we need this
+      'click .restore-version': 'openDestroyModal',
     },
 
     constructor: function () {
@@ -55,6 +55,19 @@
       $(this.descriptionEl).show();
       $(this.formControl).hide();
       $(this.descriptionEditEl).hide();
+    },
+
+    openDestroyModal: function (event) {
+      let url = $(event.target).data("url");
+
+      $.fancybox.open({
+        href: url,
+        type: 'ajax',
+        autoSize: false,
+        height: 250,
+        width: 550,
+        padding: 0
+      });
     },
   });
 

--- a/app/assets/javascripts/saved_scenario_history.js
+++ b/app/assets/javascripts/saved_scenario_history.js
@@ -1,0 +1,53 @@
+/* globals $ App Backbone I18n */
+(function (window) {
+  var ScenarioHistoryView = Backbone.View.extend({
+    events: {
+      'click .edit-description': 'showTextArea',
+      'click .submit-description': 'updateDescription',
+      'click .cancel-description': 'hideTextArea',
+      // 'click .restore': 'restore', TODO: check if we need this
+    },
+
+    constructor: function () {
+      Backbone.View.apply(this, arguments);
+
+      this.descriptionEl = this.el.querySelector('.description');
+      this.descriptionEditEl = this.el.querySelector('.description-field');
+      this.iconsEl = this.el.querySelector('.scenario-version');
+    },
+    showTextArea: function (event) {
+      $(this.iconsEl).hide();
+      $(this.descriptionEl).hide();
+      $(this.descriptionEditEl).show();
+    },
+
+    updateDescription: function(event) {
+      let newText = this.descriptionEditEl.querySelector('textarea').value;
+      let self = this;
+
+      $.ajax({
+        url: this.options.url + '/' + self.id,
+        method: 'PUT',
+        dataType: 'json',
+        data: { description: newText },
+        success: function () {
+          self.descriptionEl.textContent = newText;
+          self.hideTextArea();
+        },
+        error: function (response) {
+          console.log('Failed to update!');
+          console.log(response);
+        }
+      });
+    },
+
+    hideTextArea: function (event) {
+      $(this.iconsEl).show();
+      $(this.descriptionEl).show();
+      $(this.descriptionEditEl).hide();
+    }
+
+  });
+
+  window.ScenarioHistoryView = ScenarioHistoryView;
+})(window);

--- a/app/assets/javascripts/saved_scenario_history.js
+++ b/app/assets/javascripts/saved_scenario_history.js
@@ -45,8 +45,7 @@
       $(this.iconsEl).show();
       $(this.descriptionEl).show();
       $(this.descriptionEditEl).hide();
-    }
-
+    },
   });
 
   window.ScenarioHistoryView = ScenarioHistoryView;

--- a/app/assets/stylesheets/_header.sass
+++ b/app/assets/stylesheets/_header.sass
@@ -292,6 +292,8 @@ header.main-header
       text-overflow: ellipsis
       vertical-align: top
       white-space: nowrap
+      &:hover
+        color: #444
     .name:before
       content: "– "
   .dropdown

--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -494,7 +494,7 @@ table.default
           margin-bottom: 1px
           marign-left: -2px
         .dropdown-menu, .dropdown-menu::before
-          background: #333
+          background: $landing-gold
           color: #fff
         .dropdown-item
           font-size: inherit

--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -819,7 +819,7 @@ table.default
     margin-top: 1rem
     opacity: 0
     animation: fadeInFromNone 0.5s ease-in forwards
-    display: flex
+    display: flex !important
     justify-content: space-between
     .desc-box
       background: $soft-grey

--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -473,7 +473,7 @@ table.default
         padding-right: 0
         margin-top: -1.5rem
 
-      #scenario-location, #scenario-privacy, .scenario-version
+      #scenario-location, #scenario-privacy, .scenario-version, #scenario-copy
         button.scenario-actions
           align-items: center
           background: none
@@ -523,6 +523,10 @@ table.default
           line-height: 1.5
           margin: 0.5rem 1rem 1rem
           width: 300px
+        .url
+          padding: 10px
+          input
+            width: 100%
 
     .bar
       border-top: 1px solid #eee

--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -860,6 +860,7 @@ table.default
       font-weight: bold
       margin-right: 1.2rem
       color: #333
+      white-space: nowrap
       &:hover
         color: $landing-blue
         text-decoration: none

--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -494,11 +494,11 @@ table.default
           margin-bottom: 1px
           marign-left: -2px
         .dropdown-menu, .dropdown-menu::before
-          background: $landing-gold
-          color: #fff
+          background: #DBEDFE
+          color: #333
         .dropdown-item
           font-size: inherit
-          color: #fff
+          color: #333
           margin: 0 0.41rem
           border-radius: 5px
           padding: 0.41rem
@@ -805,6 +805,7 @@ table.default
 #saved-scenario-history
   .box
     background: $soft-grey
+    color: $landing-grey
     padding: 0.5rem 1rem
     margin-top: 1rem
     border-radius: 10px
@@ -822,13 +823,17 @@ table.default
         color: $landing-blue
 
     .main-info
+      font-weight: bold
       .fa
-        color: #fff
-        margin-right: 1rem
+        color: $landing-grey
+        margin-right: 0.5rem
       span
         color: $landing-blue
+        font-weight: normal
+        margin-left: 0.5rem
     &:first-of-type
       background: $light-blue
+      color: black
       .main-info
         .fa
           color: $landing-blue

--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -808,6 +808,8 @@ table.default
     padding: 0.5rem 1rem
     margin-top: 1rem
     border-radius: 10px
+    opacity: 0
+    animation: fadeInFromNone 0.5s ease-in forwards
     .details
       margin-bottom: 0
     .scenario-version
@@ -830,3 +832,16 @@ table.default
       .main-info
         .fa
           color: $landing-blue
+
+@keyframes fadeInFromNone
+  0%
+    display: none
+    opacity: 0
+
+  1%
+    display: block
+    opacity: 0
+
+  100%
+    display: block
+    opacity: 1

--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -129,7 +129,6 @@ table.default
       font-size: 1.67rem
       color: #333
       letter-spacing: 1px
-      margin-top: 0
       sub
         line-height: 0
 
@@ -807,8 +806,23 @@ table.default
     border-radius: 10px
     width: 50%
     min-width: 400px
+    .scenario-version
+      li a
+        display: inline
+      .fa
+        color: #888
+      .fa:hover
+        cursor: pointer
+        color: $landing-blue
+
     .main-info
+      .fa
+        color: #fff
+        margin-right: 1rem
       span
         color: $landing-blue
     &:first-of-type
       background: $light-blue
+      .main-info
+        .fa
+          color: $landing-blue

--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -494,14 +494,15 @@ table.default
           margin-bottom: 1px
           marign-left: -2px
         .dropdown-menu, .dropdown-menu::before
-          background: #F6FFF1
-          color: #333
+          background: #333
+          color: #fff
         .dropdown-item
           font-size: inherit
-          color: #333
+          color: #fff
           margin: 0 0.41rem
           border-radius: 5px
           padding: 0.41rem
+          transition: background 0.2s
           svg
             opacity: 0.5
           .fa, span.icon
@@ -804,13 +805,32 @@ table.default
 
 #saved-scenario-history
   .box
-    background: $soft-grey
     color: #333
-    padding: 0.5rem 1rem
     margin-top: 1rem
-    border-radius: 10px
     opacity: 0
     animation: fadeInFromNone 0.5s ease-in forwards
+    display: flex
+    justify-content: space-between
+    .desc-box
+      background: $soft-grey
+      color: #333
+      padding: 0.5rem 1rem
+      border-radius: 4px
+      border-radius: 4px
+      flex-grow: 2
+      position: relative
+      margin-top: -0.625rem
+      &::before
+        background: $soft-grey
+        border-radius: 2px
+        content: ''
+        height: 0.625rem
+        position: absolute
+        transform: rotate(45deg)
+        width: 0.625rem
+        left: -0.25rem
+        top: 0.8rem
+
     .details
       margin-bottom: 0
     .scenario-version
@@ -823,19 +843,30 @@ table.default
         color: $landing-blue
     .main-info
       font-weight: bold
+      margin-right: 1.2rem
       .fa
         color: $landing-grey
         margin-right: 0.5rem
+        font-size: 0.8rem
+        padding-left: 3px
       span
-        color: $landing-blue
         font-weight: normal
         margin-left: 0.5rem
+    .description, .description-flied
+      margin: 0
   .box:first-child
-    background: $light-blue
-    color: black
+    .desc-box
+      background: $light-blue
+      color: #333
+      &::before
+        background: $light-blue
     .main-info
       .fa
         color: $landing-blue
+  textarea
+    resize: none
+    margin-top: 0.5rem
+    width: 80%
 
 @keyframes fadeInFromNone
   0%

--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -809,6 +809,11 @@ table.default
     margin-top: 0
   p.history-description
     margin-bottom: 2rem
+  .back-to-scenario-view
+    .fa
+      color: #333
+      &:hover
+        color: $landing-gold
   .box
     color: #333
     margin-top: 1rem

--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -805,7 +805,7 @@ table.default
 #saved-scenario-history
   .box
     background: $soft-grey
-    color: $landing-grey
+    color: #333
     padding: 0.5rem 1rem
     margin-top: 1rem
     border-radius: 10px
@@ -821,7 +821,6 @@ table.default
       .fa:hover
         cursor: pointer
         color: $landing-blue
-
     .main-info
       font-weight: bold
       .fa
@@ -831,12 +830,12 @@ table.default
         color: $landing-blue
         font-weight: normal
         margin-left: 0.5rem
-    &:first-of-type
-      background: $light-blue
-      color: black
-      .main-info
-        .fa
-          color: $landing-blue
+  .box:first-child
+    background: $light-blue
+    color: black
+    .main-info
+      .fa
+        color: $landing-blue
 
 @keyframes fadeInFromNone
   0%

--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -804,6 +804,11 @@ table.default
         background: darken($landing-green, 1%)
 
 #saved-scenario-history
+  color: #333
+  h3
+    margin-top: 0
+  p.history-description
+    margin-bottom: 2rem
   .box
     color: #333
     margin-top: 1rem
@@ -815,8 +820,7 @@ table.default
       background: $soft-grey
       color: #333
       padding: 0.5rem 1rem
-      border-radius: 4px
-      border-radius: 4px
+      border-radius: 3px
       flex-grow: 2
       position: relative
       margin-top: -0.625rem
@@ -833,11 +837,17 @@ table.default
 
     .details
       margin-bottom: 0
-    .scenario-version
+      .control
+        display: none
+    .scenario-version, .control
       li a, li
         display: inline-block
       .fa
         color: #888
+        &.green:hover
+          color: $landing-green
+        &.red:hover
+          color: $error-red
       .fa:hover
         cursor: pointer
         color: $landing-blue
@@ -865,8 +875,7 @@ table.default
         color: $landing-blue
   textarea
     resize: none
-    margin-top: 0.5rem
-    width: 80%
+    width: 100%
 
 @keyframes fadeInFromNone
   0%

--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -859,6 +859,12 @@ table.default
     .main-info
       font-weight: bold
       margin-right: 1.2rem
+      color: #333
+      &:hover
+        color: $landing-blue
+        text-decoration: none
+        span, em
+          text-decoration: underline
       .fa
         color: $landing-grey
         margin-right: 0.5rem

--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -83,7 +83,7 @@ table.default
       width: 100%
       background: white
       border-radius: 6px
-      padding: 15px 40px
+      padding: 15px 40px 40px
 
     .version-warning
       background: #f0f7ee image-url('icons/warning-information.svg') 1.5rem 1.25rem no-repeat
@@ -428,7 +428,7 @@ table.default
         margin: 5px 0 10px 0
 
     .description
-      margin-bottom: 10px
+      margin: 7px 0 10px 0
       line-height: 1.5em
       &.info
         background: $light-blue
@@ -494,11 +494,11 @@ table.default
           margin-bottom: 1px
           marign-left: -2px
         .dropdown-menu, .dropdown-menu::before
-          background: #DBEDFE
-          color: #333
+          background: $landing-blue
+          color: #fff
         .dropdown-item
           font-size: inherit
-          color: #333
+          color: #fff
           margin: 0 0.41rem
           border-radius: 5px
           padding: 0.41rem

--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -75,11 +75,15 @@ table.default
       margin-left: 0
 
   &#show_scenario, &#feature_scenario, &#index
-    width: $landing-width + 200px
+    width: $landing-width + 400px
     margin: 0 auto 3rem
-    background: white
-    border-radius: 6px
-    padding: 15px 40px
+    display: flex
+
+    .internal-box
+      width: 100%
+      background: white
+      border-radius: 6px
+      padding: 15px 40px
 
     .version-warning
       background: #f0f7ee image-url('icons/warning-information.svg') 1.5rem 1.25rem no-repeat
@@ -470,7 +474,7 @@ table.default
         padding-right: 0
         margin-top: -1.5rem
 
-      #scenario-location, #scenario-privacy
+      #scenario-location, #scenario-privacy, .scenario-version
         button.scenario-actions
           align-items: center
           background: none
@@ -661,8 +665,8 @@ table.default
   .big-tabs
     align-items: stretch
     display: flex
+    flex-direction: column
     font-weight: 500
-    margin: -15px -40px 20px
     background: $soft-grey
     .count
       align-items: center
@@ -684,14 +688,15 @@ table.default
     .tab
       align-items: center
       background: #fff
-      border-radius: 4px 4px 0 0
+      // border-radius: 4px 4px 0 0
       margin-right: 3px
       border-bottom: 3px solid $soft-grey
       color: darken(#79828d, 15%)
       display: flex
       font-size: 16px
       gap: 0.125rem
-      padding: 20px 35px
+      padding: 10px 15px
+      width: 200px
       &:first-child
         border-top-left-radius: 6px
       &:hover
@@ -702,10 +707,10 @@ table.default
       &.active
         background: white
         color: black
-        border-bottom: none
-        border-top: 3px solid $landing-gold
-        padding-top: 17px
-        padding-bottom: 23px
+        // border-bottom: none
+        border-right: 3px solid $landing-gold
+        // padding-top: 17px
+        // padding-bottom: 23px
         &:hover
           color: black
       &.myc
@@ -794,3 +799,16 @@ table.default
       &:active
         background: darken($landing-green, 1%)
 
+#saved-scenario-history
+  .box
+    background: $soft-grey
+    padding: 0.5rem 1rem
+    margin-top: 1rem
+    border-radius: 10px
+    width: 50%
+    min-width: 400px
+    .main-info
+      span
+        color: $landing-blue
+    &:first-of-type
+      background: $light-blue

--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -804,11 +804,11 @@ table.default
     padding: 0.5rem 1rem
     margin-top: 1rem
     border-radius: 10px
-    width: 50%
-    min-width: 400px
+    .details
+      margin-bottom: 0
     .scenario-version
-      li a
-        display: inline
+      li a, li
+        display: inline-block
       .fa
         color: #888
       .fa:hover

--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -692,9 +692,7 @@ table.default
     .tab
       align-items: center
       background: #fff
-      // border-radius: 4px 4px 0 0
-      margin-right: 3px
-      border-bottom: 3px solid $soft-grey
+      margin-bottom: 3px
       color: darken(#79828d, 15%)
       display: flex
       font-size: 16px
@@ -866,8 +864,8 @@ table.default
       &:hover
         color: $landing-blue
         text-decoration: none
-        span, em
-          text-decoration: underline
+        .fa
+          color: $landing-blue
       .fa
         color: $landing-grey
         margin-right: 0.5rem
@@ -885,8 +883,11 @@ table.default
       &::before
         background: $light-blue
     .main-info
+      &:hover
+        .fa
+          color: $landing-blue
       .fa
-        color: $landing-blue
+        color: #333
   textarea
     resize: none
     width: 100%

--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -224,7 +224,7 @@ table.default
     .save-wrapper
       align-items: center
       display: flex
-      margin: 0 20px 0 auto
+      margin: 10px auto 0 auto
       .save
         margin: 0
         font-size: 14px
@@ -494,11 +494,11 @@ table.default
           margin-bottom: 1px
           marign-left: -2px
         .dropdown-menu, .dropdown-menu::before
-          background: $landing-blue
-          color: #fff
+          background: #F6FFF1
+          color: #333
         .dropdown-item
           font-size: inherit
-          color: #fff
+          color: #333
           margin: 0 0.41rem
           border-radius: 5px
           padding: 0.41rem
@@ -518,7 +518,7 @@ table.default
             opacity: 1
         .dropdown-item:hover
           color: #333 !important
-          background: #fff
+          background: $soft-grey
         .dropdown-menu .info
           line-height: 1.5
           margin: 0.5rem 1rem 1rem

--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -845,6 +845,8 @@ table.default
       .control
         display: none
     .scenario-version, .control
+      ul
+        white-space: nowrap
       li a, li
         display: inline-block
       .fa

--- a/app/controllers/api/saved_scenarios_controller.rb
+++ b/app/controllers/api/saved_scenarios_controller.rb
@@ -52,6 +52,11 @@ module API
       head :ok
     end
 
+    # NOPE --> check if old scenario id in update statement - then we restore!
+
+
+    # ADD extra API for changing description of version
+
     private
 
     def scenario_params

--- a/app/controllers/saved_scenario_history_controller.rb
+++ b/app/controllers/saved_scenario_history_controller.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Controller that fetches and updates the scenario versions underlying a saved scenario
+class SavedScenarioHistoryController < ApplicationController
+  before_action :assign_saved_scenario
+
+  before_action only: %i[index] do
+    authorize!(:read, @saved_scenario)
+  end
+
+  before_action only: %i[update] do
+    authorize!(:update, @saved_scenario)
+  end
+
+  # GET /saved_scenarios/:id/history
+  def index
+    version_tags_result = FetchSavedScenarioVersionTags.call(engine_client, @saved_scenario)
+
+    if version_tags_result.successful?
+      @history = SavedScenarioHistoryPresenter.present(@saved_scenario, version_tags_result.value)
+
+      respond_to do |format|
+        format.js
+        format.json { render @history }
+      end
+    else
+      render version_tags_result.error
+    end
+  end
+
+  # PUT /saved_scenarios/:id/history/:scenario_id
+  def update
+    # TODO: scenario-id is known -> make a service!
+  end
+
+  # GET /saved_scenarios/:id/history/:scenario_id/edit
+  def edit
+    # TODO: add route and js form
+  end
+
+  private
+
+  def assign_saved_scenario
+    @saved_scenario = SavedScenario.find(params[:saved_scenario_id])
+  rescue ActiveRecord::RecordNotFound
+    # TODO: json oly so render empty json? Or one that says: errors: not found??
+    render_not_found
+  end
+end

--- a/app/controllers/saved_scenarios_controller.rb
+++ b/app/controllers/saved_scenarios_controller.rb
@@ -73,6 +73,7 @@ class SavedScenariosController < ApplicationController
   def show
     respond_to do |format|
       format.html { @saved_scenario.loadable? ? render : redirect_to(root_path) }
+      format.js { @saved_scenario.loadable? ? render : redirect_to(root_path) }
       format.csv { @saved_scenario.loadable? ? render : render_not_found }
     end
   end

--- a/app/controllers/saved_scenarios_controller.rb
+++ b/app/controllers/saved_scenarios_controller.rb
@@ -230,10 +230,13 @@ class SavedScenariosController < ApplicationController
       restore_params[:scenario_id].to_i
     )
 
-    # TODO: check success -> flash?
-    # if result.successful?
+    flash.notice =
+      if result.successful?
+        t('flash.scenario_restored')
+      else
+        t('flash.scenario_cannot_be_restored')
+      end
 
-    # Or do we refresh?
     respond_to do |format|
       format.js
     end

--- a/app/controllers/saved_scenarios_controller.rb
+++ b/app/controllers/saved_scenarios_controller.rb
@@ -2,7 +2,7 @@
 
 # The controller that handles calls to the saved_scenario entity
 class SavedScenariosController < ApplicationController
-  load_resource only: %i[load discard undiscard publish unpublish restore]
+  load_resource only: %i[load discard undiscard publish unpublish restore confirm_restore]
   load_and_authorize_resource only: %i[show new create edit update destroy]
 
   before_action only: %i[load] do
@@ -221,6 +221,12 @@ class SavedScenariosController < ApplicationController
     )
 
     redirect_to saved_scenario_path(@saved_scenario)
+  end
+
+  def confirm_restore
+    @scenario_id = restore_params[:scenario_id].to_i
+
+    render 'confirm_restore', layout: false
   end
 
   # Restores a saved scenario to a previous version

--- a/app/controllers/saved_scenarios_controller.rb
+++ b/app/controllers/saved_scenarios_controller.rb
@@ -2,7 +2,7 @@
 
 # The controller that handles calls to the saved_scenario entity
 class SavedScenariosController < ApplicationController
-  load_resource only: %i[load discard undiscard publish unpublish]
+  load_resource only: %i[load discard undiscard publish unpublish restore]
   load_and_authorize_resource only: %i[show new create edit update destroy]
 
   before_action only: %i[load] do
@@ -13,7 +13,7 @@ class SavedScenariosController < ApplicationController
     authorize!(:update, @saved_scenario)
   end
 
-  before_action only: %i[discard undiscard] do
+  before_action only: %i[discard undiscard restore] do
     authorize!(:destroy, @saved_scenario)
   end
 
@@ -222,6 +222,23 @@ class SavedScenariosController < ApplicationController
     redirect_to saved_scenario_path(@saved_scenario)
   end
 
+  # Restores a saved scenario to a previous version
+  def restore
+    result = RestoreSavedScenario.call(
+      engine_client,
+      @saved_scenario,
+      restore_params[:scenario_id].to_i
+    )
+
+    # TODO: check success -> flash?
+    # if result.successful?
+
+    # Or do we refresh?
+    respond_to do |format|
+      format.js
+    end
+  end
+
   # DELETE /saved_scenarios/:id
   def destroy
     @saved_scenario.destroy
@@ -258,6 +275,10 @@ class SavedScenariosController < ApplicationController
 
   def saved_scenario_params
     params.require(:saved_scenario).permit(:title, :description)
+  end
+
+  def restore_params
+    params.require(:saved_scenario).permit(:scenario_id)
   end
 
   def reload_current_title(saved_scenario)

--- a/app/models/saved_scenario.rb
+++ b/app/models/saved_scenario.rb
@@ -162,6 +162,11 @@ class SavedScenario < ApplicationRecord
     save
   end
 
+  # Returns an array containing the current and historical scenario ids
+  def version_scenario_ids
+    [scenario_id] + scenario_id_history.reverse
+  end
+
   def as_json(options = {})
     options[:except] ||= %i[discarded_at]
 

--- a/app/models/saved_scenario.rb
+++ b/app/models/saved_scenario.rb
@@ -114,8 +114,22 @@ class SavedScenario < ApplicationRecord
   def add_id_to_history(scenario_id)
     return if !scenario_id || scenario_id_history.include?(scenario_id)
 
-    scenario_id_history.shift if scenario_id_history.count >= 20
+    scenario_id_history.shift if scenario_id_history.count >= 100
     scenario_id_history << scenario_id
+  end
+
+  # Restores the scenario id to the given version
+  # Returns the discarded scenarios from the history
+  def restore_version(scenario_id)
+    return unless scenario_id && scenario_id_history.include?(scenario_id)
+
+    discard_no = scenario_id_history.index(scenario_id)
+    discarded = scenario_id_history[discard_no + 1...]
+
+    self.scenario_id = scenario_id
+    self.scenario_id_history = scenario_id_history[...discard_no]
+
+    discarded
   end
 
   def scenario=(x)

--- a/app/models/saved_scenario_history_presenter.rb
+++ b/app/models/saved_scenario_history_presenter.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Given a saved scenarios version tags, parses the version tags of the underlying
+# scenarios and presents it as a json to be picked up by the front end
+class SavedScenarioHistoryPresenter
+  def self.present(saved_scenario, history)
+    new(saved_scenario, history).as_json
+  end
+
+  def initialize(saved_scenario, history)
+    # TODO: keys should be ints not strings!
+    @history = history
+    @scenario_ids_ordered = saved_scenario.version_scenario_ids
+  end
+
+  # Sorts the version tags in the history based on the ordering within the saved scenarios history
+  # With the current scenario being the first, and the oldest scenario last
+  def as_json(*)
+    @scenario_ids_ordered.map{ |id| present(id) }
+  end
+
+  private
+
+   # TODO: remove the to_s on the id
+  def present(scenario_id)
+    version = @history[scenario_id.to_s]
+
+    version['user'] =
+      if version.key?('user_id')
+        User.find(version.delete('user_id').to_i).name
+      else
+        I18n.t('scenario.users.unknown')
+      end
+
+    version['scenario_id'] = scenario_id
+
+    version
+  end
+end

--- a/app/models/saved_scenario_history_presenter.rb
+++ b/app/models/saved_scenario_history_presenter.rb
@@ -8,7 +8,6 @@ class SavedScenarioHistoryPresenter
   end
 
   def initialize(saved_scenario, history)
-    # TODO: keys should be ints not strings!
     @history = history
     @scenario_ids_ordered = saved_scenario.version_scenario_ids
   end
@@ -21,16 +20,15 @@ class SavedScenarioHistoryPresenter
 
   private
 
-   # TODO: remove the to_s on the id
   def present(scenario_id)
     version = @history[scenario_id.to_s]
 
-    version['user'] =
-      if version.key?('user_id')
-        User.find(version.delete('user_id').to_i).name
-      else
-        I18n.t('scenario.users.unknown')
-      end
+    if version.key?('user_id')
+      version['user'] = User.find(version.delete('user_id').to_i).name
+    else
+      version['frozen'] = true
+      version['user'] = I18n.t('scenario.users.unknown')
+    end
 
     version['scenario_id'] = scenario_id
 

--- a/app/models/saved_scenario_history_presenter.rb
+++ b/app/models/saved_scenario_history_presenter.rb
@@ -15,7 +15,7 @@ class SavedScenarioHistoryPresenter
   # Sorts the version tags in the history based on the ordering within the saved scenarios history
   # With the current scenario being the first, and the oldest scenario last
   def as_json(*)
-    @scenario_ids_ordered.map{ |id| present(id) }
+    @scenario_ids_ordered.map { |id| present(id) }
   end
 
   private

--- a/app/models/saved_scenario_history_presenter.rb
+++ b/app/models/saved_scenario_history_presenter.rb
@@ -15,13 +15,15 @@ class SavedScenarioHistoryPresenter
   # Sorts the version tags in the history based on the ordering within the saved scenarios history
   # With the current scenario being the first, and the oldest scenario last
   def as_json(*)
-    @scenario_ids_ordered.map { |id| present(id) }
+    @scenario_ids_ordered.filter_map { |id| present(id) }
   end
 
   private
 
   def present(scenario_id)
     version = @history[scenario_id.to_s]
+
+    return unless version
 
     if version.key?('user_id')
       version['user'] = User.find(version.delete('user_id').to_i).name

--- a/app/services/create_api_scenario_version_tag.rb
+++ b/app/services/create_api_scenario_version_tag.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Creates a ScenarioVersionTag for an ApiScenario and the current user
+class CreateAPIScenarioVersionTag
+  include Service
+
+  def initialize(http_client, scenario_id, description)
+    @http_client = http_client
+    @scenario_id = scenario_id
+    @description = description
+  end
+
+  def call
+    @http_client.post(
+      "/api/v3/scenarios/#{@scenario_id}/version", description: @description
+    )
+
+    ServiceResult.success
+  rescue Faraday::ResourceNotFound
+    ServiceResult.failure('Scenario tag not found')
+  rescue Faraday::UnprocessableEntityError => e
+    ServiceResult.failure_from_unprocessable_entity(e)
+  rescue Faraday::Error => e
+    Sentry.capture_exception(e)
+    ServiceResult.failure("Failed to update scenario version: #{e.message}")
+  end
+end

--- a/app/services/create_saved_scenario.rb
+++ b/app/services/create_saved_scenario.rb
@@ -41,6 +41,7 @@ CreateSavedScenario = lambda do |http_client, scenario_id, user, settings = {}|
   end
 
   SetAPIScenarioCompatibility.keep_compatible(http_client, api_scenario.id)
+  CreateAPIScenarioVersionTag.call(http_client, api_scenario.id, 'initial version')
 
   saved_scenario.save
   saved_scenario.scenario = api_scenario

--- a/app/services/create_saved_scenario.rb
+++ b/app/services/create_saved_scenario.rb
@@ -41,7 +41,7 @@ CreateSavedScenario = lambda do |http_client, scenario_id, user, settings = {}|
   end
 
   SetAPIScenarioCompatibility.keep_compatible(http_client, api_scenario.id)
-  CreateAPIScenarioVersionTag.call(http_client, api_scenario.id, 'initial version')
+  CreateAPIScenarioVersionTag.call(http_client, api_scenario.id, '')
 
   saved_scenario.save
   saved_scenario.scenario = api_scenario

--- a/app/services/fetch_saved_scenario_version_tags.rb
+++ b/app/services/fetch_saved_scenario_version_tags.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class FetchSavedScenarioVersionTags
+  include Service
+
+  def initialize(http_client, saved_scenario)
+    @http_client = http_client
+    @scenario_ids = saved_scenario.version_scenario_ids
+  end
+
+  def call
+    ServiceResult.success(
+      @http_client.get(
+        '/api/v3/scenarios/versions',
+        { scenarios: @scenario_ids }
+      ).body
+    )
+  rescue Faraday::ResourceNotFound
+    ServiceResult.failure('Scenario not found')
+  rescue Faraday::Error => e
+    Sentry.capture_exception(e)
+    ServiceResult.failure('Failed to fetch scenario versions')
+  end
+end

--- a/app/services/restore_saved_scenario.rb
+++ b/app/services/restore_saved_scenario.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Restores a saved scenario to an older version. Unprotects all discarded scenarios
+class RestoreSavedScenario
+  include Service
+
+  def initialize(http_client, saved_scenario, scenario_id)
+    @http_client = http_client
+    @saved_scenario = saved_scenario
+    @scenario_id = scenario_id
+  end
+
+  def call
+    return ServiceResult.success(@saved_scenario) if @saved_scenario.scenario_id == @scenario_id
+
+    unless discarded_versions
+      return ServiceResult.failure("Version #{@scenario_id} could not be restored")
+    end
+
+    @saved_scenario.save!
+
+    unprotect_discarded
+
+    ServiceResult.success(@saved_scenario)
+  end
+
+  private
+
+  def discarded_versions
+    @discarded_versions ||= @saved_scenario.restore_version(@scenario_id)
+  end
+
+  def unprotect_discarded
+    discarded_versions.each do |version_id|
+      SetAPIScenarioCompatibility.dont_keep_compatible(@http_client, version_id)
+    end
+  end
+end

--- a/app/services/update_api_scenario_version_tag.rb
+++ b/app/services/update_api_scenario_version_tag.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Updates the role of a ScenarioVersionTag for an ApiScenario
+class UpdateAPIScenarioVersionTag
+  include Service
+
+  def initialize(http_client, scenario_id, description)
+    @http_client = http_client
+    @scenario_id = scenario_id
+    @description = description
+  end
+
+  def call
+    ServiceResult.success(
+      @http_client.put(
+        "/api/v3/scenarios/#{@scenario_id}/version", description: @description
+      ).body
+    )
+  rescue Faraday::ResourceNotFound
+    ServiceResult.failure('Scenario tag not found')
+  rescue Faraday::UnprocessableEntityError => e
+    ServiceResult.failure_from_unprocessable_entity(e)
+  rescue Faraday::Error => e
+    Sentry.capture_exception(e)
+    ServiceResult.failure("Failed to update scenario version: #{e.message}")
+  end
+end

--- a/app/services/update_saved_scenario.rb
+++ b/app/services/update_saved_scenario.rb
@@ -34,6 +34,8 @@ class UpdateSavedScenario
 
       set_roles
 
+      tag_new_version
+
       ss.save
       saved_scenario.scenario_id = scenario_id
     end
@@ -57,6 +59,10 @@ class UpdateSavedScenario
 
   def set_roles
     SetAPIScenarioRoles.to_preset(http_client, scenario_id)
+  end
+
+  def tag_new_version
+    CreateAPIScenarioVersionTag.call(http_client, scenario_id, 'another version')
   end
 
   def failure

--- a/app/services/update_saved_scenario.rb
+++ b/app/services/update_saved_scenario.rb
@@ -62,7 +62,7 @@ class UpdateSavedScenario
   end
 
   def tag_new_version
-    CreateAPIScenarioVersionTag.call(http_client, scenario_id, 'another version')
+    CreateAPIScenarioVersionTag.call(http_client, scenario_id, '')
   end
 
   def failure

--- a/app/views/layouts/etm/_scenario_nav.html.haml
+++ b/app/views/layouts/etm/_scenario_nav.html.haml
@@ -6,8 +6,9 @@
       %span.year
         = Current.setting.end_year
       - if Current.setting.active_scenario_title.present?
-        %span.name
-          = Current.setting.active_scenario_title
+        = link_to(saved_scenario_path(active_saved_scenario_id)) do
+          %span.name
+            = Current.setting.active_scenario_title
     - else
       %span.region.region-flag== #{t('scenario_nav.loading')}&hellip;
       %span.year

--- a/app/views/layouts/saved_scenario.html.haml
+++ b/app/views/layouts/saved_scenario.html.haml
@@ -1,0 +1,22 @@
+- content_for(:page_title) { "#{@saved_scenario.title} - #{t('meta.name')}" }
+
+-# We'll render the flash in this view, so suppress doing so in the layout.
+- content_for(:flash) do
+  %span
+
+- content_for :content do
+  .background_wrapper#saved_scenario
+    .scenario_wrapper{ id: defined?(action_id) ? action_id : 'show_scenario'}
+      - if editable_saved_scenario?(@saved_scenario)
+        = render partial: 'saved_scenarios/scenario_list_tabs', locals: { active_tab: @saved_scenario.discarded? ? :trash : :my_scenarios, show_save_current: false }
+      .internal-box
+        .scenario
+          = render partial: 'saved_scenarios/scenario', locals: { saved_scenario: @saved_scenario }
+
+        #edit_scenario
+        - unless @saved_scenario.featured?
+          = render partial: 'scenarios/version_warning', locals: { scenario: @saved_scenario }
+
+        = yield
+
+= render template: 'layouts/application'

--- a/app/views/multi_year_charts/list.html.haml
+++ b/app/views/multi_year_charts/list.html.haml
@@ -7,15 +7,16 @@
 .background_wrapper#saved_scenario
   .scenario_wrapper#index
     = render partial: 'saved_scenarios/scenario_list_tabs', locals: { active_tab: :my_myc }
-    = render partial: 'saved_scenarios/flash_notice'
+    .internal-box
+      = render partial: 'saved_scenarios/flash_notice'
 
-    - if @multi_year_charts.any?
-      = render partial: 'multi_year_chart_row', collection: @multi_year_charts
-      = paginate @multi_year_charts
-    - else
-      .empty-state
-        %h4= t('multi_year_charts.title')
-        %p= t('multi_year_charts.description')
-        %p{ style: "font-weight: 500" }
-          = link_to scenarios_path do
-            == ← #{t('multi_year_charts.back')}
+      - if @multi_year_charts.any?
+        = render partial: 'multi_year_chart_row', collection: @multi_year_charts
+        = paginate @multi_year_charts
+      - else
+        .empty-state
+          %h4= t('multi_year_charts.title')
+          %p= t('multi_year_charts.description')
+          %p{ style: "font-weight: 500" }
+            = link_to scenarios_path do
+              == ← #{t('multi_year_charts.back')}

--- a/app/views/saved_scenario_history/_version_history.html.haml
+++ b/app/views/saved_scenario_history/_version_history.html.haml
@@ -10,7 +10,7 @@
   .history
     - @history.each_with_index do |version, index|
       .row.box{ id: "scenario-version-#{version['scenario_id']}", style: "animation-delay: #{index/3.0}s"}
-        .main-info
+        = link_to load_scenario_path(version['scenario_id']), class: 'main-info' do
           .fa.fa-circle
           %span= version['user']
           = t('last_ago', when: time_ago_in_words(version['last_updated_at']))
@@ -37,12 +37,11 @@
                 - unless version['frozen']
                   %li.edit-description.fa.fa-pencil.tooltip{ title: t("scenario.edit_description") }
                 - unless version['scenario_id'].to_i == @saved_scenario.scenario_id
-                  %li
-                    = link_to load_scenario_path(version['scenario_id']) do
-                      .fa.fa-window-restore.tooltip{ title: t("scenario.open") }
+                  -# %li
+                  -#   = link_to load_scenario_path(version['scenario_id']) do
+                  -#     .fa.fa-window-restore.tooltip{ title: t("scenario.open") }
                   - if current_user&.admin? || @saved_scenario.owner?(current_user)
-                    %li.restore-version.fa.fa-backward.tooltip{ title: t("scenario.restore"), data: {url: confirm_restore_saved_scenario_path(@saved_scenario, saved_scenario: { scenario_id: version['scenario_id']})} }
-                    -# = link_to restore_saved_scenario_path(@saved_scenario, saved_scenario: { scenario_id: version['scenario_id']}), method: :put, remote: true do
+                    %li.restore-version.fa.fa-history.tooltip{ title: t("scenario.restore"), data: {url: confirm_restore_saved_scenario_path(@saved_scenario, saved_scenario: { scenario_id: version['scenario_id']})} }
 
             - unless version['frozen']
               %li.control.stick-right

--- a/app/views/saved_scenario_history/_version_history.html.haml
+++ b/app/views/saved_scenario_history/_version_history.html.haml
@@ -1,5 +1,5 @@
-- @history.each do |version|
-  .row.box{ id: "scenario-version-#{version['scenario_id']}" }
+- @history.each_with_index do |version, index|
+  .row.box{ id: "scenario-version-#{version['scenario_id']}", style: "animation-delay: #{index/2.0}s"}
     - if (@saved_scenario.collaborator?(current_user) || current_user&.admin?)
       %ul.details
         %li.scenario-version.stick-right

--- a/app/views/saved_scenario_history/_version_history.html.haml
+++ b/app/views/saved_scenario_history/_version_history.html.haml
@@ -11,7 +11,10 @@
     - @history.each_with_index do |version, index|
       .row.box{ id: "scenario-version-#{version['scenario_id']}", style: "animation-delay: #{index/3.0}s"}
         = link_to load_scenario_path(version['scenario_id']), class: 'main-info', title: t("scenario.open") do
-          .fa.fa-circle
+          - if index.zero?
+            .fa.fa-circle
+          - else
+            .fa.fa-circle-o
           %span= version['user']
           = t('last_ago', when: time_ago_in_words(version['last_updated_at']))
         - unless version['frozen']

--- a/app/views/saved_scenario_history/_version_history.html.haml
+++ b/app/views/saved_scenario_history/_version_history.html.haml
@@ -14,7 +14,7 @@
               %li.restore-version.fa.fa-backward.tooltip{ title: "Restore this version" }
     .main-info
       .fa.fa-circle
-      = t('last_updated_ago', when: time_ago_in_words(version['last_updated_at']))
+      = t('last_ago', when: time_ago_in_words(version['last_updated_at']))
       %span= version['user']
     - unless version['frozen']
       .description

--- a/app/views/saved_scenario_history/_version_history.html.haml
+++ b/app/views/saved_scenario_history/_version_history.html.haml
@@ -41,9 +41,9 @@
                     = link_to load_scenario_path(version['scenario_id']) do
                       .fa.fa-window-restore.tooltip{ title: t("scenario.open") }
                   - if current_user&.admin? || @saved_scenario.owner?(current_user)
-                    %li
-                      = link_to restore_saved_scenario_path(@saved_scenario, saved_scenario: { scenario_id: version['scenario_id']}), method: :put, remote: true do
-                        .restore-version.fa.fa-backward.tooltip{ title: t("scenario.restore") }
+                    %li.restore-version.fa.fa-backward.tooltip{ title: t("scenario.restore"), data: {url: confirm_restore_saved_scenario_path(@saved_scenario, saved_scenario: { scenario_id: version['scenario_id']})} }
+                    -# = link_to restore_saved_scenario_path(@saved_scenario, saved_scenario: { scenario_id: version['scenario_id']}), method: :put, remote: true do
+
             - unless version['frozen']
               %li.control.stick-right
                 %ul

--- a/app/views/saved_scenario_history/_version_history.html.haml
+++ b/app/views/saved_scenario_history/_version_history.html.haml
@@ -10,7 +10,7 @@
   .history
     - @history.each_with_index do |version, index|
       .row.box{ id: "scenario-version-#{version['scenario_id']}", style: "animation-delay: #{index/3.0}s"}
-        = link_to load_scenario_path(version['scenario_id']), class: 'main-info' do
+        = link_to load_scenario_path(version['scenario_id']), class: 'main-info', title: t("scenario.open") do
           .fa.fa-circle
           %span= version['user']
           = t('last_ago', when: time_ago_in_words(version['last_updated_at']))
@@ -46,6 +46,6 @@
             - unless version['frozen']
               %li.control.stick-right
                 %ul
-                  %li.submit-description.green.fa.fa-check.tooltip{ title: t("save") }
+                  %li.submit-description.green.fa.fa-check.tooltip{ title: t("scenario.save_text") }
                   %li.cancel-description.red.fa.fa-times.tooltip{ title: t("scenario.cancel") }
 

--- a/app/views/saved_scenario_history/_version_history.html.haml
+++ b/app/views/saved_scenario_history/_version_history.html.haml
@@ -2,41 +2,46 @@
   .empty-state
     %h4= t('scenario.history.empty')
 - else
-  - @history.each_with_index do |version, index|
-    .row.box{ id: "scenario-version-#{version['scenario_id']}", style: "animation-delay: #{index/2.0}s"}
-      - if (@saved_scenario.collaborator?(current_user) || current_user&.admin?)
-        %ul.details
-          %li.scenario-version.stick-right
-            %ul
-              - unless version['frozen']
-                %li.edit-description.fa.fa-pencil.tooltip{ title: t("scenario.edit_text") }
-              - unless version['scenario_id'].to_i == @saved_scenario.scenario_id
-                %li
-                  = link_to load_scenario_path(version['scenario_id']) do
-                    .fa.fa-window-restore.tooltip{ title: t("scenario.open") }
-                - if current_user&.admin? || @saved_scenario.owner?(current_user)
+  .back-to-scenario-view
+    = link_to saved_scenario_path(@saved_scenario), remote: true, class: 'stick-right' do
+      .fa.fa-times
+  %h4= t('scenario.history.title')
+  .history
+    - @history.each_with_index do |version, index|
+      .row.box{ id: "scenario-version-#{version['scenario_id']}", style: "animation-delay: #{index/2.0}s"}
+        - if (@saved_scenario.collaborator?(current_user) || current_user&.admin?)
+          %ul.details
+            %li.scenario-version.stick-right
+              %ul
+                - unless version['frozen']
+                  %li.edit-description.fa.fa-pencil.tooltip{ title: t("scenario.edit_text") }
+                - unless version['scenario_id'].to_i == @saved_scenario.scenario_id
                   %li
-                    = link_to restore_saved_scenario_path(@saved_scenario, saved_scenario: { scenario_id: version['scenario_id']}), method: :put, remote: true do
-                      .restore-version.fa.fa-backward.tooltip{ title: t("scenario.restore") }
-      .main-info
-        .fa.fa-circle
-        = t('last_ago', when: time_ago_in_words(version['last_updated_at']))
-        %span= version['user']
-      - unless version['frozen']
-        .description
-          - if version['description']
-            = version['description']
-          - else
-            %span= t('scenario.no_description')
-        .description-field{style: 'display: none'}
-          %textarea
-            = version['description']
-          %button.submit-description Update
-          %button.cancel-description Cancel
-        :javascript
-          new ScenarioHistoryView({
-            el: $("#scenario-version-#{version['scenario_id']}"),
-            id: "#{version['scenario_id']}",
-            url: "#{saved_scenario_history_path(@saved_scenario)}"
-          }).render();
+                    = link_to load_scenario_path(version['scenario_id']) do
+                      .fa.fa-window-restore.tooltip{ title: t("scenario.open") }
+                  - if current_user&.admin? || @saved_scenario.owner?(current_user)
+                    %li
+                      = link_to restore_saved_scenario_path(@saved_scenario, saved_scenario: { scenario_id: version['scenario_id']}), method: :put, remote: true do
+                        .restore-version.fa.fa-backward.tooltip{ title: t("scenario.restore") }
+        .main-info
+          .fa.fa-circle
+          = t('last_ago', when: time_ago_in_words(version['last_updated_at']))
+          %span= version['user']
+        - unless version['frozen']
+          .description
+            - if version['description']
+              = version['description']
+            - else
+              %span= t('scenario.no_description')
+          .description-field{style: 'display: none'}
+            %textarea
+              = version['description']
+            %button.submit-description Update
+            %button.cancel-description Cancel
+          :javascript
+            new ScenarioHistoryView({
+              el: $("#scenario-version-#{version['scenario_id']}"),
+              id: "#{version['scenario_id']}",
+              url: "#{saved_scenario_history_path(@saved_scenario)}"
+            }).render();
 

--- a/app/views/saved_scenario_history/_version_history.html.haml
+++ b/app/views/saved_scenario_history/_version_history.html.haml
@@ -1,38 +1,42 @@
-- @history.each_with_index do |version, index|
-  .row.box{ id: "scenario-version-#{version['scenario_id']}", style: "animation-delay: #{index/2.0}s"}
-    - if (@saved_scenario.collaborator?(current_user) || current_user&.admin?)
-      %ul.details
-        %li.scenario-version.stick-right
-          %ul
-            - unless version['frozen']
-              %li.edit-description.fa.fa-pencil.tooltip{ title: t("scenario.edit_text") }
-            - unless version['scenario_id'].to_i == @saved_scenario.scenario_id
-              %li
-                = link_to load_scenario_path(version['scenario_id']) do
-                  .fa.fa-window-restore.tooltip{ title: t("scenario.open") }
-              - if current_user&.admin? || @saved_scenario.owner?(current_user)
+- if @history.empty?
+  .empty-state
+    %h4= t('scenario.history.empty')
+- else
+  - @history.each_with_index do |version, index|
+    .row.box{ id: "scenario-version-#{version['scenario_id']}", style: "animation-delay: #{index/2.0}s"}
+      - if (@saved_scenario.collaborator?(current_user) || current_user&.admin?)
+        %ul.details
+          %li.scenario-version.stick-right
+            %ul
+              - unless version['frozen']
+                %li.edit-description.fa.fa-pencil.tooltip{ title: t("scenario.edit_text") }
+              - unless version['scenario_id'].to_i == @saved_scenario.scenario_id
                 %li
-                  = link_to restore_saved_scenario_path(@saved_scenario, saved_scenario: { scenario_id: version['scenario_id']}), method: :put, remote: true do
-                    .restore-version.fa.fa-backward.tooltip{ title: t("scenario.restore") }
-    .main-info
-      .fa.fa-circle
-      = t('last_ago', when: time_ago_in_words(version['last_updated_at']))
-      %span= version['user']
-    - unless version['frozen']
-      .description
-        - if version['description']
-          = version['description']
-        - else
-          %span= t('scenario.no_description')
-      .description-field{style: 'display: none'}
-        %textarea
-          = version['description']
-        %button.submit-description Update
-        %button.cancel-description Cancel
-      :javascript
-        new ScenarioHistoryView({
-          el: $("#scenario-version-#{version['scenario_id']}"),
-          id: "#{version['scenario_id']}",
-          url: "#{saved_scenario_history_path(@saved_scenario)}"
-        }).render();
+                  = link_to load_scenario_path(version['scenario_id']) do
+                    .fa.fa-window-restore.tooltip{ title: t("scenario.open") }
+                - if current_user&.admin? || @saved_scenario.owner?(current_user)
+                  %li
+                    = link_to restore_saved_scenario_path(@saved_scenario, saved_scenario: { scenario_id: version['scenario_id']}), method: :put, remote: true do
+                      .restore-version.fa.fa-backward.tooltip{ title: t("scenario.restore") }
+      .main-info
+        .fa.fa-circle
+        = t('last_ago', when: time_ago_in_words(version['last_updated_at']))
+        %span= version['user']
+      - unless version['frozen']
+        .description
+          - if version['description']
+            = version['description']
+          - else
+            %span= t('scenario.no_description')
+        .description-field{style: 'display: none'}
+          %textarea
+            = version['description']
+          %button.submit-description Update
+          %button.cancel-description Cancel
+        :javascript
+          new ScenarioHistoryView({
+            el: $("#scenario-version-#{version['scenario_id']}"),
+            id: "#{version['scenario_id']}",
+            url: "#{saved_scenario_history_path(@saved_scenario)}"
+          }).render();
 

--- a/app/views/saved_scenario_history/_version_history.html.haml
+++ b/app/views/saved_scenario_history/_version_history.html.haml
@@ -1,27 +1,33 @@
 - @history.each do |version|
-  .row.box
-    %ul.details
-      %li.scenario-version.stick-right
-        .dropdown{ id: "scenario-version-#{version['scenario_id']}" }<>
-          %button.scenario-actions{ id: "scenario-version-button-#{version['scenario_id']}", aria: { expanded: 'false' }, data: { toggle: 'dropdown' }, type: 'button' }
-            %span.fa.fa-ellipsis-h
-          %ul.dropdown-menu.dropdown-menu-right{ 'aria-labelledby': "scenario-version-button-#{version['scenario_id']}", style: 'margin-top: 3px' }
-            - if @saved_scenario.collaborator?(current_user)
-              %li
-                = link_to edit_saved_scenario_path(version['scenario_id']), remote: true, class: 'dropdown-item' do
-                  .fa.fa-pencil
-                  = t("scenario.edit_text")
+  .row.box{ id: "scenario-version-#{version['scenario_id']}" }
+    - if !version['frozen'] && (@saved_scenario.collaborator?(current_user) || current_user&.admin?)
+      -# if frozen nog steeds rewuind for collab, en open for everyone
+      %ul.details
+        %li.scenario-version.stick-right
+          %ul
+            %li
+              -# top scenario cannot be opened or restored!
+              = link_to load_scenario_path(version['scenario_id']) do
+                .fa.fa-window-restore.tooltip{ title: t("scenario.open") }
+            %li.edit-description.fa.fa-pencil.tooltip{ title: t("scenario.edit_text") }
             - if current_user&.admin? || @saved_scenario.owner?(current_user)
-              %li
-                = link_to saved_scenario_users_path(version['scenario_id']), class: 'dropdown-item' do
-                  .fa.fa-arrow-left
-                  Restore this version
-
-        :javascript
-          new DropdownView({ el: $("#scenario-version-#{version['scenario_id']}") }).render()
+              %li.restore-version.fa.fa-backward.tooltip{ title: "Restore this version" }
     .main-info
+      .fa.fa-circle
       = t('last_updated_ago', when: time_ago_in_words(version['last_updated_at']))
       %span= version['user']
-    - if version['description']
+    - unless version['frozen']
       .description
         = version['description']
+      .description-field{style: 'display: none'}
+        %textarea
+          = version['description']
+        %button.submit-description Update
+        %button.cancel-description Cancel
+      :javascript
+        new ScenarioHistoryView({
+          el: $("#scenario-version-#{version['scenario_id']}"),
+          id: "#{version['scenario_id']}",
+          url: "#{saved_scenario_history_path(@saved_scenario)}"
+        }).render();
+

--- a/app/views/saved_scenario_history/_version_history.html.haml
+++ b/app/views/saved_scenario_history/_version_history.html.haml
@@ -4,17 +4,17 @@
 - else
   .back-to-scenario-view
     = link_to saved_scenario_path(@saved_scenario), remote: true, class: 'stick-right' do
-      .fa.fa-times
-  %h4= t('scenario.history.title')
+      .fa.fa-times.tooltip{ title: t("scenario.close_version_history") }
+  %h3= t('scenario.history.title')
   .history
     - @history.each_with_index do |version, index|
-      .row.box{ id: "scenario-version-#{version['scenario_id']}", style: "animation-delay: #{index/2.0}s"}
+      .row.box{ id: "scenario-version-#{version['scenario_id']}", style: "animation-delay: #{index/3.0}s"}
         - if (@saved_scenario.collaborator?(current_user) || current_user&.admin?)
           %ul.details
             %li.scenario-version.stick-right
               %ul
                 - unless version['frozen']
-                  %li.edit-description.fa.fa-pencil.tooltip{ title: t("scenario.edit_text") }
+                  %li.edit-description.fa.fa-pencil.tooltip{ title: t("scenario.edit_description") }
                 - unless version['scenario_id'].to_i == @saved_scenario.scenario_id
                   %li
                     = link_to load_scenario_path(version['scenario_id']) do
@@ -25,7 +25,7 @@
                         .restore-version.fa.fa-backward.tooltip{ title: t("scenario.restore") }
         .main-info
           .fa.fa-circle
-          = t('last_ago', when: time_ago_in_words(version['last_updated_at']))
+          = t('last_updated_ago', when: time_ago_in_words(version['last_updated_at']))
           %span= version['user']
         - unless version['frozen']
           .description

--- a/app/views/saved_scenario_history/_version_history.html.haml
+++ b/app/views/saved_scenario_history/_version_history.html.haml
@@ -6,6 +6,7 @@
     = link_to saved_scenario_path(@saved_scenario), remote: true, class: 'stick-right' do
       .fa.fa-times.tooltip{ title: t("scenario.close_version_history") }
   %h3= t('scenario.history.title')
+  %p.history-description= t('scenario.history.description')
   .history
     - @history.each_with_index do |version, index|
       .row.box{ id: "scenario-version-#{version['scenario_id']}", style: "animation-delay: #{index/3.0}s"}
@@ -21,11 +22,8 @@
               - else
                 %em= t('scenario.no_description')
             .description-field{style: 'display: none'}
-              %textarea
+              %textarea{placeholder: t('scenario.add_description')}
                 = version['description']
-              %button.submit-description Update
-              -# move cancel to the righthand options
-              %button.cancel-description Cancel
             :javascript
               new ScenarioHistoryView({
                 el: $("#scenario-version-#{version['scenario_id']}"),
@@ -46,4 +44,9 @@
                     %li
                       = link_to restore_saved_scenario_path(@saved_scenario, saved_scenario: { scenario_id: version['scenario_id']}), method: :put, remote: true do
                         .restore-version.fa.fa-backward.tooltip{ title: t("scenario.restore") }
+            - unless version['frozen']
+              %li.control.stick-right
+                %ul
+                  %li.submit-description.green.fa.fa-check.tooltip{ title: t("save") }
+                  %li.cancel-description.red.fa.fa-times.tooltip{ title: t("scenario.cancel") }
 

--- a/app/views/saved_scenario_history/_version_history.html.haml
+++ b/app/views/saved_scenario_history/_version_history.html.haml
@@ -13,7 +13,7 @@
               - if current_user&.admin? || @saved_scenario.owner?(current_user)
                 %li
                   = link_to restore_saved_scenario_path(@saved_scenario, saved_scenario: { scenario_id: version['scenario_id']}), method: :put, remote: true do
-                    .restore-version.fa.fa-backward.tooltip{ title: "Restore this version" }
+                    .restore-version.fa.fa-backward.tooltip{ title: t("scenario.restore") }
     .main-info
       .fa.fa-circle
       = t('last_ago', when: time_ago_in_words(version['last_updated_at']))

--- a/app/views/saved_scenario_history/_version_history.html.haml
+++ b/app/views/saved_scenario_history/_version_history.html.haml
@@ -9,6 +9,29 @@
   .history
     - @history.each_with_index do |version, index|
       .row.box{ id: "scenario-version-#{version['scenario_id']}", style: "animation-delay: #{index/3.0}s"}
+        .main-info
+          .fa.fa-circle
+          %span= version['user']
+          = t('last_ago', when: time_ago_in_words(version['last_updated_at']))
+        - unless version['frozen']
+          .desc-box
+            .description
+              - if version['description'].present?
+                = version['description']
+              - else
+                %em= t('scenario.no_description')
+            .description-field{style: 'display: none'}
+              %textarea
+                = version['description']
+              %button.submit-description Update
+              -# move cancel to the righthand options
+              %button.cancel-description Cancel
+            :javascript
+              new ScenarioHistoryView({
+                el: $("#scenario-version-#{version['scenario_id']}"),
+                id: "#{version['scenario_id']}",
+                url: "#{saved_scenario_history_path(@saved_scenario)}"
+              }).render();
         - if (@saved_scenario.collaborator?(current_user) || current_user&.admin?)
           %ul.details
             %li.scenario-version.stick-right
@@ -23,25 +46,4 @@
                     %li
                       = link_to restore_saved_scenario_path(@saved_scenario, saved_scenario: { scenario_id: version['scenario_id']}), method: :put, remote: true do
                         .restore-version.fa.fa-backward.tooltip{ title: t("scenario.restore") }
-        .main-info
-          .fa.fa-circle
-          = t('last_updated_ago', when: time_ago_in_words(version['last_updated_at']))
-          %span= version['user']
-        - unless version['frozen']
-          .description
-            - if version['description']
-              = version['description']
-            - else
-              %span= t('scenario.no_description')
-          .description-field{style: 'display: none'}
-            %textarea
-              = version['description']
-            %button.submit-description Update
-            %button.cancel-description Cancel
-          :javascript
-            new ScenarioHistoryView({
-              el: $("#scenario-version-#{version['scenario_id']}"),
-              id: "#{version['scenario_id']}",
-              url: "#{saved_scenario_history_path(@saved_scenario)}"
-            }).render();
 

--- a/app/views/saved_scenario_history/_version_history.html.haml
+++ b/app/views/saved_scenario_history/_version_history.html.haml
@@ -1,0 +1,27 @@
+- @history.each do |version|
+  .row.box
+    %ul.details
+      %li.scenario-version.stick-right
+        .dropdown{ id: "scenario-version-#{version['scenario_id']}" }<>
+          %button.scenario-actions{ id: "scenario-version-button-#{version['scenario_id']}", aria: { expanded: 'false' }, data: { toggle: 'dropdown' }, type: 'button' }
+            %span.fa.fa-ellipsis-h
+          %ul.dropdown-menu.dropdown-menu-right{ 'aria-labelledby': "scenario-version-button-#{version['scenario_id']}", style: 'margin-top: 3px' }
+            - if @saved_scenario.collaborator?(current_user)
+              %li
+                = link_to edit_saved_scenario_path(version['scenario_id']), remote: true, class: 'dropdown-item' do
+                  .fa.fa-pencil
+                  = t("scenario.edit_text")
+            - if current_user&.admin? || @saved_scenario.owner?(current_user)
+              %li
+                = link_to saved_scenario_users_path(version['scenario_id']), class: 'dropdown-item' do
+                  .fa.fa-arrow-left
+                  Restore this version
+
+        :javascript
+          new DropdownView({ el: $("#scenario-version-#{version['scenario_id']}") }).render()
+    .main-info
+      = t('last_updated_ago', when: time_ago_in_words(version['last_updated_at']))
+      %span= version['user']
+    - if version['description']
+      .description
+        = version['description']

--- a/app/views/saved_scenario_history/_version_history.html.haml
+++ b/app/views/saved_scenario_history/_version_history.html.haml
@@ -1,24 +1,29 @@
 - @history.each do |version|
   .row.box{ id: "scenario-version-#{version['scenario_id']}" }
-    - if !version['frozen'] && (@saved_scenario.collaborator?(current_user) || current_user&.admin?)
-      -# if frozen nog steeds rewuind for collab, en open for everyone
+    - if (@saved_scenario.collaborator?(current_user) || current_user&.admin?)
       %ul.details
         %li.scenario-version.stick-right
           %ul
-            %li
-              -# top scenario cannot be opened or restored!
-              = link_to load_scenario_path(version['scenario_id']) do
-                .fa.fa-window-restore.tooltip{ title: t("scenario.open") }
-            %li.edit-description.fa.fa-pencil.tooltip{ title: t("scenario.edit_text") }
-            - if current_user&.admin? || @saved_scenario.owner?(current_user)
-              %li.restore-version.fa.fa-backward.tooltip{ title: "Restore this version" }
+            - unless version['frozen']
+              %li.edit-description.fa.fa-pencil.tooltip{ title: t("scenario.edit_text") }
+            - unless version['scenario_id'].to_i == @saved_scenario.scenario_id
+              %li
+                = link_to load_scenario_path(version['scenario_id']) do
+                  .fa.fa-window-restore.tooltip{ title: t("scenario.open") }
+              - if current_user&.admin? || @saved_scenario.owner?(current_user)
+                %li
+                  = link_to restore_saved_scenario_path(@saved_scenario, saved_scenario: { scenario_id: version['scenario_id']}), method: :put, remote: true do
+                    .restore-version.fa.fa-backward.tooltip{ title: "Restore this version" }
     .main-info
       .fa.fa-circle
       = t('last_ago', when: time_ago_in_words(version['last_updated_at']))
       %span= version['user']
     - unless version['frozen']
       .description
-        = version['description']
+        - if version['description']
+          = version['description']
+        - else
+          %span= t('scenario.no_description')
       .description-field{style: 'display: none'}
         %textarea
           = version['description']

--- a/app/views/saved_scenario_history/index.html.haml
+++ b/app/views/saved_scenario_history/index.html.haml
@@ -1,0 +1,4 @@
+#saved-scenario-history
+  =render partial: 'version_history', locals: { history: @history }
+:javascript
+  $('#main-scenario-description').hide();

--- a/app/views/saved_scenario_history/index.js.erb
+++ b/app/views/saved_scenario_history/index.js.erb
@@ -1,0 +1,1 @@
+$('#saved-scenario-history').html("<%= escape_javascript(render partial: 'version_history', locals: { history: @history } ) %>");

--- a/app/views/saved_scenario_history/index.js.erb
+++ b/app/views/saved_scenario_history/index.js.erb
@@ -1,3 +1,5 @@
 $('#saved-scenario-history').show();
 $('#saved-scenario-history').html("<%= escape_javascript(render partial: 'version_history', locals: { history: @history } ) %>");
 $('#main-scenario-description').hide();
+
+history.pushState(null, null, window.location + '/history');

--- a/app/views/saved_scenario_history/index.js.erb
+++ b/app/views/saved_scenario_history/index.js.erb
@@ -1,1 +1,3 @@
+$('#saved-scenario-history').show();
 $('#saved-scenario-history').html("<%= escape_javascript(render partial: 'version_history', locals: { history: @history } ) %>");
+$('#main-scenario-description').hide();

--- a/app/views/saved_scenarios/_info.html.haml
+++ b/app/views/saved_scenarios/_info.html.haml
@@ -81,7 +81,7 @@
             %li
               = link_to saved_scenario_history_path(@saved_scenario), remote: true, class: 'dropdown-item' do
                 .fa.fa-history
-                Show history
+                = t("scenario.show_history")
             - if current_user&.admin?
               %li
                 - if @saved_scenario.featured?

--- a/app/views/saved_scenarios/_info.html.haml
+++ b/app/views/saved_scenarios/_info.html.haml
@@ -1,3 +1,7 @@
+.back-to-scenario-view
+  %a.stick-right{ href: scenarios_path }
+    ⟵
+    = t('scenario.back_to_overview')
 %h1= format_subscripts(scenario.localized_title(I18n.locale))
 
 %ul.details.last
@@ -17,7 +21,7 @@
   %ul.details.stick-right
     - if editable_saved_scenario?(scenario) && action_name == 'show'
       - if scenario.private?
-        %li{ style: 'margin-left: auto; margin-right: 1rem; padding-right: 0' }
+        %li{ style: 'margin-right: 1rem; padding-right: 0' }
           .dropdown#scenario-privacy<>
             %button.scenario-actions#scenario-privacy-button{ aria: { expanded: 'false' }, data: { toggle: 'dropdown' }, type: 'button' }
               = inline_svg_tag 'hero/20/lock.svg', class: 'lock-icon'
@@ -32,7 +36,7 @@
                   = inline_svg_tag 'hero/20/eye.svg'
                   = t('scenario.privacy.private.invert')
       - else
-        %li{ style: 'margin-left: auto; margin-right: 1rem; padding-right: 0' }
+        %li{ style: 'margin-right: 1rem; padding-right: 0' }
           .dropdown#scenario-privacy<>
             %button.scenario-actions#scenario-privacy-button{ aria: { expanded: 'false' }, data: { toggle: 'dropdown' }, type: 'button' }
               = inline_svg_tag 'hero/20/eye.svg', style: 'margin-right: 0.125rem'
@@ -71,6 +75,10 @@
                 = link_to saved_scenario_users_path(@saved_scenario.id), class: 'dropdown-item' do
                   .fa.fa-users
                   = t("scenario.users.manage")
+            %li
+              = link_to saved_scenario_history_path(@saved_scenario), remote: true, class: 'dropdown-item' do
+                .fa.fa-history
+                Show history
             - if current_user&.admin?
               %li
                 - if @saved_scenario.featured?

--- a/app/views/saved_scenarios/_info.html.haml
+++ b/app/views/saved_scenarios/_info.html.haml
@@ -19,7 +19,7 @@
 
 .row
   %ul.details.stick-right
-    - if editable_saved_scenario?(scenario) && action_name == 'show'
+    - if editable_saved_scenario?(scenario) && action_name != 'edit'
       - if scenario.private?
         %li{ style: 'margin-right: 1rem; padding-right: 0' }
           .dropdown#scenario-privacy<>

--- a/app/views/saved_scenarios/_info.html.haml
+++ b/app/views/saved_scenarios/_info.html.haml
@@ -14,7 +14,10 @@
     = local_time(scenario.updated_at, :long)
 
   %li.with-button
-    = link_to t("scenario.load"), load_saved_scenario_path(scenario), class: "scenario-button button load no-margin-right"
+    - if active_saved_scenario_id == scenario.id
+      = link_to t("scenario.continue"), Current.setting.last_etm_page || play_path, class: "scenario-button button save no-margin-right"
+    - else
+      = link_to t("scenario.load"), load_saved_scenario_path(scenario), class: "scenario-button button load no-margin-right"
 
 
 .row

--- a/app/views/saved_scenarios/_info.html.haml
+++ b/app/views/saved_scenarios/_info.html.haml
@@ -54,7 +54,7 @@
       :javascript
         new DropdownView({ el: $('#scenario-privacy') }).render()
 
-      %li{ style: 'padding-right: 0' }
+      %li{ style: 'margin-right: 1rem; padding-right: 0' }
         .dropdown#scenario-location<>
           %button.scenario-actions#scenario-location-button{ aria: { expanded: 'false' }, data: { toggle: 'dropdown' }, type: 'button' }
             = inline_svg_tag 'hero/20/cog.svg'
@@ -112,3 +112,18 @@
 
         :javascript
           new DropdownView({ el: $('#scenario-location') }).render()
+        - unless scenario.private?
+          %li{ style: 'margin-right: 1rem; padding-right: 0' }
+            .dropdown#scenario-copy<>
+              %button.scenario-actions#scenario-copy-button{ aria: { expanded: 'false' }, data: { toggle: 'dropdown' }, type: 'button' }
+                .icon{ class: 'fa fa-copy' }
+                = t('scenario.share.copy')
+                %span.fa.fa-caret-down
+              %ul.dropdown-menu.dropdown-menu-right{ 'aria-labelledby': 'scenario-copy-button', style: 'margin-top: 3px' }
+                %li
+                  .info
+                    = t('scenario.share.copy_description')
+                %li.sep-above
+                  .url= text_field_tag 'url', request.original_url
+          :javascript
+            new DropdownView({ el: $('#scenario-copy') }).render()

--- a/app/views/saved_scenarios/_info.html.haml
+++ b/app/views/saved_scenarios/_info.html.haml
@@ -1,3 +1,18 @@
+%h1= format_subscripts(scenario.localized_title(I18n.locale))
+
+%ul.details.last
+  %li
+    %strong
+      = t "areas.#{scenario.area_code}"
+      = scenario.end_year
+  %li
+    = t('scenario.updated')
+    = local_time(scenario.updated_at, :long)
+
+  %li.with-button
+    = link_to t("scenario.load"), load_saved_scenario_path(scenario), class: "scenario-button button load no-margin-right"
+
+
 .row
   %ul.details.stick-right
     - if editable_saved_scenario?(scenario) && action_name == 'show'
@@ -89,17 +104,3 @@
 
         :javascript
           new DropdownView({ el: $('#scenario-location') }).render()
-
-%h1= format_subscripts(scenario.localized_title(I18n.locale))
-
-%ul.details.last
-  %li
-    %strong
-      = t "areas.#{scenario.area_code}"
-      = scenario.end_year
-  %li
-    = t('scenario.updated')
-    = local_time(scenario.updated_at, :long)
-
-  %li.with-button
-    = link_to t("scenario.load"), load_saved_scenario_path(scenario), class: "scenario-button button load no-margin-right"

--- a/app/views/saved_scenarios/_scenario.html.haml
+++ b/app/views/saved_scenarios/_scenario.html.haml
@@ -1,5 +1,5 @@
 = render partial: 'info', locals: { scenario: saved_scenario }
-
+.bar
 - if saved_scenario.localized_description(I18n.locale).presence
   .description
     = formatted_scenario_description(saved_scenario.localized_description(I18n.locale), allow_external_links: saved_scenario.featured?)

--- a/app/views/saved_scenarios/_scenario.html.haml
+++ b/app/views/saved_scenarios/_scenario.html.haml
@@ -1,6 +1,6 @@
-= render partial: 'flash_notice'
+= render partial: 'saved_scenarios/flash_notice'
 
-= render partial: 'info', locals: { scenario: saved_scenario }
+= render partial: 'saved_scenarios/info', locals: { scenario: saved_scenario }
 .bar
 - if saved_scenario.localized_description(I18n.locale).presence
   .description#main-scenario-description

--- a/app/views/saved_scenarios/_scenario.html.haml
+++ b/app/views/saved_scenarios/_scenario.html.haml
@@ -1,5 +1,7 @@
+= render partial: 'flash_notice'
+
 = render partial: 'info', locals: { scenario: saved_scenario }
 .bar
 - if saved_scenario.localized_description(I18n.locale).presence
-  .description
+  .description#main-scenario-description
     = formatted_scenario_description(saved_scenario.localized_description(I18n.locale), allow_external_links: saved_scenario.featured?)

--- a/app/views/saved_scenarios/_scenario_list_tabs.html.haml
+++ b/app/views/saved_scenarios/_scenario_list_tabs.html.haml
@@ -35,11 +35,4 @@
       %span.name= t('scenario.all')
   - if Current.setting.api_session_id && local_assigns[:show_save_current] != false
     .save-wrapper
-      - if current_user.admin?
-        %a.button.scenario-button.save.save-icon.tooltip{href: new_saved_scenario_path(scenario_id: Current.setting.api_session_id), title: t("scenario.link")}
-          :plain
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" stroke="none"viewBox="0 0 448 512">
-              <path d="M64 32C28.7 32 0 60.7 0 96V416c0 35.3 28.7 64 64 64H384c35.3 0 64-28.7 64-64V173.3c0-17-6.7-33.3-18.7-45.3L352 50.7C340 38.7 323.7 32 306.7 32H64zm0 96c0-17.7 14.3-32 32-32H288c17.7 0 32 14.3 32 32v64c0 17.7-14.3 32-32 32H96c-17.7 0-32-14.3-32-32V128zM224 288a64 64 0 1 1 0 128 64 64 0 1 1 0-128z"/>
-            </svg>
-      - else
-        = link_to t("scenario.link"), new_saved_scenario_path(scenario_id: Current.setting.api_session_id), class: 'button scenario-button save'
+      = link_to t("scenario.link"), new_saved_scenario_path(scenario_id: Current.setting.api_session_id), class: 'button scenario-button save'

--- a/app/views/saved_scenarios/_version_history.html.haml
+++ b/app/views/saved_scenarios/_version_history.html.haml
@@ -1,8 +1,0 @@
-.row
-  current
-  = @saved_scenario.scenario_id
-
-- @saved_scenario.scenario_id_history.reverse.each do |old_id|
-  .row
-    old
-    =old_id

--- a/app/views/saved_scenarios/_version_history.html.haml
+++ b/app/views/saved_scenarios/_version_history.html.haml
@@ -1,0 +1,8 @@
+.row
+  current
+  = @saved_scenario.scenario_id
+
+- @saved_scenario.scenario_id_history.reverse.each do |old_id|
+  .row
+    old
+    =old_id

--- a/app/views/saved_scenarios/all.html.haml
+++ b/app/views/saved_scenarios/all.html.haml
@@ -3,11 +3,11 @@
 .background_wrapper#saved_scenario
   .scenario_wrapper#index
     = render partial: 'scenario_list_tabs', locals: { active_tab: :all_scenarios }
-
-    - if current_user.admin?
-      = render partial: 'scenario_row', collection: @saved_scenarios
-      = paginate @saved_scenarios
-    - else
-      .empty-state
-        %h4= t('scenario.cannot_load')
+    .internal-box
+      - if current_user.admin?
+        = render partial: 'scenario_row', collection: @saved_scenarios
+        = paginate @saved_scenarios
+      - else
+        .empty-state
+          %h4= t('scenario.cannot_load')
 

--- a/app/views/saved_scenarios/confirm_restore.html.haml
+++ b/app/views/saved_scenarios/confirm_restore.html.haml
@@ -1,0 +1,7 @@
+.scenario_wrapper
+  %h1= t('scenario.history.restore.title')
+  %p= t('scenario.history.restore.description')
+
+  .remove_saved_scenario_user_form
+    = link_to t('scenario.history.restore.button'), restore_saved_scenario_path(@saved_scenario, saved_scenario: { scenario_id: @scenario_id}), method: :put, remote: true
+    = link_to t('cancel'), '#', class: 'cancel', onclick: "$.fancybox.close();"

--- a/app/views/saved_scenarios/discarded.html.haml
+++ b/app/views/saved_scenarios/discarded.html.haml
@@ -7,21 +7,22 @@
 .background_wrapper#saved_scenario
   .scenario_wrapper#index
     = render partial: 'scenario_list_tabs', locals: { active_tab: :trash }
-    = render partial: 'flash_notice'
+    .internal-box
+      = render partial: 'flash_notice'
 
-    - if @discarded_scenarios.any?
-      .trash-notice
-        :plain
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-          </svg>
-        = t('scenario.trash.notice', deleted_after: SavedScenario::AUTO_DELETES_AFTER.in_days.to_i)
-      = render partial: 'discarded_row', collection: @discarded_scenarios
-      = paginate @discarded_scenarios
-    - else
-      .empty-state
-        %h4= t('scenario.trash.empty.title')
-        %p= t('scenario.trash.empty.description', deleted_after: SavedScenario::AUTO_DELETES_AFTER.in_days.to_i)
-        %p{ style: "font-weight: 500" }
-          = link_to scenarios_path do
-            == ← #{t('scenario.trash.empty.back')}
+      - if @discarded_scenarios.any?
+        .trash-notice
+          :plain
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+            </svg>
+          = t('scenario.trash.notice', deleted_after: SavedScenario::AUTO_DELETES_AFTER.in_days.to_i)
+        = render partial: 'discarded_row', collection: @discarded_scenarios
+        = paginate @discarded_scenarios
+      - else
+        .empty-state
+          %h4= t('scenario.trash.empty.title')
+          %p= t('scenario.trash.empty.description', deleted_after: SavedScenario::AUTO_DELETES_AFTER.in_days.to_i)
+          %p{ style: "font-weight: 500" }
+            = link_to scenarios_path do
+              == ← #{t('scenario.trash.empty.back')}

--- a/app/views/saved_scenarios/restore.js.erb
+++ b/app/views/saved_scenarios/restore.js.erb
@@ -1,3 +1,4 @@
 $('.scenario').html("<%= escape_javascript(render partial: 'scenario', locals: { saved_scenario: @saved_scenario } ) %>");
 $('#saved-scenario-history').hide();
+$.fancybox.close();
 $(document).ready(restore);

--- a/app/views/saved_scenarios/restore.js.erb
+++ b/app/views/saved_scenarios/restore.js.erb
@@ -1,1 +1,3 @@
-console.log('History has been updated');
+$('.scenario').html("<%= escape_javascript(render partial: 'scenario', locals: { saved_scenario: @saved_scenario } ) %>");
+$('#saved-scenario-history').hide();
+$(document).ready(restore);

--- a/app/views/saved_scenarios/restore.js.erb
+++ b/app/views/saved_scenarios/restore.js.erb
@@ -1,0 +1,1 @@
+console.log('History has been updated');

--- a/app/views/saved_scenarios/show.html.haml
+++ b/app/views/saved_scenarios/show.html.haml
@@ -22,5 +22,4 @@
 
       #saved-scenario-history
         -# it this the best spot: or do we put it in the menu?
-        = link_to saved_scenario_history_path(@saved_scenario), remote: true do
-          My history!
+

--- a/app/views/saved_scenarios/show.html.haml
+++ b/app/views/saved_scenarios/show.html.haml
@@ -9,8 +9,6 @@
     - if editable_saved_scenario?(@saved_scenario)
       = render partial: 'scenario_list_tabs', locals: { active_tab: @saved_scenario.discarded? ? :trash : :my_scenarios, show_save_current: false }
     .internal-box
-      = render partial: 'saved_scenarios/flash_notice'
-
       .scenario
         = render partial: 'scenario', locals: { saved_scenario: @saved_scenario }
 

--- a/app/views/saved_scenarios/show.html.haml
+++ b/app/views/saved_scenarios/show.html.haml
@@ -18,8 +18,6 @@
       - unless @saved_scenario.featured?
         = render partial: 'scenarios/version_warning', locals: { scenario: @saved_scenario }
 
-      = render partial: 'scenarios/share_links', locals: { scenario: @saved_scenario }
-
       #saved-scenario-history
         -# it this the best spot: or do we put it in the menu?
 

--- a/app/views/saved_scenarios/show.html.haml
+++ b/app/views/saved_scenarios/show.html.haml
@@ -8,15 +8,19 @@
   .scenario_wrapper#show_scenario
     - if editable_saved_scenario?(@saved_scenario)
       = render partial: 'scenario_list_tabs', locals: { active_tab: @saved_scenario.discarded? ? :trash : :my_scenarios, show_save_current: false }
-    = render partial: 'saved_scenarios/flash_notice'
+    .internal-box
+      = render partial: 'saved_scenarios/flash_notice'
 
-    .scenario
-      = render partial: 'scenario', locals: { saved_scenario: @saved_scenario }
+      .scenario
+        = render partial: 'scenario', locals: { saved_scenario: @saved_scenario }
 
-    #edit_scenario
-    - unless @saved_scenario.featured?
-      = render partial: 'scenarios/version_warning', locals: { scenario: @saved_scenario }
+      #edit_scenario
+      - unless @saved_scenario.featured?
+        = render partial: 'scenarios/version_warning', locals: { scenario: @saved_scenario }
 
-    = render partial: 'scenarios/share_links', locals: { scenario: @saved_scenario }
+      = render partial: 'scenarios/share_links', locals: { scenario: @saved_scenario }
 
-    = render partial: 'version_history', locals: { saved_scenario: @saved_scenario }
+      #saved-scenario-history
+        -# it this the best spot: or do we put it in the menu?
+        = link_to saved_scenario_history_path(@saved_scenario), remote: true do
+          My history!

--- a/app/views/saved_scenarios/show.html.haml
+++ b/app/views/saved_scenarios/show.html.haml
@@ -18,3 +18,5 @@
       = render partial: 'scenarios/version_warning', locals: { scenario: @saved_scenario }
 
     = render partial: 'scenarios/share_links', locals: { scenario: @saved_scenario }
+
+    = render partial: 'version_history', locals: { saved_scenario: @saved_scenario }

--- a/app/views/saved_scenarios/show.js.erb
+++ b/app/views/saved_scenarios/show.js.erb
@@ -1,0 +1,3 @@
+$('.scenario').html("<%= escape_javascript(render partial: 'scenario', locals: { saved_scenario: @saved_scenario } ) %>");
+$('#saved-scenario-history').hide();
+$(document).ready(restore);

--- a/app/views/saved_scenarios/show.js.erb
+++ b/app/views/saved_scenarios/show.js.erb
@@ -1,3 +1,4 @@
 $('.scenario').html("<%= escape_javascript(render partial: 'scenario', locals: { saved_scenario: @saved_scenario } ) %>");
 $('#saved-scenario-history').hide();
+history.pushState(null, null, "<%=escape_javascript(saved_scenario_path(@saved_scenario))%>");
 $(document).ready(restore);

--- a/app/views/scenarios/_share_links.html.haml
+++ b/app/views/scenarios/_share_links.html.haml
@@ -1,5 +1,3 @@
-.bar
-
 .sharing-links
   .copy-link
     %a
@@ -9,16 +7,3 @@
       .arrow
       .cross{ class: 'fa fa-times', title: 'Close' }
       .url= text_field_tag 'url', request.original_url
-
-  -# = link_to share_by_mail_link(scenario) do
-  -#   .icon{ class: 'fa fa-envelope-o' }
-  -#   Email
-  -# = link_to share_by_twitter_link, open_attributes do
-  -#   .icon{ class: 'fa fa-twitter' }
-  -#   Twitter
-  -# = link_to share_by_linkedin_link, open_attributes do
-  -#   .icon{ class: 'fa fa-linkedin' }
-  -#   LinkedIn
-  -# = link_to share_by_facebook_link, open_attributes do
-  -#   .icon{ class: 'fa fa-facebook-official' }
-  -#   Facebook

--- a/app/views/scenarios/index.html.haml
+++ b/app/views/scenarios/index.html.haml
@@ -7,5 +7,6 @@
 .background_wrapper#saved_scenario
   .scenario_wrapper#index
     = render partial: 'saved_scenarios/scenario_list_tabs', locals: { active_tab: :my_scenarios }
-    = render partial: 'saved_scenarios/flash_notice'
-    = render 'scenarios_slice'
+    .internal-box
+      = render partial: 'saved_scenarios/flash_notice'
+      = render 'scenarios_slice'

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -258,7 +258,7 @@ en:
     area_code: "Country"
     author: "Author"
     compare: "Compare"
-    continue: 'Continue'
+    continue: 'Continue with this scenario'
     merge: "Merge"
     local_vs_global: "Combine and compare"
     open_in_myc: Create a new Transition Path Chart

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -259,6 +259,7 @@ en:
     area_code: "Country"
     author: "Author"
     compare: "Compare"
+    continue: 'Continue'
     merge: "Merge"
     local_vs_global: "Combine and compare"
     open_in_myc: Create a new Transition Path Chart

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -345,6 +345,9 @@ en:
     history:
       empty: There is no history to show
       title: Version history
+      description:
+        Here you can see the different versions that have been saved, and you are able to add a
+        description to each version.
     users:
       manage: 'Manage access'
       manage_description:

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -28,6 +28,7 @@ en:
   nevermind: "Never mind"
   cancel: "Cancel"
   last_updated_ago: "Last updated %{when} ago"
+  last_ago: "%{when} ago"
   delete: Delete
   delete_permanently: Delete Permanently
   restore: Restore

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -367,7 +367,7 @@ en:
       name: 'Name'
       role: 'Role'
       you: 'you'
-      unknown: 'Uknown user'
+      unknown: 'Unknown user'
       roles:
         scenario_owner: 'Owner'
         scenario_collaborator: 'Collaborator'

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -32,7 +32,7 @@ en:
   delete_permanently: Delete Permanently
   restore: Restore
   trash: Trash
-  settings: Settings
+  settings: Options
   move_to: Move to
   undo: Undo
   required: Required
@@ -266,6 +266,7 @@ en:
     end_year: "End Year"
     go_back: "Or go back to"
     back_to: "Back to scenario"
+    back_to_overview: "Back to my scenarios"
     link: "Save current scenario"
     by: "By"
     area_not_exists: 'Area does not exist'

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -28,7 +28,6 @@ en:
   nevermind: "Never mind"
   cancel: "Cancel"
   last_updated_ago: "Last updated %{when} ago"
-  last_updated_date: "Last updated: %{when}"
   last_ago: "%{when} ago"
   delete: Delete
   delete_permanently: Delete Permanently
@@ -270,6 +269,8 @@ en:
     go_back: "Or go back to"
     back_to: "Back to scenario"
     back_to_overview: "Back to my scenarios"
+    show_history: "Show version history"
+    close_version_history: "Close version history"
     link: "Save current scenario"
     by: "By"
     area_not_exists: 'Area does not exist'
@@ -332,6 +333,7 @@ en:
     add_description: 'Add a description of your scenario...'
     no_description: 'No description'
     edit_text: 'Edit title and description'
+    edit_description: 'Edit description'
     save_text: 'Save changes'
     open: 'Open this scenario version'
     restore: 'Restore this version'

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -28,6 +28,7 @@ en:
   nevermind: "Never mind"
   cancel: "Cancel"
   last_updated_ago: "Last updated %{when} ago"
+  last_updated_date: "Last updated: %{when}"
   last_ago: "%{when} ago"
   delete: Delete
   delete_permanently: Delete Permanently
@@ -271,7 +272,7 @@ en:
     link: "Save current scenario"
     by: "By"
     area_not_exists: 'Area does not exist'
-    load: "Open this scenario"
+    load: "Open scenario"
     load_energy_mix: "Open energy mix infographic"
     no_title: "Scenario without title"
     overview: "overview"
@@ -331,6 +332,8 @@ en:
     no_description: 'No description'
     edit_text: 'Edit title and description'
     save_text: 'Save changes'
+    open: 'Open this scenario version'
+    restore: 'Restore this version'
     cancel_text: 'Discard changes'
     edit_featured_scenario: 'Edit featured scenario settings'
     feature_scenario: 'Feature this scenario'

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -346,8 +346,8 @@ en:
       empty: There is no history to show
       title: Version history
       description:
-        Here you can see the different versions that have been saved, and you are able to add a
-        description to each version.
+        Here you can see the different scenario versions that have been saved. A description can be added to each version.
+        When you are owner of this scenario, you can reset the scenario to an older version. 
       restore:
         title: Restore an older version
         description: You are restoring the scenario to an older version. This action is irreverisble. Are you sure?
@@ -440,6 +440,8 @@ en:
     reset: "Scenario is reset to default values."
     scenario_load: "Loaded scenario"
     scenario_saved: "Saved scenario"
+    scenario_restored: "Scenario succesfully restored"
+    scenario_cannot_be_restored: "Scenario cannot be restored"
     succesfully_saved: "The scenario was succesfully saved."
     account_deleted: "Your account has been deleted"
     newsletter_subscribe: "You have subscribed to our newsletter. Please check your e-mail inbox to confirm."

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -340,6 +340,8 @@ en:
     feature_scenario: 'Feature this scenario'
     featured_scenario: 'Featured scenario'
     created_with: 'Scenario created with the Energy Transition Model'
+    history:
+      empty: There is no history to show
     users:
       manage: 'Manage access'
       manage_description:

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -348,6 +348,11 @@ en:
       description:
         Here you can see the different versions that have been saved, and you are able to add a
         description to each version.
+      restore:
+        title: Restore an older version
+        description: You are restoring the scenario to an older version. This action is irreverisble. Are you sure?
+        button: Restore now
+      flash: The scenario was succesfully restored to an older version!
     users:
       manage: 'Manage access'
       manage_description:

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -328,6 +328,7 @@ en:
       <a href="https://docs.energytransitionmodel.com/main/external-coupling#uncoupling-the-scenario" target=\"_blank\">
       documentation</a> for more information.
     add_description: 'Add a description of your scenario...'
+    no_description: 'No description'
     edit_text: 'Edit title and description'
     save_text: 'Save changes'
     cancel_text: 'Discard changes'

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -378,6 +378,9 @@ en:
     share:
       by: 'Share by'
       copy: 'Copy link'
+      copy_description:
+        This is a link you can share with other people to view your scenario. If you want to give
+        others access to make changes to your scenario, please go to Options > Manage access.
       email_subject: 'Energy Transition Model: Sharing scenario'
       message: "Hi!%0D%0A
         %0D%0A

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -347,6 +347,7 @@ en:
       name: 'Name'
       role: 'Role'
       you: 'you'
+      unknown: 'Uknown user'
       roles:
         scenario_owner: 'Owner'
         scenario_collaborator: 'Collaborator'

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -342,6 +342,7 @@ en:
     created_with: 'Scenario created with the Energy Transition Model'
     history:
       empty: There is no history to show
+      title: Version history
     users:
       manage: 'Manage access'
       manage_description:

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -260,6 +260,7 @@ nl:
     author: "Auteur"
     compare: "Vergelijk"
     merge: "Samensmelten"
+    continue: 'Ga verder met scenario'
     local_vs_global: "Combineren en vergelijken"
     open_in_myc: Maak een nieuwe Transition Path Chart
     all: Alle Scenarios (admin)

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -267,6 +267,7 @@ nl:
     end_year: "Eindjaar"
     go_back: " of ga anders terug naar"
     back_to: "Terug naar scenario"
+    back_to_overview: "Terug naar mijn scenarios"
     link: "Sla huidig scenario op"
     by: "Door"
     area_not_exists: 'Regio bestaat niet'

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -341,6 +341,8 @@ nl:
     feature_scenario: 'Maak dit een uitgelicht scenario'
     featured_scenario: 'Uitgelicht scenario'
     created_with: 'Scenario gemaakt met het Energietransitiemodel'
+    history:
+      empty: Er kon geen geschiedenis getoond worden
     users:
       manage: 'Beheer toegang'
       manage_description:

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -336,7 +336,7 @@ nl:
     no_description: 'Geen beschrijving'
     edit_text: 'Pas titel en beschrijving aan'
     edit_description: 'Pas beschrijving aan'
-    save_text: 'Sla veranderingen op'
+    save_text: 'Sla wijzigingen op'
     open: 'Open deze versie'
     restore: 'Herstel deze versie'
     cancel_text: 'Annuleren'
@@ -347,6 +347,15 @@ nl:
     history:
       empty: Er kon geen geschiedenis getoond worden
       title: Versiegeschiedenis
+      description:
+        Hieronder zie je de verschillende opgeslagen versies van het scenario. Aan elke versie kan een beschrijving 
+        worden toegevoegd. Wanneer je eigenaar bent van dit scenario, kan je het scenario terugzetten naar een 
+        oudere versie.
+      restore:
+        title: Herstel oudere versie
+        description: Je herstelt het scenario naar een oudere versie. Deze actie is onomkeerbaar. Weet je het zeker?
+        button: Herstel oudere versie
+        flash: Het scenario is succesvol hersteld naar een oudere versie!
     users:
       manage: 'Beheer toegang'
       manage_description:
@@ -440,6 +449,8 @@ nl:
     reset: "Scenario is ge-reset naar de standaardwaarden."
     scenario_load: "Scenario geladen"
     scenario_saved: "Scenario opgeslagen"
+    scenario_restored: "Scenario is hersteld naar oudere versie"
+    scenario_cannot_be_restored: "Scenario kan niet worden hersteld naar oudere versie"
     succesfully_saved: "Het scenario is succesvol opgeslagen."
     account_deleted: "Uw account is verwijderd"
     newsletter_subscribe: "Je hebt je ingeschreven voor onze nieuwsbrief. Kijk in je mailbox om je inschrijving te bevestigen."

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -343,6 +343,7 @@ nl:
     created_with: 'Scenario gemaakt met het Energietransitiemodel'
     history:
       empty: Er kon geen geschiedenis getoond worden
+      title: Versiegeschiedenis
     users:
       manage: 'Beheer toegang'
       manage_description:

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -349,6 +349,7 @@ nl:
       name: 'Naam'
       role: 'Rol'
       you: 'jij'
+      unknown: 'Onbekende gebruiker'
       roles:
         scenario_owner: 'Eigenaar'
         scenario_collaborator: 'Bewerker'

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -385,6 +385,9 @@ nl:
     share:
       by: 'Delen via'
       copy: 'Kopieer link'
+      copy_description: |
+        Met deze link kunnen anderen het scenario bekijken. Om ze het recht te geven om het scenario
+        te kunnen bewerken, ga naar Opties > Beheer toegang.
       email_subject: 'Energy Transition Model: Delen van scenario'
       message: "Hallo,%0D%0A
         %0D%0A

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -330,6 +330,7 @@ nl:
       <a href="https://docs.energytransitionmodel.com/main/external-coupling#uncoupling-the-scenario" target=\"_blank\">
       documentatie</a>.
     add_description: 'Voeg een beschrijving van je scenario toe...'
+    no_description: 'Geen beschrijving'
     edit_text: 'Pas titel en beschrijving aan'
     save_text: 'Sla veranderingen op'
     cancel_text: 'Annuleren'

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -272,7 +272,7 @@ nl:
     link: "Sla huidig scenario op"
     by: "Door"
     area_not_exists: 'Regio bestaat niet'
-    load: "Open dit scenario"
+    load: "Open scenario"
     load_energy_mix: "Open energie-mix infographic"
     no_title: "Scenario zonder titel"
     overview: "overzicht"
@@ -333,6 +333,8 @@ nl:
     no_description: 'Geen beschrijving'
     edit_text: 'Pas titel en beschrijving aan'
     save_text: 'Sla veranderingen op'
+    open: 'Open deze versie'
+    restore: 'Herstel deze versie'
     cancel_text: 'Annuleren'
     edit_featured_scenario: 'Instellingen voor uitgelicht scenario'
     feature_scenario: 'Maak dit een uitgelicht scenario'

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -28,6 +28,7 @@ nl:
   nevermind: "Niet gebruiken"
   cancel: "Annuleren"
   last_updated_ago: "Laatst bijgewerkt %{when} geleden"
+  last_ago: "%{when} geleden"
   delete: Verwijderen
   delete_permanently: Permanent verwijderen
   restore: Herstellen

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -270,6 +270,8 @@ nl:
     go_back: " of ga anders terug naar"
     back_to: "Terug naar scenario"
     back_to_overview: "Terug naar mijn scenarios"
+    show_history: "Weergeef versiegeschiedenis"
+    close_version_history: "Sluit versiegeschiedenis"
     link: "Sla huidig scenario op"
     by: "Door"
     area_not_exists: 'Regio bestaat niet'
@@ -333,6 +335,7 @@ nl:
     add_description: 'Voeg een beschrijving van je scenario toe...'
     no_description: 'Geen beschrijving'
     edit_text: 'Pas titel en beschrijving aan'
+    edit_description: 'Pas beschrijving aan'
     save_text: 'Sla veranderingen op'
     open: 'Open deze versie'
     restore: 'Herstel deze versie'
@@ -392,7 +395,7 @@ nl:
       by: 'Delen via'
       copy: 'Kopieer link'
       copy_description: |
-        Met deze link kunnen anderen het scenario bekijken. Om ze het recht te geven om het scenario
+        Met deze link kunnen anderen het scenario bekijken. Om ze het recht te geven het scenario
         te kunnen bewerken, ga naar Opties > Beheer toegang.
       email_subject: 'Energy Transition Model: Delen van scenario'
       message: "Hallo,%0D%0A

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,9 @@ Rails.application.routes.draw do
       get :all
     end
 
+    get '/history' => 'saved_scenario_history#index'
+    put '/history' => 'saved_scenario_history#update'
+
     get '/report/:report_name' => 'saved_scenario_reports#show'
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,7 @@ Rails.application.routes.draw do
       put :undiscard
       put :publish
       put :unpublish
+      put :restore
     end
 
     collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,6 +84,7 @@ Rails.application.routes.draw do
       put :publish
       put :unpublish
       put :restore
+      get :confirm_restore
     end
 
     collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,7 +91,7 @@ Rails.application.routes.draw do
     end
 
     get '/history' => 'saved_scenario_history#index'
-    put '/history' => 'saved_scenario_history#update'
+    put '/history/:scenario_id' => 'saved_scenario_history#update',  as: :update_saved_scenario_history
 
     get '/report/:report_name' => 'saved_scenario_reports#show'
   end

--- a/spec/cassettes/SavedScenarioHistoryController/with_a_user_that_owns_the_scenario/GET_index/as_json/contains_the_scenario_versions_of_the_full_histoty.yml
+++ b/spec/cassettes/SavedScenarioHistoryController/with_a_user_that_owns_the_scenario/GET_index/as_json/contains_the_scenario_versions_of_the_full_histoty.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://beta-engine.energytransitionmodel.com/api/v3/scenarios/versions?scenarios%5B%5D=111&scenarios%5B%5D=122&scenarios%5B%5D=123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.7.3
+      Authorization:
+      - Bearer access_BAr4riHCgXH5awmn
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx/1.21.3
+      Date:
+      - Tue, 16 Apr 2024 11:48:40 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - dfbd9a30-77f2-4cab-b334-cdeaed256265
+      X-Runtime:
+      - '0.011295'
+    body:
+      encoding: UTF-8
+      string: '{"errors":["Scenario not found"]}'
+  recorded_at: Tue, 16 Apr 2024 11:48:40 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/SavedScenariosController/_GET_show/has_an_ok_status.yml
+++ b/spec/cassettes/SavedScenariosController/_GET_show/has_an_ok_status.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://beta-engine.energytransitionmodel.com/api/v3/scenarios/versions?scenarios%5B%5D=648695
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.7.3
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx/1.21.3
+      Date:
+      - Tue, 16 Apr 2024 08:19:29 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - bbfad101-f1db-4585-9927-3343306ab960
+      X-Runtime:
+      - '0.011815'
+    body:
+      encoding: UTF-8
+      string: '{"errors":["Scenario not found"]}'
+  recorded_at: Tue, 16 Apr 2024 08:19:29 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/SavedScenariosController/_GET_show/when_the_scenario_cannot_be_loaded/redirects_to_the_root_page.yml
+++ b/spec/cassettes/SavedScenariosController/_GET_show/when_the_scenario_cannot_be_loaded/redirects_to_the_root_page.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://beta-engine.energytransitionmodel.com/api/v3/scenarios/versions?scenarios%5B%5D=648695
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.7.3
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx/1.21.3
+      Date:
+      - Tue, 16 Apr 2024 08:19:29 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - acb31edd-a3eb-409f-bc5a-cd7b25eb4bf0
+      X-Runtime:
+      - '0.008996'
+    body:
+      encoding: UTF-8
+      string: '{"errors":["Scenario not found"]}'
+  recorded_at: Tue, 16 Apr 2024 08:19:29 GMT
+recorded_with: VCR 6.0.0

--- a/spec/controllers/saved_scenario_history_controller_spec.rb
+++ b/spec/controllers/saved_scenario_history_controller_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SavedScenarioHistoryController, vcr: true do
+  render_views
+
+  let(:user) { create(:user) }
+  let(:saved_scenario) { create(:saved_scenario, user: user, scenario_id: 123, scenario_id_history: [111, 122]) }
+
+  before do
+    allow(UpdateAPIScenarioVersionTag).to receive(:call).and_return(ServiceResult.success)
+  end
+
+  context 'with a user that owns the scenario' do
+    before do
+      sign_in user
+      session[:setting] = Setting.new
+    end
+
+    # TODO: finish the test!
+    # describe 'GET index' do
+    #   context 'as json' do
+    #     before do
+    #       get :index, format: :json, params: {
+    #         saved_scenario_id: saved_scenario.id
+    #       }
+    #     end
+
+    #     it 'contains the scenario versions of the full histoty' do
+    #       expect(JSON.parse(response)).to include 'hi'
+    #     end
+    #   end
+    # end
+
+    describe 'PUT update' do
+      before do
+        put :update, format: :json, params: {
+          saved_scenario_id: saved_scenario.id,
+          scenario_id: 123,
+          description: 'my update'
+        }
+      end
+
+      it 'is succesful' do
+        expect(response).to be_ok
+      end
+    end
+  end
+
+  # TODO: tests for whn it fails
+end

--- a/spec/controllers/saved_scenario_history_controller_spec.rb
+++ b/spec/controllers/saved_scenario_history_controller_spec.rb
@@ -10,6 +10,13 @@ describe SavedScenarioHistoryController, vcr: true do
 
   before do
     allow(UpdateAPIScenarioVersionTag).to receive(:call).and_return(ServiceResult.success)
+    allow(FetchSavedScenarioVersionTags).to receive(:call).and_return(ServiceResult.success(
+      {
+        "123" => { 'user_id' => user.id, description: 'my last version' },
+        "122" => {},
+        "111" => {}
+      }
+    ))
   end
 
   context 'with a user that owns the scenario' do
@@ -18,20 +25,25 @@ describe SavedScenarioHistoryController, vcr: true do
       session[:setting] = Setting.new
     end
 
-    # TODO: finish the test!
-    # describe 'GET index' do
-    #   context 'as json' do
-    #     before do
-    #       get :index, format: :json, params: {
-    #         saved_scenario_id: saved_scenario.id
-    #       }
-    #     end
+    describe 'GET index' do
+      context 'as json' do
+        before do
+          get :index, format: :json, params: {
+            saved_scenario_id: saved_scenario.id
+          }
+        end
 
-    #     it 'contains the scenario versions of the full histoty' do
-    #       expect(JSON.parse(response)).to include 'hi'
-    #     end
-    #   end
-    # end
+        it 'is succesful' do
+          expect(response).to be_ok
+        end
+
+        it 'contains the scenario versions of the full histoty' do
+          expect(JSON.parse(response.body)).to include({
+            'description' => 'my last version', 'scenario_id' => 123, 'user' => user.name
+          })
+        end
+      end
+    end
 
     describe 'PUT update' do
       before do
@@ -47,6 +59,4 @@ describe SavedScenarioHistoryController, vcr: true do
       end
     end
   end
-
-  # TODO: tests for whn it fails
 end

--- a/spec/controllers/saved_scenarios_controller_spec.rb
+++ b/spec/controllers/saved_scenarios_controller_spec.rb
@@ -433,7 +433,7 @@ describe SavedScenariosController, vcr: true do
     before do
       sign_in(user)
       session[:setting] = Setting.new
-      allow(RestoreSavedScenario).to receive(:call)
+      allow(RestoreSavedScenario).to receive(:call).and_return(ServiceResult.success)
     end
 
     context 'with an owned saved scenario' do

--- a/spec/controllers/saved_scenarios_controller_spec.rb
+++ b/spec/controllers/saved_scenarios_controller_spec.rb
@@ -429,6 +429,44 @@ describe SavedScenariosController, vcr: true do
     end
   end
 
+  describe 'PUT restore' do
+    before do
+      sign_in(user)
+      session[:setting] = Setting.new
+      allow(RestoreSavedScenario).to receive(:call)
+    end
+
+    context 'with an owned saved scenario' do
+      before do
+        user_scenario.update!(scenario_id_history: [8, 9, 10])
+        put(
+          :restore,
+          format: :js,
+          params: { id: user_scenario.id, saved_scenario: { scenario_id: 9 } }
+        )
+      end
+
+      it 'is succesfull' do
+        expect(response).to be_successful
+      end
+    end
+
+    context 'with an unowned saved scenario' do
+      before do
+        admin_scenario.update!(scenario_id_history: [8, 9, 10])
+        put(
+          :restore,
+          format: :js,
+          params: { id: admin_scenario.id, saved_scenario: { scenario_id: 9 } }
+        )
+      end
+
+      it 'returns 404' do
+        expect(response).to be_not_found
+      end
+    end
+  end
+
   describe 'DELETE destroy' do
     before do
       sign_in(user)

--- a/spec/controllers/saved_scenarios_controller_spec.rb
+++ b/spec/controllers/saved_scenarios_controller_spec.rb
@@ -125,6 +125,10 @@ describe SavedScenariosController, vcr: true do
           attributes_for(:engine_scenario, id: 999, area_code: 'nl', end_year: 2050)
         ))
       )
+
+      allow(CreateAPIScenarioVersionTag).to receive(:call).and_return(
+        ServiceResult.success
+      )
     end
 
     context 'with valid attributes' do

--- a/spec/models/saved_scenario_history_presenter_spec.rb
+++ b/spec/models/saved_scenario_history_presenter_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SavedScenarioHistoryPresenter do
+  subject { described_class.present(saved_scenario, api_response) }
+
+  let(:api_response) do
+    {
+      '123' => {
+        'id' => 2,
+        'user_id' => user.id,
+        'description'  => 'added some buildings',
+        'last_updated_at' => 2.hours.ago.to_json
+      },
+      '111' => {
+        'last_updated_at' =>  2.days.ago.to_json
+      },
+      '122' => {
+        'id' => 1,
+        'user_id' => user.id,
+        'description' => 'adjusted wind turbines',
+        'last_updated_at' =>  1.day.ago.to_json
+      }
+    }
+  end
+
+  let(:user) { create(:user) }
+  let(:saved_scenario) { create(:saved_scenario, scenario_id: 123, scenario_id_history: [111, 122]) }
+
+  it 'returns the versions sorted from current to last' do
+    expect(subject.map { |v| v['scenario_id'] }).to eq([123, 122, 111])
+  end
+
+  it 'subsitutes the user id for a users name' do
+    expect(subject.first).to include({ 'user' => user.name })
+  end
+
+  it 'removes the user id' do
+    expect(subject.first.keys).not_to include('user_id')
+  end
+
+  it 'sets a "unknown" name when no user was known for the version (older scenario compatability)' do
+    expect(subject.last.keys).to include('user')
+  end
+end

--- a/spec/models/saved_scenario_spec.rb
+++ b/spec/models/saved_scenario_spec.rb
@@ -49,11 +49,40 @@ describe SavedScenario do
         .to change{subject.scenario_id_history.count}.by 1
     end
 
-    it "won't add more then 20 items" do
-      20.times{|n| subject.add_id_to_history(n)}
+    it "won't add more then 100 items" do
+      100.times { |n| subject.add_id_to_history(n) }
 
       expect{ subject.add_id_to_history("1234") }
         .not_to change{subject.scenario_id_history.count}
+    end
+  end
+
+  describe 'restore_version' do
+    before do
+      subject.scenario_id_history = [123, 1234, 12345]
+    end
+
+    it 'sets the version as the main scenario id' do
+      subject.restore_version(1234)
+      expect(subject.scenario_id).to eq(1234)
+    end
+
+    it 'removes old scenarios from history' do
+      expect { subject.restore_version(1234) }
+        .to change { subject.scenario_id_history.count }.by(-2)
+    end
+
+    it 'keeps correct ids in history' do
+      subject.restore_version(1234)
+      expect(subject.scenario_id_history).to eq([123])
+    end
+
+    it 'returns the discarded ids' do
+      expect(subject.restore_version(1234)).to eq([123_45])
+    end
+
+    it 'does nothing when the scenario was not in the history' do
+      expect(subject.restore_version(999_999)).to be_nil
     end
   end
 

--- a/spec/requests/api/saved_scenarios_spec.rb
+++ b/spec/requests/api/saved_scenarios_spec.rb
@@ -314,6 +314,28 @@ RSpec.describe 'API::SavedScenarios', type: :request, api: true do
       end
     end
 
+    context 'when updating with a historic scenario ID' do
+      before do
+        scenario.update(scenario_id_history: [999_999, 2, 111_111])
+        scenario.reload
+      end
+
+      it 'returns success' do
+        request
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'changes the scenario ID history' do
+        expect { request }
+          .to change { scenario.reload.scenario_id_history }
+          .from([999_999, 2, 111_111]).to([999_999])
+      end
+
+      it 'changes the scenario ID' do
+        expect { request }.to change { scenario.reload.scenario_id }.from(1).to(2)
+      end
+    end
+
     context 'when given invalid data' do
       let(:scenario_attributes) do
         super().merge(title: '')

--- a/spec/services/fetch_saved_scenario_version_tags_spec.rb
+++ b/spec/services/fetch_saved_scenario_version_tags_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+describe FetchSavedScenarioVersionTags, type: :service do
+  let(:result) { described_class.call(client, saved_scenario) }
+  let(:saved_scenario) { create(:saved_scenario, scenario_id: 123, scenario_id_history: [111, 122])}
+
+  let(:response_data) do
+    {
+      '123' => {
+        'id' => 2,
+        'user_id' => 245,
+        'description'  => 'added some buildings',
+        'last_updated_at' => 2.hours.ago.to_json
+      },
+      '111' => {
+        'last_updated_at' =>  2.days.ago.to_json
+      },
+      '122' => {
+        'id' => 1,
+        'user_id' => 245,
+        'description' => 'adjusted wind turbines',
+        'last_updated_at' =>  1.day.ago.to_json
+      }
+    }
+  end
+
+  context 'when the response contains data for the versions' do
+    let(:client) do
+      Faraday.new do |builder|
+        builder.adapter(:test) do |stub|
+          stub.get('/api/v3/scenarios/versions') do
+            [
+              200,
+              { 'Content-Type' => 'application/json' },
+              response_data
+            ]
+          end
+        end
+      end
+    end
+
+    it 'returns a success' do
+      expect(result).to be_successful
+    end
+  end
+end

--- a/spec/services/restore_saved_scenario.rb
+++ b/spec/services/restore_saved_scenario.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe RestoreSavedScenario, type: :service do
+  let(:client) { instance_double(Faraday::Connection) }
+  let(:user) { create(:user) }
+  let(:restore_id) { 1234 }
+  let(:result) { described_class.call(client, saved_scenario, restore_id) }
+  let!(:saved_scenario) do
+    create(
+      :saved_scenario,
+      user: user,
+      id: 648_695,
+      scenario_id_history: [123, 1234, 12_345]
+    )
+  end
+
+  before do
+    allow(client).to receive(:put).with(
+      '/api/v3/scenarios/12345', scenario: { keep_compatible: false }
+    )
+  end
+
+  context 'when the restore is succesful' do
+    it 'returns a ServiceResult' do
+      expect(result).to be_a(ServiceResult)
+    end
+
+    it 'is successful' do
+      expect(result).to be_successful
+    end
+
+    it 'updates the main scenario id' do
+      expect { result }.to(change(saved_scenario, :scenario_id))
+    end
+
+    it 'has the given scenario id as main scenario id in the resulting saved scenario' do
+      expect(result.value.scenario_id).to eq(restore_id)
+    end
+  end
+
+  context 'when restoring to an unknown scenario id' do
+    let(:restore_id) { 999_999 }
+
+    it 'returns a ServiceResult' do
+      expect(result).to be_a(ServiceResult)
+    end
+
+    it 'is successful' do
+      expect(result).not_to be_successful
+    end
+
+    it 'did not change the main scenario id' do
+      expect { result }.not_to(change(saved_scenario, :scenario_id))
+    end
+  end
+end

--- a/spec/services/update_saved_scenario_spec.rb
+++ b/spec/services/update_saved_scenario_spec.rb
@@ -26,7 +26,7 @@ describe UpdateSavedScenario, type: :service do
       '/api/v3/scenarios/10', scenario: { set_preset_roles: true }
     )
     allow(client).to receive(:post).with(
-      '/api/v3/scenarios/10/version', { :description => "another version" }
+      '/api/v3/scenarios/10/version', { :description => "" }
     )
   end
 

--- a/spec/services/update_saved_scenario_spec.rb
+++ b/spec/services/update_saved_scenario_spec.rb
@@ -25,6 +25,9 @@ describe UpdateSavedScenario, type: :service do
     allow(client).to receive(:put).with(
       '/api/v3/scenarios/10', scenario: { set_preset_roles: true }
     )
+    allow(client).to receive(:post).with(
+      '/api/v3/scenarios/10/version', { :description => "another version" }
+    )
   end
 
   context 'when the API response is successful' do


### PR DESCRIPTION
For a long time, we have been keeping the saved scenario history hidden. Now it's time we finally show it to the public!

Users can now
- View the historic versions of their saved scenario's
- Open historic versions
- Restore historic versions
- Add a description to an historic version
- See who last altered a historic version

We also decided to give the whole 'my scenarios' page a small facelift to increase usability. But there could be much more improved there.

<img width="1203" alt="Screenshot 2024-04-30 at 13 27 04" src="https://github.com/quintel/etmodel/assets/14875123/bbd1d7e5-ff5b-4461-9500-05a8c23878f8">

---

Still to do:
- [x] Review texts and create Dutch translation 
- [x] Routing (when refreshing history page it should stay on the history page)
- [x] Add API actions

Nice to have:
- [x] Back button / close history button
- [ ] Possible re-adding of (country) flag
- [ ] 'Read more...' for long descriptions
- [ ] When opening an old version, title should be kept with something like _'version 04-05-2024'_ appended