### PR TITLE
Fixing broken links

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,7 +328,7 @@ GEM
     minitest (5.22.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)
-    mysql2 (0.5.3)
+    mysql2 (0.5.6)
     net-imap (0.4.10)
       date
       net-protocol

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,7 +328,7 @@ GEM
     minitest (5.22.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)
-    mysql2 (0.5.6)
+    mysql2 (0.5.3)
     net-imap (0.4.10)
       date
       net-protocol

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -600,7 +600,7 @@ en:
   no_scenario_id_error_html:
     Sorry, your scenario cannot be saved at the moment. You can
     <a href="%{previous_path}">go back to your previous page</a> and try
-    again, or <a href="https://energytranstionmodel.com/contact">send us a message</a> if you continue
+    again, or <a href="https://energytransitionmodel.com/contact">send us a message</a> if you continue
     to experience problems.
 
   # Sign-up form

--- a/config/locales/en_landing_page.yml
+++ b/config/locales/en_landing_page.yml
@@ -1,7 +1,7 @@
 en:
   landing_page:
     title: "Create your <em>own</em> Energy Future."
-    explanation: "The <strong>Energy Transition Model</strong> is an independent, comprehensive and fact-based energy model that is used by governments, corporations, NGOs and <a href='http://onderwijs.quintel.nl'>educators</a> in various countries. It is backed by more than <a href='/partners'>20 partners</a>. There are three different versions of the Energy Transition Model."
+    explanation: "The <strong>Energy Transition Model</strong> is an independent, comprehensive and fact-based energy model that is used by governments, corporations, NGOs and educators in various countries. It is backed by more than <a href='/partners'>20 partners</a>. There are three different versions of the Energy Transition Model."
     etflex:
       title: "Light"
       explanation: "A fun <strong>introduction</strong> to the most important energy themes. Will your energy future get the highest score?"

--- a/config/locales/interface/input_elements/en_costs.yml
+++ b/config/locales/interface/input_elements/en_costs.yml
@@ -21,12 +21,12 @@ en:
     costs_hydrogen:
       title: Hydrogen
       short_description:
-      description: |
-        This slider sets the future wholesale price of hydrogen (in €/MWh).
+      description: 
+        "This slider sets the future wholesale price of hydrogen (in €/MWh).
         This slider affects the costs of imported hydrogen and influences the position
         of hydrogen fired gas turbines in the merit order of the electricity market.
         The costs of domestically produced hydrogen are determined by your choices
-        in the <a href="/scenario/supply/hydrogen/hydrogen-production\"\>'hydrogen
+        in the <a href=\"/scenario/supply/hydrogen/hydrogen-production\"\>'hydrogen
         production'</a> section.<br /><br />\r\n\r\nBelow you can find reference values
         for the current costs of some common hydrogen production technologies (in
         €/MWh hydrogen): <br /><br />\r\n<ul>\r\n<li>Steam Methane Reforming (SMR):
@@ -42,7 +42,7 @@ en:
         MWh. <br /> <br />\r\nSources:<br />   \r\n1. Gnanapragasam, N.V. & Rosen
         M.A. (2017). A review of hydrogen production using coal, biomass and other
         solid fuels. In: Biofuels (8), pp.725-745 <br />\r\n2. CE Delft (2018). Waterstofroutes
-        Nederland\r\n
+        Nederland\r\n"
     costs_imported_liquid_hydrogen:
       title: Liquid hydrogen
       short_description:

--- a/config/locales/interface/input_elements/en_costs.yml
+++ b/config/locales/interface/input_elements/en_costs.yml
@@ -25,7 +25,7 @@ en:
         This slider affects the costs of imported hydrogen and influences the position
         of hydrogen fired gas turbines in the merit order of the electricity market.
         The costs of domestically produced hydrogen are determined by your choices
-        in the <a href=\"/scenario/supply/hydrogen/hydrogen-production\">'hydrogen
+        in the <a href=\"/scenario/supply/hydrogen/hydrogen-production\"\>'hydrogen
         production'</a> section.<br /><br />\r\n\r\nBelow you can find reference values
         for the current costs of some common hydrogen production technologies (in
         €/MWh hydrogen): <br /><br />\r\n<ul>\r\n<li>Steam Methane Reforming (SMR):

--- a/config/locales/interface/input_elements/en_costs.yml
+++ b/config/locales/interface/input_elements/en_costs.yml
@@ -21,11 +21,12 @@ en:
     costs_hydrogen:
       title: Hydrogen
       short_description:
-      description: "This slider sets the future wholesale price of hydrogen (in €/MWh).
+      description: |
+        This slider sets the future wholesale price of hydrogen (in €/MWh).
         This slider affects the costs of imported hydrogen and influences the position
         of hydrogen fired gas turbines in the merit order of the electricity market.
         The costs of domestically produced hydrogen are determined by your choices
-        in the <a href=\"/scenario/supply/hydrogen/hydrogen-production\"\>'hydrogen
+        in the <a href="/scenario/supply/hydrogen/hydrogen-production\"\>'hydrogen
         production'</a> section.<br /><br />\r\n\r\nBelow you can find reference values
         for the current costs of some common hydrogen production technologies (in
         €/MWh hydrogen): <br /><br />\r\n<ul>\r\n<li>Steam Methane Reforming (SMR):
@@ -41,7 +42,7 @@ en:
         MWh. <br /> <br />\r\nSources:<br />   \r\n1. Gnanapragasam, N.V. & Rosen
         M.A. (2017). A review of hydrogen production using coal, biomass and other
         solid fuels. In: Biofuels (8), pp.725-745 <br />\r\n2. CE Delft (2018). Waterstofroutes
-        Nederland\r\n"
+        Nederland\r\n
     costs_imported_liquid_hydrogen:
       title: Liquid hydrogen
       short_description:

--- a/config/locales/interface/input_elements/en_costs.yml
+++ b/config/locales/interface/input_elements/en_costs.yml
@@ -21,28 +21,28 @@ en:
     costs_hydrogen:
       title: Hydrogen
       short_description:
-      description: 
-        "This slider sets the future wholesale price of hydrogen (in €/MWh).
+      description: |
+        This slider sets the future wholesale price of hydrogen (in €/MWh).
         This slider affects the costs of imported hydrogen and influences the position
         of hydrogen fired gas turbines in the merit order of the electricity market.
         The costs of domestically produced hydrogen are determined by your choices
-        in the <a href=\"/scenario/supply/hydrogen/hydrogen-production\"\>'hydrogen
-        production'</a> section.<br /><br />\r\n\r\nBelow you can find reference values
+        in the <a href="/scenario/supply/hydrogen/hydrogen-production">Hydrogen
+        production</a> section.<br/><br/>Below you can find reference values
         for the current costs of some common hydrogen production technologies (in
-        €/MWh hydrogen): <br /><br />\r\n<ul>\r\n<li>Steam Methane Reforming (SMR):
-        € 40.5 <sup>1</sup></li>\r\n<li>Steam Methane Reforming (SMR) + CCS: € 46.9
-        <sup>2</sup></li>\r\n<li>Autothermal Reforming (ATR): € 109.6 <sup>1</sup></li>\r\n<li>Coal
-        gasification: € 45.0 <sup>1</sup></li>\r\n<li>Electrolysis (wind): € 273.3
-        <sup>1</sup></li>\r\n<li>Electrolysis (solar): € 747.7 <sup>1</sup></li>\r\n<li>Combined
-        wind and sun (North sea): € 157.4 <sup>2</sup></li>\r\n<li>Combined wind and
-        sun (Morocco): € 124.0 <sup>2</sup></li>\r\n</ul> <br />\r\nNote that the
+        €/MWh hydrogen): <br/><br/><ul><li>Steam Methane Reforming (SMR):
+        € 40.5 <sup>1</sup></li><li>Steam Methane Reforming (SMR) + CCS: € 46.9
+        <sup>2</sup></li><li>Autothermal Reforming (ATR): € 109.6 <sup>1</sup></li><li>Coal
+        gasification: € 45.0 <sup>1</sup></li><li>Electrolysis (wind): € 273.3
+        <sup>1</sup></li><li>Electrolysis (solar): € 747.7 <sup>1</sup></li><li>Combined
+        wind and sun (North sea): € 157.4 <sup>2</sup></li><li>Combined wind and
+        sun (Morocco): € 124.0 <sup>2</sup></li></ul> <br />Note that the
         above numbers are production costs only. To determine the wholesale price
         additional costs have to be taken into account such as transporting hydrogen
         to your area. For tanker ship transport these costs are roughly € 21.0 per
-        MWh. <br /> <br />\r\nSources:<br />   \r\n1. Gnanapragasam, N.V. & Rosen
+        MWh. <br/><br/>Sources:<br/>  1. Gnanapragasam, N.V. & Rosen
         M.A. (2017). A review of hydrogen production using coal, biomass and other
