### PR TITLE
Update energy mix visual

### DIFF
--- a/app/views/energy_mix/_reverse.html.haml
+++ b/app/views/energy_mix/_reverse.html.haml
@@ -226,10 +226,18 @@
     bodem (500 m. diepte) en grote ondergrondse boilervaten.
 
 #disclaimer
-  Deze infographic is automatisch gegenereerd met het Energietransitiemodel op
-  basis van een scenario dat niet is gevalideerd door een expert. Quintel of
-  Over Morgen zijn dan ook niet verantwoordelijk of aansprakelijk voor de inhoud
-  of uitkomsten van deze infographic.
+  %p
+    Deze infographic is automatisch gegenereerd met het Energietransitiemodel op 
+    basis van een scenario dat niet is gevalideerd door een expert. Quintel is dan 
+    ook niet verantwoordelijk of aansprakelijk voor de inhoud of uitkomsten van 
+    deze infographic.
+    
+  %p
+    De Energiemix wordt in 2025 vervangen door een nieuwe feature en zal dan niet 
+    meer in deze vorm beschikbaar zijn. Het Energietransitiemodel is gratis in gebruik. 
+    Ontwikkelingen en onderhoud worden betaald door enthousiaste gebruikers en zijn 
+    daardoor beschikbaar voor iedereen. Mocht je willen bijdragen aan een update, 
+    laat het dan weten via info@quintel.com.
 
   - if can_dismiss_disclaimer?
-    %button Hide disclaimer
+    %button Verberg disclaimer

--- a/app/views/energy_mix/_reverse.html.haml
+++ b/app/views/energy_mix/_reverse.html.haml
@@ -45,7 +45,7 @@
   omgeving, mobiliteit, industrie en landbouw. We noemen dit ook wel ‘de vraag
   aan de meter’. De energievraag van dit moment is gebaseerd op de laatste
   complete set gegevens uit de Klimaatmonitor van Rijkswaterstaat (peiljaar
-  2016). Energiegebruik van internationaal vracht- en vliegverkeer en
+  2019). Energiegebruik van internationaal vracht- en vliegverkeer en
   grootschalige opwekking van energie zit hier niet in. De energievraag bestaat
   uit:
 

--- a/app/views/energy_mix/_reverse.html.haml
+++ b/app/views/energy_mix/_reverse.html.haml
@@ -13,7 +13,7 @@
 
 %p
   De berekeningen zijn gemaakt met behulp van het
-  = link_to('EnergieTransitieModel', root_url)
+  = link_to('Energietransitiemodel', root_url)
   van bureau Quintel. Door adviesbureau Over Morgen is in samenspraak met
   gemeenten en de provincie voor elke gemeente een scenario opgesteld. Alle
   uitgangspunten en instellingen van het scenario zijn terug te vinden en te

--- a/app/views/energy_mix/_reverse.html.haml
+++ b/app/views/energy_mix/_reverse.html.haml
@@ -64,7 +64,7 @@
   %li
     Collectief warmtegebruik voor verwarmen van de gebouwde omgeving;
   %li
-    Individuele zonthermie in de vorm van zonnecollectoren op daken;
+    Individuele zonthermie in de vorm van zonnecollectoren en PVT op daken;
   %li
     Alle elektriciteitsgebruik.
 

--- a/app/views/energy_mix/show.html.haml
+++ b/app/views/energy_mix/show.html.haml
@@ -20,8 +20,7 @@
       %dt Energiegebruik gebouwde omgeving
       %dd{ data: { query: "factsheet_share_households_buildings_in_total_demand", period: "future" } } &mdash;
     .logos
-      = image_tag('energy_mix/Quintel-logotype-black.svg', style: 'margin-right: 1rem; width: 8rem')
-      = image_tag('energy_mix/over-morgen.png', style: 'width: 6rem')
+      = image_tag('header/logo400-blue@2x.png', style: 'width: 16rem')
       %br<>
       %span.date
         = Date.today.strftime("%-d-%-m-%Y")

--- a/app/views/energy_mix/show.html.haml
+++ b/app/views/energy_mix/show.html.haml
@@ -77,7 +77,7 @@
               )
             %li.spacer
               %span{ data: { query: "factsheet_number_of_wind_turbines_offshore" } }> &mdash;
-              &nbsp;windturbines op zee (10 MW) en/of innovatie
+              &nbsp;windturbines op zee (10 MW)
 
         .panel.solar
           %h3 Zon
@@ -85,7 +85,7 @@
           %ul
             %li
               %span{ data: { query: "factsheet_number_of_roof_solar_pv", precision: "-3" } } &mdash;
-              PV-panelen op dak
+              PV(T)-panelen op dak
               (
               %span{ data: { query: "energy_mix_capacity_per_panel_solar_pv" } }<> &mdash;
               \ Wp) ->
@@ -96,7 +96,7 @@
               %span{ data: { query: "factsheet_supply_from_solar_pv_plants" } } &mdash;
             %li
               %span{ data: { query: "factsheet_installed_capacity_of_solar_pv", as: "MW" } } &mdash;
-              zon PV totaal
+              zon PV(T) totaal
             %li.spacer
             %li
               %span{ data: { query: "factsheet_number_of_roof_water_heater_solar_thermal", precision: "-3" } } &mdash;

--- a/config/interface/slides/data_visuals.yml
+++ b/config/interface/slides/data_visuals.yml
@@ -10,6 +10,7 @@
 - key: data_visuals_energy_mix
   position: 20
   sidebar_item_key: data_visuals
+  dependent_on: has_offshore_solar    # only true for NL regions so energy mix only visible for NL regions
   output_element_key: final_demand_mekko_energetic_mece
 - key: data_visuals_co2_sheet
   position: 30