-        solid fuels. In: Biofuels (8), pp.725-745 <br />\r\n2. CE Delft (2018). Waterstofroutes
-        Nederland\r\n"
+        solid fuels. In: Biofuels (8), pp.725-745. <br/> 2. CE Delft (2018). Waterstofroutes
+        Nederland.
     costs_imported_liquid_hydrogen:
       title: Liquid hydrogen
       short_description:

--- a/config/locales/interface/input_elements/en_costs.yml
+++ b/config/locales/interface/input_elements/en_costs.yml
@@ -21,12 +21,11 @@ en:
     costs_hydrogen:
       title: Hydrogen
       short_description:
-      description: |
-        This slider sets the future wholesale price of hydrogen (in €/MWh).
+      description: "This slider sets the future wholesale price of hydrogen (in €/MWh).
         This slider affects the costs of imported hydrogen and influences the position
         of hydrogen fired gas turbines in the merit order of the electricity market.
         The costs of domestically produced hydrogen are determined by your choices
-        in the <a href="/scenario/supply/hydrogen/hydrogen-production\"\>'hydrogen
+        in the <a href=\"/scenario/supply/hydrogen/hydrogen-production\"\>'hydrogen
         production'</a> section.<br /><br />\r\n\r\nBelow you can find reference values
         for the current costs of some common hydrogen production technologies (in
         €/MWh hydrogen): <br /><br />\r\n<ul>\r\n<li>Steam Methane Reforming (SMR):
@@ -42,7 +41,7 @@ en:
         MWh. <br /> <br />\r\nSources:<br />   \r\n1. Gnanapragasam, N.V. & Rosen
         M.A. (2017). A review of hydrogen production using coal, biomass and other
         solid fuels. In: Biofuels (8), pp.725-745 <br />\r\n2. CE Delft (2018). Waterstofroutes
-        Nederland\r\n
+        Nederland\r\n"
     costs_imported_liquid_hydrogen:
       title: Liquid hydrogen
       short_description:

--- a/config/locales/interface/input_elements/en_data_visuals.yml
+++ b/config/locales/interface/input_elements/en_data_visuals.yml
@@ -16,7 +16,7 @@ en:
         The output capacity and full load hours of a large-scale wind turbine are listed in 
         <a href="#" class="open_chart" data-chart-key="land_use_solar_wind" data-chart-location="side">
         this table</a>.
-        Change the total capacity of wind <a href="/scenario/supply/electricity_renewable/wind-turbines\">here</a>.
+        Change the total capacity of wind <a href="/scenario/supply/electricity_renewable/wind-turbines">here</a>.
     land_use_impact_visual_wind_inland_small_scale:
       title: Small-scale inland wind
       description: |
@@ -27,5 +27,4 @@ en:
         The output capacity and full load hours of a large-scale wind turbine are listed in 
         <a href="#" class="open_chart" data-chart-key="land_use_solar_wind" data-chart-location="side">
         this table</a>.
-        Change the total capacity of wind <a href="/scenario/supply/electricity_renewable/wind-turbines\">here</a>.
-        
+        Change the total capacity of wind <a href="/scenario/supply/electricity_renewable/wind-turbines">here</a>.

--- a/config/locales/interface/input_elements/en_data_visuals.yml
+++ b/config/locales/interface/input_elements/en_data_visuals.yml
@@ -16,7 +16,7 @@ en:
         The output capacity and full load hours of a large-scale wind turbine are listed in 
         <a href="#" class="open_chart" data-chart-key="land_use_solar_wind" data-chart-location="side">
         this table</a>.
-        Change the total capacity of wind <a href=\"/scenario/supply/electricity_renewable/wind-turbines\">here</a>.
+        Change the total capacity of wind <a href="/scenario/supply/electricity_renewable/wind-turbines\">here</a>.
     land_use_impact_visual_wind_inland_small_scale:
       title: Small-scale inland wind
       description: |
@@ -27,5 +27,5 @@ en:
         The output capacity and full load hours of a large-scale wind turbine are listed in 
         <a href="#" class="open_chart" data-chart-key="land_use_solar_wind" data-chart-location="side">
         this table</a>.
-        Change the total capacity of wind <a href=\"/scenario/supply/electricity_renewable/wind-turbines\">here</a>.
+        Change the total capacity of wind <a href="/scenario/supply/electricity_renewable/wind-turbines\">here</a>.
         

--- a/config/locales/interface/input_elements/en_demand_buildings.yml
+++ b/config/locales/interface/input_elements/en_demand_buildings.yml
@@ -42,8 +42,8 @@ en:
         The number of new buildings in the scenario can be set 
         <a href="/scenario/demand/buildings/building-stock">here</a>.
         <br><br>
-        Check out the <a href="https://docs.energytransitionmodel.com/main/insulation\" target=\"_blank\">documentation</a>
-        for more information or check out the <a href="https://data.energytransitionmodel.com\" target=\"_blank\">dataset</a> 
+        Check out the <a href=\"https://docs.energytransitionmodel.com/main/insulation\" target=\"_blank\">documentation</a>
+        for more information or check out the <a href=\"https://data.energytransitionmodel.com\" target=\"_blank\">dataset</a> 
         for a description of the data sources.
     buildings_insulation_level_buildings_present:
       title: Present buildings
@@ -61,8 +61,8 @@ en:
         The number of present buildings in the scenario can be set 
         <a href="/scenario/demand/buildings/building-stock">here</a>.
         <br><br>
-        Check out the <a href="https://docs.energytransitionmodel.com/main/insulation\" target=\"_blank\">documentation</a>
-        for more information or check out the <a href="https://data.energytransitionmodel.com\" target=\"_blank\">dataset</a> 
+        Check out the <a href=\"https://docs.energytransitionmodel.com/main/insulation\" target=\"_blank\">documentation</a>
+        for more information or check out the <a href=\"https://data.energytransitionmodel.com\" target=\"_blank\">dataset</a> 
         for a description of the data sources.
     buildings_useful_demand_electricity:
       title: Electricity per building

--- a/config/locales/interface/input_elements/en_demand_buildings.yml
+++ b/config/locales/interface/input_elements/en_demand_buildings.yml
@@ -42,8 +42,8 @@ en:
         The number of new buildings in the scenario can be set 
         <a href="/scenario/demand/buildings/building-stock">here</a>.
         <br><br>
-        Check out the <a href=\"https://docs.energytransitionmodel.com/main/insulation\" target=\"_blank\">documentation</a>
-        for more information or check out the <a href=\"https://data.energytransitionmodel.com\" target=\"_blank\">dataset</a> 
+        Check out the <a href="https://docs.energytransitionmodel.com/main/insulation\" target=\"_blank\">documentation</a>
+        for more information or check out the <a href="https://data.energytransitionmodel.com\" target=\"_blank\">dataset</a> 
         for a description of the data sources.
     buildings_insulation_level_buildings_present:
       title: Present buildings
@@ -61,8 +61,8 @@ en:
         The number of present buildings in the scenario can be set 
         <a href="/scenario/demand/buildings/building-stock">here</a>.
         <br><br>
-        Check out the <a href=\"https://docs.energytransitionmodel.com/main/insulation\" target=\"_blank\">documentation</a>
-        for more information or check out the <a href=\"https://data.energytransitionmodel.com\" target=\"_blank\">dataset</a> 
+        Check out the <a href="https://docs.energytransitionmodel.com/main/insulation\" target=\"_blank\">documentation</a>
+        for more information or check out the <a href="https://data.energytransitionmodel.com\" target=\"_blank\">dataset</a> 
         for a description of the data sources.
     buildings_useful_demand_electricity:
       title: Electricity per building

--- a/config/locales/interface/input_elements/en_flexibility.yml
+++ b/config/locales/interface/input_elements/en_flexibility.yml
@@ -381,13 +381,15 @@ en:
     flexibility_heat_pump_space_heating_cop_cutoff_gas:
       title: Space heating (gas)
       short_description:
-      description: "Here you indicate the threshold COP of hybrid heat pumps for space
-        heating. This applies to both network gas-based and hydrogen-based hybrid heat pumps \r\n<p>\r\n
+      description: |
+        Here you indicate the threshold COP of hybrid heat pumps for space
+        heating. This applies to both network gas-based and hydrogen-based hybrid heat pumps. </br></br> 
         The default setting is that the electric part of the HHP
         is used maximally for space heating. With the current network gas and electricity
         price financial optimization for the user is achieved with a threshold COP
-        of 2.6, this can be concluded from the chart on the right.\r\nFor more information
-        about (hybrid) heat pumps see our <a href=\"https://docs.energytransitionmodel.com/main/heat-pumps\" target=\"_blank\">documentation</a>."
+        of 2.6, this can be concluded from the chart on the right. </br></br>
+        For more information
+        about (hybrid) heat pumps see our <a href="https://docs.energytransitionmodel.com/main/heat-pumps/" target=\"_blank\">documentation</a>.
     flexibility_heat_pump_space_heating_cop_cutoff_crude_oil:
       title: Space heating (oil)
       short_description:
@@ -398,14 +400,15 @@ en:
         is used maximally for space heating. With the current oil and electricity
         price financial optimization for the user is achieved with a threshold COP
         of  3.7. </br></br>
-        For more information about (hybrid) heat pumps see our <a href=\"https://docs.energytransitionmodel.com/main/heat-pumps\" target=\"_blank\">documentation</a>.
+        For more information about (hybrid) heat pumps see our <a href="https://docs.energytransitionmodel.com/main/heat-pumps\" target=\"_blank\">documentation</a>.
     flexibility_heat_pump_water_heating_cop_cutoff:
       title: Hot water
       short_description:
-      description: "Here you indicate the threshold COP of hybrid heat pumps for hot
-        water.\r\n<p>\r\nThe default setting is that the fuel-fired part of the HHP (using network gas, hydrogen or oil) is used
-        for hot water. The threshold COP is therefore set at its maximum value of 6.0 so that the fuel-fired part is always enabled. \r\n<p>\r\n
-        For calculations on the threshold COP see <a href=\"https://docs.energytransitionmodel.com/main/heat-pumps\" target=\"_blank\">documentation</a>"
+      description: |
+        Here you indicate the threshold COP of hybrid heat pumps for hot
+        water. </br></br> The default setting is that the fuel-fired part of the HHP (using network gas, hydrogen or oil) is used
+        for hot water. The threshold COP is therefore set at its maximum value of 6.0 so that the fuel-fired part is always enabled. </br></br>
+        For calculations on the threshold COP see <a href="https://docs.energytransitionmodel.com/main/heat-pumps\" target=\"_blank\">documentation</a>
     households_flexibility_consumer_gas_price:
       title: Gas price
       short_description:

--- a/config/locales/interface/input_elements/en_supply_electricity.yml
+++ b/config/locales/interface/input_elements/en_supply_electricity.yml
@@ -90,10 +90,10 @@ en:
         the local power grid requires a higher capacity or smarter local grid, to
         prevent it from overloading. It may be desirable to curtail the power peaks
         in order to decrease the load on the net, you can set this you can set this 
-        <a href=\"/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">here</a>. <br/><br/>
+        <a href="/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">here</a>. <br/><br/>
         You can adjust the full load hours of solar
-        panels <a href=\"/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >here</a>.
-        The efficiency of solar panels can be adjusted <a href=\"/scenario/costs/specs_renewable_electricity/solar-power\" >here</a>.<br
+        panels <a href="/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >here</a>.
+        The efficiency of solar panels can be adjusted <a href"/scenario/costs/specs_renewable_electricity/solar-power\" >here</a>.<br
         />
     capacity_of_buildings_solar_pv_solar_radiation:
       title: Solar PV buildings
@@ -108,7 +108,7 @@ en:
         on the grid and that saves energy. Feeding locally produced power back into
         the local power grid requires a higher capacity or smarter local grid, to
         prevent it from overloading. It may be desirable to curtail the power peaks
-        in order to decrease the load on the net, you can set this <a href=\"/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">here</a>. 
+        in order to decrease the load on the net, you can set this <a href="/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">here</a>. 
         <br/><br/>
         You can adjust the full load hours of solar
         panels <a href=\"/scenario/costs/specs_renewable_electricity/solar-power\" >here</a>.
@@ -126,10 +126,10 @@ en:
         can be large, because electricity is fed back into the local grid. This may
         require balancing solutions at the local level for the grid. In some cases
         it is smart to connect solar parks to only a certain percentage of the peak
-        power, you can set this <a href=\"/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">here</a>.<br/><br/>
+        power, you can set this <a href="/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">here</a>.<br/><br/>
         You can adjust the full load hours of solar
-        panels <a href=\"/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >here</a>.
-        The efficiency of solar panels can be adjusted <a href=\"/scenario/costs/specs_renewable_electricity/solar-power\" >here</a>.
+        panels <a href="/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >here</a>.
+        The efficiency of solar panels can be adjusted <a href="/scenario/costs/specs_renewable_electricity/solar-power\" >here</a>.
     capacity_of_energy_power_solar_csp_solar_radiation:
       title: Concentrated solar power
       short_description: ''

--- a/config/locales/interface/input_elements/en_supply_electricity.yml
+++ b/config/locales/interface/input_elements/en_supply_electricity.yml
@@ -90,10 +90,10 @@ en:
         the local power grid requires a higher capacity or smarter local grid, to
         prevent it from overloading. It may be desirable to curtail the power peaks
         in order to decrease the load on the net, you can set this you can set this 
-        <a href="/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">here</a>. <br/><br/>
+        <a href=\"/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">here</a>. <br/><br/>
         You can adjust the full load hours of solar
-        panels <a href="/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >here</a>.
-        The efficiency of solar panels can be adjusted <a href"/scenario/costs/specs_renewable_electricity/solar-power\" >here</a>.<br
+        panels <a href=\"/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >here</a>.
+        The efficiency of solar panels can be adjusted <a href=\"/scenario/costs/specs_renewable_electricity/solar-power\" >here</a>.<br
         />
     capacity_of_buildings_solar_pv_solar_radiation:
       title: Solar PV buildings
@@ -108,7 +108,7 @@ en:
         on the grid and that saves energy. Feeding locally produced power back into
         the local power grid requires a higher capacity or smarter local grid, to
         prevent it from overloading. It may be desirable to curtail the power peaks
-        in order to decrease the load on the net, you can set this <a href="/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">here</a>. 
+        in order to decrease the load on the net, you can set this <a href=\"/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">here</a>. 
         <br/><br/>
         You can adjust the full load hours of solar
         panels <a href=\"/scenario/costs/specs_renewable_electricity/solar-power\" >here</a>.
@@ -126,10 +126,10 @@ en:
         can be large, because electricity is fed back into the local grid. This may
         require balancing solutions at the local level for the grid. In some cases
         it is smart to connect solar parks to only a certain percentage of the peak
-        power, you can set this <a href="/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">here</a>.<br/><br/>
+        power, you can set this <a href=\"/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">here</a>.<br/><br/>
         You can adjust the full load hours of solar
-        panels <a href="/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >here</a>.
-        The efficiency of solar panels can be adjusted <a href="/scenario/costs/specs_renewable_electricity/solar-power\" >here</a>.
+        panels <a href=\"/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >here</a>.
+        The efficiency of solar panels can be adjusted <a href=\"/scenario/costs/specs_renewable_electricity/solar-power\" >here</a>.
     capacity_of_energy_power_solar_csp_solar_radiation:
       title: Concentrated solar power
       short_description: ''

--- a/config/locales/interface/input_elements/en_supply_hydrogen.yml
+++ b/config/locales/interface/input_elements/en_supply_hydrogen.yml
@@ -98,9 +98,9 @@ en:
         offshore wind turbines dedicated to hydrogen production and a corresponding
         amount of electrolysis capacity to convert the produced electricity into hydrogen.
         The efficiency of electrolysers can
-        be adjusted <a href=\"/scenario/costs/costs_hydrogen/hydrogen-production\" >here</a>.
+        be adjusted <a href="/scenario/costs/costs_hydrogen/hydrogen-production\" >here</a>.
         You can adjust the full load hours of wind turbines 
-        <a href=\"/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >here</a>
+        <a href="/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >here</a>
         <br/><br/>Note: The technical and financial specifications below are
         only the specifications of the electrolyser, not the wind turbines. The specifications
         of the wind turbines can be found in the <a href="/scenario/supply/electricity_renewable/wind-turbines\">Renewable

--- a/config/locales/interface/input_elements/en_supply_hydrogen.yml
+++ b/config/locales/interface/input_elements/en_supply_hydrogen.yml
@@ -103,7 +103,7 @@ en:
         <a href=\"/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >here</a>
         <br/><br/>Note: The technical and financial specifications below are
         only the specifications of the electrolyser, not the wind turbines. The specifications
-        of the wind turbines can be found in the <a href=\"/scenario/supply/electricity_renewable/wind-turbines\">Renewable
+        of the wind turbines can be found in the <a href="/scenario/supply/electricity_renewable/wind-turbines\">Renewable
         electricity section</a>.<br/>
     capacity_of_energy_hydrogen_solar_pv_solar_radiation:
       title: Solar PV plant for H<sub>2</sub>

--- a/config/locales/interface/input_elements/en_supply_hydrogen.yml
+++ b/config/locales/interface/input_elements/en_supply_hydrogen.yml
@@ -98,9 +98,9 @@ en:
         offshore wind turbines dedicated to hydrogen production and a corresponding
         amount of electrolysis capacity to convert the produced electricity into hydrogen.
         The efficiency of electrolysers can
-        be adjusted <a href="/scenario/costs/costs_hydrogen/hydrogen-production\" >here</a>.
+        be adjusted <a href=\"/scenario/costs/costs_hydrogen/hydrogen-production\" >here</a>.
         You can adjust the full load hours of wind turbines 
-        <a href="/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >here</a>
+        <a href=\"/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >here</a>
         <br/><br/>Note: The technical and financial specifications below are
         only the specifications of the electrolyser, not the wind turbines. The specifications
         of the wind turbines can be found in the <a href="/scenario/supply/electricity_renewable/wind-turbines\">Renewable