--- a/config/locales/en_energy_mix.yml
+++ b/config/locales/en_energy_mix.yml
@@ -25,7 +25,7 @@ en:
       factsheet_supply_fossil_other: Fossiel (overig)
       factsheet_supply_gas_from_biogas: Biogas
       factsheet_supply_gas_from_fossil: Aardgas
-      factsheet_supply_gas_from_synthetic_gas: Waterstof import
+      factsheet_supply_gas_from_synthetic_gas: Waterstof
       factsheet_supply_heat_collective: Collectieve warmte
       factsheet_supply_dry_biomass: Droge biomassa
       factsheet_supply_heat_from_other: Warmte (andere bronen)

--- a/config/locales/en_energy_mix.yml
+++ b/config/locales/en_energy_mix.yml
@@ -31,4 +31,4 @@ en:
       factsheet_supply_heat_from_other: Warmte (andere bronen)
       factsheet_supply_heat_from_solar_thermal: Zonthermie
       factsheet_supply_heat_from_ambient: Omgevingswarmte
-      factsheet_supply_heat_from_rest_and_geothermal: Restwarmte en diepe geothermie
+      factsheet_supply_heat_from_rest_and_geothermal: Restwarmte en geothermie

--- a/config/locales/en_energy_mix.yml
+++ b/config/locales/en_energy_mix.yml
@@ -25,7 +25,7 @@ en:
       factsheet_supply_fossil_other: Fossiel (overig)
       factsheet_supply_gas_from_biogas: Biogas
       factsheet_supply_gas_from_fossil: Aardgas
-      factsheet_supply_gas_from_synthetic_gas: Waterstof
+      factsheet_supply_gas_from_synthetic_gas: Waterstof import
       factsheet_supply_heat_collective: Collectieve warmte
       factsheet_supply_dry_biomass: Droge biomassa
       factsheet_supply_heat_from_other: Warmte (andere bronen)

--- a/config/locales/en_energy_mix.yml
+++ b/config/locales/en_energy_mix.yml
@@ -29,6 +29,6 @@ en:
       factsheet_supply_heat_collective: Collectieve warmte
       factsheet_supply_dry_biomass: Droge biomassa
       factsheet_supply_heat_from_other: Warmte (andere bronen)
-      factsheet_supply_heat_from_solar_thermal: Individuele zonthermie
+      factsheet_supply_heat_from_solar_thermal: Zonthermie
       factsheet_supply_heat_from_ambient: Omgevingswarmte
       factsheet_supply_heat_from_rest_and_geothermal: Restwarmte en diepe geothermie

--- a/config/locales/nl_energy_mix.yml
+++ b/config/locales/nl_energy_mix.yml
@@ -28,7 +28,7 @@ nl:
       factsheet_supply_gas_from_synthetic_gas: Waterstof import
       factsheet_supply_heat_collective: Collectieve warmte
       factsheet_supply_dry_biomass: Droge biomassa
-      factsheet_supply_heat_from_other: Warmte (andere bronen)
+      factsheet_supply_heat_from_other: Warmte (andere bronnen)
       factsheet_supply_heat_from_solar_thermal: Zonthermie
       factsheet_supply_heat_from_ambient: Omgevingswarmte
-      factsheet_supply_heat_from_rest_and_geothermal: Restwarmte en diepe geothermie
+      factsheet_supply_heat_from_rest_and_geothermal: Restwarmte en geothermie

--- a/config/locales/nl_energy_mix.yml
+++ b/config/locales/nl_energy_mix.yml
@@ -25,7 +25,7 @@ nl:
       factsheet_supply_fossil_other: Fossiel (overig)
       factsheet_supply_gas_from_biogas: Biogas
       factsheet_supply_gas_from_fossil: Aardgas
-      factsheet_supply_gas_from_synthetic_gas: Waterstof import
+      factsheet_supply_gas_from_synthetic_gas: Waterstof
       factsheet_supply_heat_collective: Collectieve warmte
       factsheet_supply_dry_biomass: Droge biomassa
       factsheet_supply_heat_from_other: Warmte (andere bronen)

--- a/config/locales/nl_energy_mix.yml
+++ b/config/locales/nl_energy_mix.yml
@@ -29,6 +29,6 @@ nl:
       factsheet_supply_heat_collective: Collectieve warmte
       factsheet_supply_dry_biomass: Droge biomassa
       factsheet_supply_heat_from_other: Warmte (andere bronen)
-      factsheet_supply_heat_from_solar_thermal: Individuele zonthermie
+      factsheet_supply_heat_from_solar_thermal: Zonthermie
       factsheet_supply_heat_from_ambient: Omgevingswarmte
       factsheet_supply_heat_from_rest_and_geothermal: Restwarmte en diepe geothermie

--- a/config/locales/nl_energy_mix.yml
+++ b/config/locales/nl_energy_mix.yml
@@ -25,7 +25,7 @@ nl:
       factsheet_supply_fossil_other: Fossiel (overig)
       factsheet_supply_gas_from_biogas: Biogas
       factsheet_supply_gas_from_fossil: Aardgas
-      factsheet_supply_gas_from_synthetic_gas: Waterstof
+      factsheet_supply_gas_from_synthetic_gas: Waterstof import
       factsheet_supply_heat_collective: Collectieve warmte
       factsheet_supply_dry_biomass: Droge biomassa
       factsheet_supply_heat_from_other: Warmte (andere bronen)


### PR DESCRIPTION
The energy mix visual was outdated and is hereby updated. Updating the visual encompasses the following changes:

- Updating underlying queries of 'Opgave per thema 2050' components
- Updating underlying queries of 'Energiebronnen 2050'
- Locales improvements
- Incorporate ETM logo

Goes with:
- https://github.com/quintel/etmodel/pull/4261
- https://github.com/quintel/etsource/pull/3045