--- a/config/locales/interface/input_elements/nl_data_visuals.yml
+++ b/config/locales/interface/input_elements/nl_data_visuals.yml
@@ -16,7 +16,7 @@ nl:
         Het vermogen en de vollasturen van een grootschalige windturbine staan vermeld in 
         <a href="#" class="open_chart" data-chart-key="land_use_solar_wind" data-chart-location="side">
         deze tabel</a>.
-        Verander het totale vermogen wind op land <a href=\"/scenario/supply/electricity_renewable/wind-turbines\">hier</a>.
+        Verander het totale vermogen wind op land <a href="/scenario/supply/electricity_renewable/wind-turbines\">hier</a>.
     land_use_impact_visual_wind_inland_small_scale:
       title: Wind op land (klein)
       description: |
@@ -27,4 +27,4 @@ nl:
         Het vermogen en de vollasturen van een kleinschalige windturbine staan vermeld in 
         <a href="#" class="open_chart" data-chart-key="land_use_solar_wind" data-chart-location="side">
         deze tabel</a>.
-        Verander het totale vermogen wind op land <a href=\"/scenario/supply/electricity_renewable/wind-turbines\">hier</a>.
+        Verander het totale vermogen wind op land <a href="/scenario/supply/electricity_renewable/wind-turbines\">hier</a>.

--- a/config/locales/interface/input_elements/nl_flexibility.yml
+++ b/config/locales/interface/input_elements/nl_flexibility.yml
@@ -409,7 +409,7 @@ nl:
         optimalisatie voor de gebruiker bereikt met een omslag-COP van 3.7.
         </br></br>
         Voor meer informatie over (hybride)
-        warmtepompen zie onze <a href="https://docs.energytransitionmodel.com/main/heat-pumps\"target=\"_blank\">documentatie</a>."
+        warmtepompen zie onze <a href="https://docs.energytransitionmodel.com/main/heat-pumps\"target=\"_blank\">documentatie</a>.
     flexibility_heat_pump_water_heating_cop_cutoff:
       title: Warm water
       short_description:
@@ -418,17 +418,17 @@ nl:
         voor warm water. </br></br> Met de standaardinstelling voor de omslag-COP wordt
         het brandstofdeel van de hybride warmtepomp (op netwerkgas, waterstof of olie) maximaal gebruikt voor verwarmen van
         tapwater. De omslag-COP staat daarom ingesteld op de maximale waarde van 6,0, zodat het brandstofdeel altijd ingeschakeld is voor tapwater.</br></br>
-        Voor meer informatie zie: <a href="https://docs.energytransitionmodel.com/main/heat-pumps\" target=\"_blank\">documentatie</a>
+        Voor meer informatie zie: <a href="https://docs.energytransitionmodel.com/main/heat-pumps\" target=\"_blank\">documentatie</a>.
     households_flexibility_consumer_gas_price:
       title: Gasprijs
       short_description:
-      description: |-
+      description: |
         Het tarief van een m3 gas is in 2020 gemiddeld 81,4 eurocent in Nederland. Daarvan is 32 cent voor het gas zelf (de marktprijs) en 50 cent voor de energiebelasting en de opslag duurzame energie (ODE) (<a href="https://www.milieucentraal.nl/energie-besparen/snel-besparen/grip-op-je-energierekening/energierekening" target="_blank">Milieu Centraal</a>).</br></br>
         Deze slider heeft enkel invloed op de geadviseerde omslag COP in de grafiek rechts en dus niet op andere ETM-berekeningen.
     households_flexibility_consumer_electricity_price:
       title: Elektriciteitsprijs
       short_description:
-      description: |-
+      description: |
         Het tarief van een kWh stroom is in 2020 gemiddeld 22,5 cent in Nederland. Daarvan is 7,5 cent voor de elektriciteit zelf (de marktprijs) en 15 cent voor de energiebelasting en de opslag duurzame energie (ODE) (<a href="https://www.milieucentraal.nl/energie-besparen/snel-besparen/grip-op-je-energierekening/energierekening" target="_blank">Milieu Centraal</a>).</br></br>
         Deze slider heeft enkel invloed op de geadviseerde omslag COP in de grafiek rechts en dus niet op andere ETM-berekeningen
     electricity_interconnector_1_export_availability: &interconnector_export_availability

--- a/config/locales/interface/input_elements/nl_flexibility.yml
+++ b/config/locales/interface/input_elements/nl_flexibility.yml
@@ -390,13 +390,14 @@ nl:
     flexibility_heat_pump_space_heating_cop_cutoff_gas:
       title: Ruimteverwarming (gas)
       short_description:
-      description: "Geef hier aan wat de omslag-COP van hybride warmtepompen op gas is
-        voor ruimteverwarming.\r\n<p>\r\nMet de standaardinstelling voor de omslag-COP
+      description: |
+        Geef hier aan wat de omslag-COP van hybride warmtepompen op gas is
+        voor ruimteverwarming. </br></br> Met de standaardinstelling voor de omslag-COP
         wordt het elektrische deel van de hybride warmtepomp maximaal gebruikt voor
         ruimteverwarming. Met de huidige gas- en elektriciteitsprijs wordt financiële
         optimalisatie voor de gebruiker bereikt met een omslag-COP van 2.6. Dit is
         te zien in de grafiek rechts. Voor meer informatie over (hybride)
-        warmtepompen zie onze <a href=\"https://docs.energytransitionmodel.com/main/heat-pumps\"target=\"_blank\">documentatie</a>."
+        warmtepompen zie onze <a href="https://docs.energytransitionmodel.com/main/heat-pumps\"target=\"_blank\">documentatie</a>.
     flexibility_heat_pump_space_heating_cop_cutoff_crude_oil:
       title: Ruimteverwarming (olie)
       short_description:
@@ -408,15 +409,16 @@ nl:
         optimalisatie voor de gebruiker bereikt met een omslag-COP van 3.7.
         </br></br>
         Voor meer informatie over (hybride)
-        warmtepompen zie onze <a href=\"https://docs.energytransitionmodel.com/main/heat-pumps\"target=\"_blank\">documentatie</a>."
+        warmtepompen zie onze <a href="https://docs.energytransitionmodel.com/main/heat-pumps\"target=\"_blank\">documentatie</a>."
     flexibility_heat_pump_water_heating_cop_cutoff:
       title: Warm water
       short_description:
-      description: "Geef hier aan wat de omslag-COP van het hybride warmtepompen is
-        voor warm water.\r\n<p>\r\nMet de standaardinstelling voor de omslag-COP wordt
+      description: |
+        Geef hier aan wat de omslag-COP van het hybride warmtepompen is
+        voor warm water. </br></br> Met de standaardinstelling voor de omslag-COP wordt
         het brandstofdeel van de hybride warmtepomp (op netwerkgas, waterstof of olie) maximaal gebruikt voor verwarmen van
-        tapwater. De omslag-COP staat daarom ingesteld op de maximale waarde van 6,0, zodat het brandstofdeel altijd ingeschakeld is voor tapwater.\r\n<p>\r\n
-        Voor meer informatie zie: <a href=\"https://docs.energytransitionmodel.com/main/heat-pumps\" target=\"_blank\">documentatie</a>"
+        tapwater. De omslag-COP staat daarom ingesteld op de maximale waarde van 6,0, zodat het brandstofdeel altijd ingeschakeld is voor tapwater.</br></br>
+        Voor meer informatie zie: <a href="https://docs.energytransitionmodel.com/main/heat-pumps\" target=\"_blank\">documentatie</a>
     households_flexibility_consumer_gas_price:
       title: Gasprijs
       short_description:

--- a/config/locales/interface/input_elements/nl_supply_electricity.yml
+++ b/config/locales/interface/input_elements/nl_supply_electricity.yml
@@ -84,10 +84,10 @@ nl:
         te transporteren over het elektriciteitsnet. Zo worden netwerkverliezen vermeden
         en energie bespaard. Stroom die niet wordt gebruikt kan aan het lokale netwerk
         worden teruggeleverd. Het kan wenselijk zijn om de productie te beperken om
-        zo het net te ontlasten, dit kan je <a href=\"/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">hier</a>
+        zo het net te ontlasten, dit kan je <a href="/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">hier</a>
         instellen.<br/><br/>
-        Je kunt het aantal vollasturen van zonnepanelen <a href=\"/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >hier</a> aanpassen.
-        De efficiëntie van zonnepanelen kan <a href=\"/scenario/costs/specs_renewable_electricity/solar-power\" >hier</a> aangepast worden.<br
+        Je kunt het aantal vollasturen van zonnepanelen <a href="/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >hier</a> aanpassen.
+        De efficiëntie van zonnepanelen kan <a href="/scenario/costs/specs_renewable_electricity/solar-power\" >hier</a> aangepast worden.<br
         />
     capacity_of_households_solar_pv_solar_radiation:
       title: Zon op dak huishoudens
@@ -101,10 +101,10 @@ nl:
         te transporteren over het elektriciteitsnet. Zo worden netwerkverliezen vermeden
         en energie bespaard. Stroom die niet wordt gebruikt kan aan het lokale netwerk
         worden teruggeleverd. Het kan wenselijk zijn om de productie te beperken om
-        zo het net te ontlasten, dit kan je <a href=\"/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">hier</a>
+        zo het net te ontlasten, dit kan je <a href="/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">hier</a>
         instellen. <br/><br/>
-        Je kunt het aantal vollasturen van zonnepanelen <a href=\"/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >hier</a> aanpassen.
-        De efficiëntie van zonnepanelen kan <a href=\"/scenario/costs/specs_renewable_electricity/solar-power\" >hier</a> aangepast worden.<br
+        Je kunt het aantal vollasturen van zonnepanelen <a href="/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >hier</a> aanpassen.
+        De efficiëntie van zonnepanelen kan <a href="/scenario/costs/specs_renewable_electricity/solar-power\" >hier</a> aangepast worden.<br
         />
     capacity_of_energy_power_solar_pv_solar_radiation:
       title: Zon op land
@@ -115,10 +115,10 @@ nl:
         beter te voorspellen. Als zeer veel zonnepanelen geïnstalleerd worden, kan
         het nodig zijn om oplossingen te vinden voor onbalans op het laagspanningsnet.
         In sommige gevallen is het slim om zonneparken aan te sluiten op slechts een
-        bepaald percentage van het piekvermogen, dit kan je <a href=\"/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">hier</a>
+        bepaald percentage van het piekvermogen, dit kan je <a href="/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">hier</a>
         instellen.\r\n<br/><br/>
-        Je kunt het aantal vollasturen van zonnepanelen <a href=\"/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >hier</a> aanpassen.
-        De efficiëntie van zonnepanelen kan <a href=\"/scenario/costs/specs_renewable_electricity/solar-power\" >hier </a> aangepast worden.<br
+        Je kunt het aantal vollasturen van zonnepanelen <a href="/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >hier</a> aanpassen.
+        De efficiëntie van zonnepanelen kan <a href="/scenario/costs/specs_renewable_electricity/solar-power\" >hier </a> aangepast worden.<br
         />
     capacity_of_energy_battery_solar_pv_solar_radiation:
       title: Zon op land met batterijsysteem

--- a/config/locales/interface/input_elements/nl_supply_electricity.yml
+++ b/config/locales/interface/input_elements/nl_supply_electricity.yml
@@ -84,10 +84,10 @@ nl:
         te transporteren over het elektriciteitsnet. Zo worden netwerkverliezen vermeden
         en energie bespaard. Stroom die niet wordt gebruikt kan aan het lokale netwerk
         worden teruggeleverd. Het kan wenselijk zijn om de productie te beperken om
-        zo het net te ontlasten, dit kan je <a href="/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">hier</a>
+        zo het net te ontlasten, dit kan je <a href=\"/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">hier</a>
         instellen.<br/><br/>
-        Je kunt het aantal vollasturen van zonnepanelen <a href="/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >hier</a> aanpassen.
-        De efficiëntie van zonnepanelen kan <a href="/scenario/costs/specs_renewable_electricity/solar-power\" >hier</a> aangepast worden.<br
+        Je kunt het aantal vollasturen van zonnepanelen <a href=\"/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >hier</a> aanpassen.
+        De efficiëntie van zonnepanelen kan <a href=\"/scenario/costs/specs_renewable_electricity/solar-power\" >hier</a> aangepast worden.<br
         />
     capacity_of_households_solar_pv_solar_radiation:
       title: Zon op dak huishoudens
@@ -101,10 +101,10 @@ nl:
         te transporteren over het elektriciteitsnet. Zo worden netwerkverliezen vermeden
         en energie bespaard. Stroom die niet wordt gebruikt kan aan het lokale netwerk
         worden teruggeleverd. Het kan wenselijk zijn om de productie te beperken om
-        zo het net te ontlasten, dit kan je <a href="/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">hier</a>
+        zo het net te ontlasten, dit kan je <a href=\"/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">hier</a>
         instellen. <br/><br/>
-        Je kunt het aantal vollasturen van zonnepanelen <a href="/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >hier</a> aanpassen.
-        De efficiëntie van zonnepanelen kan <a href="/scenario/costs/specs_renewable_electricity/solar-power\" >hier</a> aangepast worden.<br
+        Je kunt het aantal vollasturen van zonnepanelen <a href=\"/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >hier</a> aanpassen.
+        De efficiëntie van zonnepanelen kan <a href=\"/scenario/costs/specs_renewable_electricity/solar-power\" >hier</a> aangepast worden.<br
         />
     capacity_of_energy_power_solar_pv_solar_radiation:
       title: Zon op land
@@ -115,10 +115,10 @@ nl:
         beter te voorspellen. Als zeer veel zonnepanelen geïnstalleerd worden, kan
         het nodig zijn om oplossingen te vinden voor onbalans op het laagspanningsnet.
         In sommige gevallen is het slim om zonneparken aan te sluiten op slechts een
-        bepaald percentage van het piekvermogen, dit kan je <a href="/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">hier</a>
+        bepaald percentage van het piekvermogen, dit kan je <a href=\"/scenario/flexibility/flexibility_net_load/curtailment-solar-pv\">hier</a>
         instellen.\r\n<br/><br/>
-        Je kunt het aantal vollasturen van zonnepanelen <a href="/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >hier</a> aanpassen.
-        De efficiëntie van zonnepanelen kan <a href="/scenario/costs/specs_renewable_electricity/solar-power\" >hier </a> aangepast worden.<br
+        Je kunt het aantal vollasturen van zonnepanelen <a href=\"/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >hier</a> aanpassen.
+        De efficiëntie van zonnepanelen kan <a href=\"/scenario/costs/specs_renewable_electricity/solar-power\" >hier </a> aangepast worden.<br
         />
     capacity_of_energy_battery_solar_pv_solar_radiation:
       title: Zon op land met batterijsysteem

--- a/config/locales/interface/input_elements/nl_supply_hydrogen.yml
+++ b/config/locales/interface/input_elements/nl_supply_hydrogen.yml
@@ -98,7 +98,7 @@ nl:
         van windmolens op zee dat ingezet wordt voor waterstofproductie en het benodigde
         vermogen van elektrolyse-installaties om de geproduceerde elektriciteit om
         te zetten in waterstof. De efficiëntie van elektrolysers
-        kan <a href="/scenario/costs/costs_hydrogen/hydrogen-production\" >hier</a> worden aangepast.
+        kan <a href=\"/scenario/costs/costs_hydrogen/hydrogen-production\" >hier</a> worden aangepast.
         Je kunt het aantal vollasturen van windmolens <a href="/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >hier</a> aanpassen. 
         <br /><br>
         Opmerking: De technische en financiële

--- a/config/locales/interface/input_elements/nl_supply_hydrogen.yml
+++ b/config/locales/interface/input_elements/nl_supply_hydrogen.yml
@@ -87,20 +87,23 @@ nl:
     capacity_of_energy_hydrogen_wind_turbine_offshore:
       title: Windmolen op zee voor H<sub>2</sub>
       short_description:
-      description: "Hoeveel windmolens zullen elektriciteit produceren dat direct
-        zal worden omgezet in waterstof met electrolysers?\r\n</br></br>\r\nEr zijn
-        grote ambities voor windparken ver op zee. Voor deze windparken zal
+      description: |
+        Hoeveel windmolens zullen elektriciteit produceren dat direct
+        zal worden omgezet in waterstof met electrolysers?</br></br>
+        Er zijn grote ambities voor windparken ver op zee. Voor deze windparken zal
         het waarschijnlijk economisch haalbaarder zijn om de elektriciteit ter plekke
         om te zetten in waterstof in plaats van de elektriciteit eerst naar land te
         transporteren. Dit heeft te maken met de relatief hoge kosten voor elektriciteitskabels
-        vergeleken met de gaspijpkosten. \r\n</br></br>\r\nDeze schuif zet het vermogen
+        vergeleken met de gaspijpkosten. </br></br> Deze schuif zet het vermogen
         van windmolens op zee dat ingezet wordt voor waterstofproductie en het benodigde
         vermogen van elektrolyse-installaties om de geproduceerde elektriciteit om
         te zetten in waterstof. De efficiëntie van elektrolysers
-        kan <a href=\"/scenario/costs/costs_hydrogen/hydrogen-production\" >hier</a> worden aangepast. Je kunt het aantal vollasturen van windmolens <a href=\"/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >hier</a> aanpassen.<br /><br />\r\n\r\nOpmerking: De technische en financiële
+        kan <a href=\"/scenario/costs/costs_hydrogen/hydrogen-production\" >hier</a> worden aangepast.
+        Je kunt het aantal vollasturen van windmolens <a href="/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >hier</a> aanpassen. 
+        <br /><br>
+        Opmerking: De technische en financiële
         specificaties hieronder zijn alleen voor de elektrolyser, niet voor de windmolens.
-        De specificaties van de windmolens kun je vinden in het tabblad <a href=\"/scenario/supply/electricity_renewable/wind-turbines\">Hernieuwbare
-        elektriciteit</a>.<br />"
+        De specificaties van de windmolens kun je vinden in het tabblad <a href="/scenario/supply/electricity_renewable/wind-turbines\">Hernieuwbare elektriciteit</a>.
     capacity_of_energy_hydrogen_solar_pv_solar_radiation:
       title: Zonnecentrale PV voor H<sub>2</sub>
       short_description:

--- a/config/locales/interface/input_elements/nl_supply_hydrogen.yml
+++ b/config/locales/interface/input_elements/nl_supply_hydrogen.yml
@@ -98,7 +98,7 @@ nl:
         van windmolens op zee dat ingezet wordt voor waterstofproductie en het benodigde
         vermogen van elektrolyse-installaties om de geproduceerde elektriciteit om
         te zetten in waterstof. De efficiëntie van elektrolysers
-        kan <a href=\"/scenario/costs/costs_hydrogen/hydrogen-production\" >hier</a> worden aangepast.
+        kan <a href="/scenario/costs/costs_hydrogen/hydrogen-production\" >hier</a> worden aangepast.
         Je kunt het aantal vollasturen van windmolens <a href="/scenario/flexibility/flexibility_weather/extreme-weather-conditions\" >hier</a> aanpassen. 
         <br /><br>
         Opmerking: De technische en financiële

--- a/config/locales/interface/output_elements/en_flexibility.yml
+++ b/config/locales/interface/output_elements/en_flexibility.yml
@@ -78,7 +78,7 @@ en:
         first conversion unit or one more wind turbine. </li> \r\n<li>Future cost
         reductions of technologies are not taken into account (learning effects and
         economy of scale).</li> \r\n</ul> \r\n\r\nFor a detailed explanation and a
-        complete list of assumptions, have a look at our <a href=\"https://docs.energytransitionmodel.com/main/electricity-storage/\"
+        complete list of assumptions, have a look at our <a href=\"https://docs.energytransitionmodel.com/main/storage\"
         target =\"_blank\">documentation</a>. "
     use_of_excess_electricity:
       title: Use of flexible electricity demand

--- a/config/locales/interface/output_elements/en_flexibility.yml
+++ b/config/locales/interface/output_elements/en_flexibility.yml
@@ -78,7 +78,7 @@ en:
         first conversion unit or one more wind turbine. </li> \r\n<li>Future cost
         reductions of technologies are not taken into account (learning effects and
         economy of scale).</li> \r\n</ul> \r\n\r\nFor a detailed explanation and a
-        complete list of assumptions, have a look at our <a href=\"https://docs.energytransitionmodel.com/main/storage\"
+        complete list of assumptions, have a look at our <a href=\"https://docs.energytransitionmodel.com/main/electricity-storage/\"
         target =\"_blank\">documentation</a>. "
     use_of_excess_electricity:
       title: Use of flexible electricity demand

--- a/config/locales/interface/output_elements/en_supply.yml
+++ b/config/locales/interface/output_elements/en_supply.yml
@@ -344,7 +344,7 @@ en:
         This table shows the electricity production, technical parameters and land use of all solar and wind technologies.
         Onshore inland wind production can be manually split into large-scale and small-scale turbines. 
         You can set the share of each type of turbine in the 
-        <a href="scenario/data/data_visuals/data/data_visuals/land-use-of-solar-and-wind-energy-supply"> Land use of solar and wind </a> section.
+        <a href="scenario/data/data_visuals/data/land-use-of-solar-and-wind-energy-supply"> Land use of solar and wind </a> section.
         Please note that the split between large-scale and small-scale wind turbines is for visual purposes only.
     land_use_solar_wind_chart:
       title: Land use of solar and wind (chart)

--- a/config/locales/interface/output_elements/nl_flexibility.yml
+++ b/config/locales/interface/output_elements/nl_flexibility.yml
@@ -58,7 +58,7 @@ nl:
         conversie eenheid of een extra wind turbine te plaatsen.</li>\r\n<li>Toekomstige
         kostendalingen van de verschillende technologieën worden niet in ogenschouw
         genomen (leereffecten en schaalvoordelen).</li>\r\n</ul> \r\n\r\nVoor een
-        gedetailleerde uitleg en een complete lijst van aannames, kunt u onze <a href=\"https://docs.energytransitionmodel.com/main/storage\"
+        gedetailleerde uitleg en een complete lijst van aannames, kunt u onze <a href=\"https://docs.energytransitionmodel.com/main/electricity-storage/\"
         target =\"_blank\">documentatie</a> bekijken. "
     use_of_excess_electricity:
       title: Gebruik van flexibele elektriciteitsvraag

--- a/config/locales/interface/output_elements/nl_flexibility.yml
+++ b/config/locales/interface/output_elements/nl_flexibility.yml
@@ -58,7 +58,7 @@ nl:
         conversie eenheid of een extra wind turbine te plaatsen.</li>\r\n<li>Toekomstige
         kostendalingen van de verschillende technologieën worden niet in ogenschouw
         genomen (leereffecten en schaalvoordelen).</li>\r\n</ul> \r\n\r\nVoor een
-        gedetailleerde uitleg en een complete lijst van aannames, kunt u onze <a href=\"https://docs.energytransitionmodel.com/main/electricity-storage/\"
+        gedetailleerde uitleg en een complete lijst van aannames, kunt u onze <a href=\"https://docs.energytransitionmodel.com/main/storage\"
         target =\"_blank\">documentatie</a> bekijken. "
     use_of_excess_electricity:
       title: Gebruik van flexibele elektriciteitsvraag

--- a/config/locales/interface/output_elements/nl_supply.yml
+++ b/config/locales/interface/output_elements/nl_supply.yml
@@ -346,7 +346,7 @@ nl:
         Deze tabel toont de elektriciteitsproductie, technische parameters en landgebruik van alle opwek uit zon en wind.
         De opwek van wind op land kan handmatig onderverdeeld worden in grootschalige en kleinschalige turbines.
         Het aandeel van deze typen turbines kun je instellen in de 
-        <a href="scenario/data/data_visuals/data/data_visuals/land-use-of-solar-and-wind-energy-supply"> Ruimtegebruik van zon en wind </a> sectie.
+        <a href="scenario/data/data_visuals/land-use-of-solar-and-wind-energy-supply"> Ruimtegebruik van zon en wind </a> sectie.
         Let op: de onderverdeling tussen grootschalig en kleinschalige wind op land heeft alleen een visuele functie. 
         Deze onderverdeling heeft geen verdere invloed op jouw scenario.
     land_use_solar_wind_chart:

--- a/config/locales/interface/slides/en_data.yml
+++ b/config/locales/interface/slides/en_data.yml
@@ -23,7 +23,7 @@ en:
         installed capacities of power plants and characteristics of the region such as the population size,
         number of houses, roof surface suitable for solar panels etc.
       country_description: |
-        When possible, we use open source energy balances from <a href="https://ec.europa.eu/eurostat/databrowser/view/nrg_bal_c/default/table?lang=en&category=nrg.nrg_quant.nrg_quanta.nrg_bal"target="_blank">Eurostat</a> as a
+        When possible, we use open source energy balances from <a href="https://doi.org/10.2908/NRG_BAL_C"target="_blank">Eurostat</a> as a
         basis for our country datasets. Additionally, analyses are performed
         to provide any additonal data that is required to create a complete dataset. These analyses can be found on
         <a href="https://github.com/quintel/etdataset-public/tree/master/source_analyses"target="_blank">this GitHub page</a>, in separate folders per country.

--- a/config/locales/interface/slides/en_data.yml
+++ b/config/locales/interface/slides/en_data.yml
@@ -23,7 +23,7 @@ en:
         installed capacities of power plants and characteristics of the region such as the population size,
         number of houses, roof surface suitable for solar panels etc.
       country_description: |
-        When possible, we use open source energy balances from <a href="https://ec.europa.eu/eurostat/web/energy/data/energy-balances"target="_blank">Eurostat</a> as a
+        When possible, we use open source energy balances from <a href="https://ec.europa.eu/eurostat/databrowser/view/nrg_bal_c/default/table?lang=en&category=nrg.nrg_quant.nrg_quanta.nrg_bal"target="_blank">Eurostat</a> as a
         basis for our country datasets. Additionally, analyses are performed
         to provide any additonal data that is required to create a complete dataset. These analyses can be found on
         <a href="https://github.com/quintel/etdataset-public/tree/master/source_analyses"target="_blank">this GitHub page</a>, in separate folders per country.
@@ -291,7 +291,7 @@ en:
         <b> Note: </b> Solar PVT panels and solar thermal panels are included in the chart and table. 
         The ETM considers PVT panels (and solar thermal panels) primarily as a heating technology in combination with a heat pump.
         To adjust the share of a PVT heat pump system for space heating and hot water or to adjust the number of solar thermal panels, go to the 
-        <a href="/scenario/demand/households/demand/households/space-heating-and-hot-water">
+        <a href="/scenario/demand/households/space-heating-and-hot-water">
         Households space heating and hot water</a> section. 
     flexibility_merit_order_merit_order_price:
       title: Hourly curves for electricity

--- a/config/locales/interface/slides/en_data.yml
+++ b/config/locales/interface/slides/en_data.yml
@@ -23,7 +23,7 @@ en:
         installed capacities of power plants and characteristics of the region such as the population size,
         number of houses, roof surface suitable for solar panels etc.
       country_description: |
-        When possible, we use open source energy balances from <a href="https://ec.europa.eu/eurostat/databrowser/view/nrg_bal_c/default/table?lang=en&category=nrg.nrg_quant.nrg_quanta.nrg_bal"target="_blank">Eurostat</a> as a
+        When possible, we use open source energy balances from <a href="https://ec.europa.eu/eurostat/web/energy/data/energy-balances"target="_blank">Eurostat</a> as a
         basis for our country datasets. Additionally, analyses are performed
         to provide any additonal data that is required to create a complete dataset. These analyses can be found on
         <a href="https://github.com/quintel/etdataset-public/tree/master/source_analyses"target="_blank">this GitHub page</a>, in separate folders per country.
@@ -291,7 +291,7 @@ en:
         <b> Note: </b> Solar PVT panels and solar thermal panels are included in the chart and table. 
         The ETM considers PVT panels (and solar thermal panels) primarily as a heating technology in combination with a heat pump.
         To adjust the share of a PVT heat pump system for space heating and hot water or to adjust the number of solar thermal panels, go to the 
-        <a href="/scenario/demand/households/space-heating-and-hot-water">
+        <a href="/scenario/demand/households/demand/households/space-heating-and-hot-water">
         Households space heating and hot water</a> section. 
     flexibility_merit_order_merit_order_price:
       title: Hourly curves for electricity

--- a/config/locales/interface/slides/en_demand.yml
+++ b/config/locales/interface/slides/en_demand.yml
@@ -398,7 +398,7 @@ en:
       description: Currently emissions from international transport are not included
         in national energy statistics, since it is complex to decide to which country
         they should be allocated. However, international aviation and navigation are
-        responsible for more than 4.5% of the global GHG emissions (<a href="https://ec.europa.eu/clima/policies/transport_en">EC
+        responsible for more than 4.5% of the global GHG emissions (<a href="https://climate.ec.europa.eu/eu-action/transport_en">EC
         Climate Action</a>). Insight in the energy demand is needed in this sector
         in order to take measures reducing their emissions. Therefore, in this model
         it is possible to include international aviation and navigation to a desired

--- a/config/locales/interface/slides/en_demand.yml
+++ b/config/locales/interface/slides/en_demand.yml
@@ -398,7 +398,7 @@ en:
       description: Currently emissions from international transport are not included
         in national energy statistics, since it is complex to decide to which country
         they should be allocated. However, international aviation and navigation are
-        responsible for more than 4.5% of the global GHG emissions (<a href="https://climate.ec.europa.eu/eu-action/transport_en">EC
+        responsible for more than 4.5% of the global GHG emissions (<a href="https://ec.europa.eu/clima/policies/transport_en">EC
         Climate Action</a>). Insight in the energy demand is needed in this sector
         in order to take measures reducing their emissions. Therefore, in this model
         it is possible to include international aviation and navigation to a desired

--- a/config/locales/interface/slides/en_emissions.yml
+++ b/config/locales/interface/slides/en_emissions.yml
@@ -94,8 +94,8 @@ en:
       description: |
         In some scenarios hydrogen carriers and/or ammonia will be imported from outside your
         region. This depends on how much you choose to produce locally in the
-        <a href="/scenario/supply/hydrogen/hydrogen-production\">Hydrogen production</a>
-        and <a href="/scenario/supply/hydrogen/ammonia-production\">Ammonia production</a>
+        <a href=\"/scenario/supply/hydrogen/hydrogen-production\">Hydrogen production</a>
+        and <a href=\"/scenario/supply/hydrogen/ammonia-production\">Ammonia production</a>
         tabs. The production and distribution of imported hydrogen could have caused
         CO<sub>2</sub> emissions elsewhere. How much of these emissions do you want
         to attribute to your region?

--- a/config/locales/interface/slides/en_emissions.yml
+++ b/config/locales/interface/slides/en_emissions.yml
@@ -94,8 +94,8 @@ en:
       description: |
         In some scenarios hydrogen carriers and/or ammonia will be imported from outside your
         region. This depends on how much you choose to produce locally in the
-        <a href=\"/scenario/supply/hydrogen/hydrogen-production\">Hydrogen production</a>
-        and <a href=\"/scenario/supply/hydrogen/ammonia-production\">Ammonia production</a>
+        <a href="/scenario/supply/hydrogen/hydrogen-production\">Hydrogen production</a>
+        and <a href="/scenario/supply/hydrogen/ammonia-production\">Ammonia production</a>
         tabs. The production and distribution of imported hydrogen could have caused
         CO<sub>2</sub> emissions elsewhere. How much of these emissions do you want
         to attribute to your region?

--- a/config/locales/interface/slides/nl_data.yml
+++ b/config/locales/interface/slides/nl_data.yml
@@ -22,7 +22,7 @@ nl:
         geïnstalleerd vermogen van elektriciteitscentrales en karakteristieken van de regio zoals het aantal inwoners,
         het aantal huizen, het dakoppervlak dat geschikt is voor zonnepanelen etc.
       country_description: |
-        Wanneer mogelijk gebruiken we de open-source energiebalansen van <a href="https://ec.europa.eu/eurostat/databrowser/view/nrg_bal_c/default/table?lang=en&category=nrg.nrg_quant.nrg_quanta.nrg_bal"target="_blank">Eurostat</a> als basis
+        Wanneer mogelijk gebruiken we de open-source energiebalansen van <a href="https://ec.europa.eu/eurostat/web/energy/data/energy-balances"target="_blank">Eurostat</a> als basis
         voor onze landelijke datasets. Daarnaast worden analyses gedaan om alle aanvullende data te leveren die nodig is om een complete dataset te
         maken. Deze analyses zijn te vinden op <a href="https://github.com/quintel/etdataset-public/tree/master/source_analyses"target="_blank">
         deze GitHub pagina</a>, in aparte mappen per land. In de toekomst willen we de transparantie naar onze gebruikers vergroten door landelijke
@@ -299,7 +299,7 @@ nl:
         <b> Opmerking: </b> PVT-panelen voor huishoudens en zonthermische panelen zijn ook opgenomen in de figuur en tabel. 
         Het ETM beschouwt PVT-panelen (en zonthermische panelen) hoofdzakelijk als een verwarmingstechnologie in combinatie met een warmtepomp.
         Het aandeel van een PVT-warmtepomp in de ruimteverwarming en warm water alsmede de hoeveelheid zonthermische panelen is aan te passen in de 
-        <a href="/scenario/demand/households/space-heating-and-hot-water">
+        <a href="/scenario/demand/households/demand/households/space-heating-and-hot-water">
         desbetreffende sectie</a>.  
     flexibility_merit_order_merit_order_price:
       title: Uurlijkse profielen voor elektriciteit

--- a/config/locales/interface/slides/nl_data.yml
+++ b/config/locales/interface/slides/nl_data.yml
@@ -22,7 +22,7 @@ nl:
         geïnstalleerd vermogen van elektriciteitscentrales en karakteristieken van de regio zoals het aantal inwoners,
         het aantal huizen, het dakoppervlak dat geschikt is voor zonnepanelen etc.
       country_description: |
-        Wanneer mogelijk gebruiken we de open-source energiebalansen van <a href="https://ec.europa.eu/eurostat/databrowser/view/nrg_bal_c/default/table?lang=en&category=nrg.nrg_quant.nrg_quanta.nrg_bal"target="_blank">Eurostat</a> als basis
+        Wanneer mogelijk gebruiken we de open-source energiebalansen van <a href="https://doi.org/10.2908/NRG_BAL_C"target="_blank">Eurostat</a> als basis
         voor onze landelijke datasets. Daarnaast worden analyses gedaan om alle aanvullende data te leveren die nodig is om een complete dataset te
         maken. Deze analyses zijn te vinden op <a href="https://github.com/quintel/etdataset-public/tree/master/source_analyses"target="_blank">
         deze GitHub pagina</a>, in aparte mappen per land. In de toekomst willen we de transparantie naar onze gebruikers vergroten door landelijke

--- a/config/locales/interface/slides/nl_data.yml
+++ b/config/locales/interface/slides/nl_data.yml
@@ -22,7 +22,7 @@ nl:
         geïnstalleerd vermogen van elektriciteitscentrales en karakteristieken van de regio zoals het aantal inwoners,
         het aantal huizen, het dakoppervlak dat geschikt is voor zonnepanelen etc.
       country_description: |
-        Wanneer mogelijk gebruiken we de open-source energiebalansen van <a href="https://ec.europa.eu/eurostat/web/energy/data/energy-balances"target="_blank">Eurostat</a> als basis
+        Wanneer mogelijk gebruiken we de open-source energiebalansen van <a href="https://ec.europa.eu/eurostat/databrowser/view/nrg_bal_c/default/table?lang=en&category=nrg.nrg_quant.nrg_quanta.nrg_bal"target="_blank">Eurostat</a> als basis
         voor onze landelijke datasets. Daarnaast worden analyses gedaan om alle aanvullende data te leveren die nodig is om een complete dataset te
         maken. Deze analyses zijn te vinden op <a href="https://github.com/quintel/etdataset-public/tree/master/source_analyses"target="_blank">
         deze GitHub pagina</a>, in aparte mappen per land. In de toekomst willen we de transparantie naar onze gebruikers vergroten door landelijke
@@ -299,7 +299,7 @@ nl:
         <b> Opmerking: </b> PVT-panelen voor huishoudens en zonthermische panelen zijn ook opgenomen in de figuur en tabel. 
         Het ETM beschouwt PVT-panelen (en zonthermische panelen) hoofdzakelijk als een verwarmingstechnologie in combinatie met een warmtepomp.
         Het aandeel van een PVT-warmtepomp in de ruimteverwarming en warm water alsmede de hoeveelheid zonthermische panelen is aan te passen in de 
-        <a href="/scenario/demand/households/demand/households/space-heating-and-hot-water">
+        <a href="/scenario/demand/households/space-heating-and-hot-water">
         desbetreffende sectie</a>.  
     flexibility_merit_order_merit_order_price:
       title: Uurlijkse profielen voor elektriciteit

--- a/config/locales/interface/slides/nl_demand.yml
+++ b/config/locales/interface/slides/nl_demand.yml
@@ -392,7 +392,7 @@ nl:
         energiestatistieken, omdat het complex is om emissies hiervan toe te wijzen
         aan een specifiek land. Internationale lucht- en scheepvaart zijn echter wel
         verantwoordelijk voor meer dan 4.5% van de wereldwijde uitstoot van broeikasgassen
-        (<a href="https://ec.europa.eu/clima/policies/transport_en">EC Climate Action</a>).
+        (<a href="https://climate.ec.europa.eu/eu-action/transport_en">EC Climate Action</a>).
         Om emissiereductiemaatregelen te kunnen nemen is inzicht nodig in dit energiegebruik.
         Daarom kun je hier kiezen welk percentage van de internationale lucht- en
         scheepvaart je mee wilt laten tellen.

--- a/config/locales/interface/slides/nl_demand.yml
+++ b/config/locales/interface/slides/nl_demand.yml
@@ -392,7 +392,7 @@ nl:
         energiestatistieken, omdat het complex is om emissies hiervan toe te wijzen
         aan een specifiek land. Internationale lucht- en scheepvaart zijn echter wel
         verantwoordelijk voor meer dan 4.5% van de wereldwijde uitstoot van broeikasgassen
-        (<a href="https://climate.ec.europa.eu/eu-action/transport_en">EC Climate Action</a>).
+        (<a href="https://ec.europa.eu/clima/policies/transport_en">EC Climate Action</a>).
         Om emissiereductiemaatregelen te kunnen nemen is inzicht nodig in dit energiegebruik.
         Daarom kun je hier kiezen welk percentage van de internationale lucht- en
         scheepvaart je mee wilt laten tellen.

--- a/config/locales/interface/slides/nl_emissions.yml
+++ b/config/locales/interface/slides/nl_emissions.yml
@@ -90,8 +90,8 @@ nl:
       description: |
         In sommige scenario's worden er waterstofdragers en/of ammoniak geïmporteerd van buiten
         jouw gebied. Hoeveel er geïmporteerd wordt, hangt af van jouw keuzes in de tabbladen 
-        <a href="/scenario/supply/hydrogen/hydrogen-production\">Waterstofproductie</a> en 
-        <a href="/scenario/supply/hydrogen/ammonia-production\">Ammoniakproductie</a>.
+        <a href=\"/scenario/supply/hydrogen/hydrogen-production\">Waterstofproductie</a> en 
+        <a href=\"/scenario/supply/hydrogen/ammonia-production\">Ammoniakproductie</a>.
         De productie en distributie van geïmporteerde waterstof en ammoniak kunnen 
         CO<sub>2</sub>-emissies hebben veroorzaakt. Hoeveel van deze emissies wil je toekennen 
         aan jouw gebied?

--- a/config/locales/interface/slides/nl_emissions.yml
+++ b/config/locales/interface/slides/nl_emissions.yml
@@ -90,8 +90,8 @@ nl:
       description: |
         In sommige scenario's worden er waterstofdragers en/of ammoniak geïmporteerd van buiten
         jouw gebied. Hoeveel er geïmporteerd wordt, hangt af van jouw keuzes in de tabbladen 
-        <a href=\"/scenario/supply/hydrogen/hydrogen-production\">Waterstofproductie</a> en 
-        <a href=\"/scenario/supply/hydrogen/ammonia-production\">Ammoniakproductie</a>.
+        <a href="/scenario/supply/hydrogen/hydrogen-production\">Waterstofproductie</a> en 
+        <a href="/scenario/supply/hydrogen/ammonia-production\">Ammoniakproductie</a>.
         De productie en distributie van geïmporteerde waterstof en ammoniak kunnen 
         CO<sub>2</sub>-emissies hebben veroorzaakt. Hoeveel van deze emissies wil je toekennen 
         aan jouw gebied?

--- a/config/locales/interface/slides/nl_supply.yml
+++ b/config/locales/interface/slides/nl_supply.yml
@@ -261,7 +261,7 @@ nl:
       description: |
         Hoeveel windenergie zal er geproduceerd worden?
         De vollasturen voor wind en zon kunnen worden ingesteld in bij
-        <a href="/scenario/flexibility/flexibility_weather/extreme-weather-conditions\">
+        <a href=\"/scenario/flexibility/flexibility_weather/extreme-weather-conditions\">
         'Weersomstandigheden'</a>.
     supply_electricity_renewable_hydrogen_plants:
       title: Waterstofcentrales

--- a/config/locales/interface/slides/nl_supply.yml
+++ b/config/locales/interface/slides/nl_supply.yml
@@ -261,7 +261,7 @@ nl:
       description: |
         Hoeveel windenergie zal er geproduceerd worden?
         De vollasturen voor wind en zon kunnen worden ingesteld in bij
-        <a href=\"/scenario/flexibility/flexibility_weather/extreme-weather-conditions\">
+        <a href="/scenario/flexibility/flexibility_weather/extreme-weather-conditions\">
         'Weersomstandigheden'</a>.
     supply_electricity_renewable_hydrogen_plants:
       title: Waterstofcentrales

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -612,7 +612,7 @@ nl:
   no_scenario_id_error_html:
     Sorry, your scenario cannot be saved at the moment. You can
     <a href="%{previous_path}">go back to your previous page</a> and try
-    again, or <a href="https://energytranstionmodel.com/contact">send us a message</a> if you continue
+    again, or <a href="https://energytransitionmodel.com/contact">send us a message</a> if you continue
     to experience problems.
 
   # Sign-up form

--- a/config/locales/nl_landing_page.yml
+++ b/config/locales/nl_landing_page.yml
@@ -1,7 +1,7 @@
 nl:
   landing_page:
     title: "Maak je <em>eigen</em> Energietoekomst."
-    explanation: "Het <strong>Energietransitiemodel</strong> is een onafhankelijk, uitgebreid, en op feiten gebaseerd energiemodel dat wordt gebruikt door overheden, bedrijven, NGO's en <a href='http://onderwijs.quintel.nl'>onderwijsinstellingen</a> in verschillende landen. Het wordt ondersteund door meer dan <a href='/partners'>20 partners</a>. Er zijn drie verschillende versies van het Energietransitiemodel."
+    explanation: "Het <strong>Energietransitiemodel</strong> is een onafhankelijk, uitgebreid, en op feiten gebaseerd energiemodel dat wordt gebruikt door overheden, bedrijven, NGO's en onderwijsinstellingen in verschillende landen. Het wordt ondersteund door meer dan <a href='/partners'>20 partners</a>. Er zijn drie verschillende versies van het Energietransitiemodel."
     etflex:
       title: "Light"
       explanation: "Een leuke <strong>inleiding</strong> tot de belangrijkste energiethema's. Kun jij de hoogste score halen met jouw energietoekomst?"


### PR DESCRIPTION
This PR aims to remove the broken links within ETModel.
Most broken links existed because of the two ways slidertexts can be written in the model: with or without the "|" at the start. 
While writing a slider text without the "|" it is necessary to put a "\" before the url. The link will break when a "|" is put before the text. 
Thus, this PR primarily focused on fixing these links.