### PR TITLE
Changed locales of hydrogen costs to levelised costs of hydrogen

### DIFF
--- a/config/locales/interface/output_element_series/en_labels.yml
+++ b/config/locales/interface/output_element_series/en_labels.yml
@@ -857,7 +857,7 @@ en:
         hydrogen_lohc: "LOHC"
         hydrogen_production_inflexible: "Must-run and volatile hydrogen production"
         hydrogen_demand_inflexible : 'Baseload hydrogen demand'
-        hydrogen_production_cost_curve: "Hydrogen costs per hour"
+        hydrogen_production_cost_curve: "Levelises costs of hydrogen per hour"
         energy_hydrogen_biomass_gasification: "Biomass gasification"
         energy_hydrogen_biomass_gasification_ccs: "Biomass gasification + CCS"
         energy_hydrogen_electrolysis_solar_electricity: "Solar PV plant for H2"

--- a/config/locales/interface/output_element_series/en_labels.yml
+++ b/config/locales/interface/output_element_series/en_labels.yml
@@ -857,7 +857,7 @@ en:
         hydrogen_lohc: "LOHC"
         hydrogen_production_inflexible: "Must-run and volatile hydrogen production"
         hydrogen_demand_inflexible : 'Baseload hydrogen demand'
-        hydrogen_production_cost_curve: "Levelises costs of hydrogen per hour"
+        hydrogen_production_cost_curve: "Levelised costs of hydrogen per hour"
         energy_hydrogen_biomass_gasification: "Biomass gasification"
         energy_hydrogen_biomass_gasification_ccs: "Biomass gasification + CCS"
         energy_hydrogen_electrolysis_solar_electricity: "Solar PV plant for H2"

--- a/config/locales/interface/output_element_series/nl_labels.yml
+++ b/config/locales/interface/output_element_series/nl_labels.yml
@@ -900,7 +900,7 @@ nl:
         hydrogen_import: "Waterstof import"
         hydrogen_export: "Waterstof export"
         hydrogen_production: "Waterstofproductie"
-        hydrogen_production_cost_curve: "Uurlijkse waterstofkosten"
+        hydrogen_production_cost_curve: "Integrale waterstofproductiekosten per uur"
         hydrogen_ships: "Waterstofschepen"
         hydrogen_storage: "Waterstofopslag"
         hydrogen_storage_input: "Waterstof naar opslag"

--- a/config/locales/interface/output_elements/en_supply.yml
+++ b/config/locales/interface/output_elements/en_supply.yml
@@ -245,18 +245,18 @@ en:
         in the scenario are depicted to have production costs of 0 €/MWh. In reality, the production costs per MWh are infinite since 
         there is no hydrogen production by this technology.
     hydrogen_production_cost_curve:
-      title: Costs of hydrogen production per hour
+      title: Levelised costs of hydrogen production per hour
       short_description:
       description: |
-        this graph shows the weighted average production costs in €/MWh for each hour of the year.
+        This graph shows the levelised costs of hydrogen production in €/MWh for each hour of the year.
         The larger the area of a certain production method, the more influence it has on the average production costs of that hour.
         </br></br>
-        Please note: These are not the market prices of the hydrogne market, since the ETM does not model the hydrogen market.
+        Please note: these are not the market prices of the hydrogen market since the ETM does not model hydrogen market prices.
         </br></br>
         It can be useful to compare this graph with the <a href="#" class="open_chart" data-chart-key="hydrogen_production" data-chart-location="side">
         Hydrogen production</a> graph to get a better understanding of the cost dynamic of the production method.
         </br></br>
-        Alternatively, you can download the Hydrogen integral costs export, which can be found <a href="/scenario/data/data_export/hourly-curves-for-hydrogen">here</a>, 
+        Alternatively, you can download the Levelised costs of hydrogen production export, which can be found <a href="/scenario/data/data_export/hourly-curves-for-hydrogen">here</a>, 
         for more information. 
     mekko_of_kerosene_demand_supply:
       title: Supply and demand of kerosene

--- a/config/locales/interface/output_elements/en_supply.yml
+++ b/config/locales/interface/output_elements/en_supply.yml
@@ -248,7 +248,7 @@ en:
       title: Levelised costs of hydrogen production per hour
       short_description:
       description: |
-        This graph shows the levelised costs of hydrogen production in €/MWh for each hour of the year.
+        This graph shows the average levelised costs of hydrogen production in €/MWh for each hour of the year.
         The larger the area of a certain production method, the more influence it has on the average production costs of that hour.
         </br></br>
         Please note: these are not the market prices of the hydrogen market since the ETM does not model hydrogen market prices.

--- a/config/locales/interface/output_elements/nl_supply.yml
+++ b/config/locales/interface/output_elements/nl_supply.yml
@@ -210,17 +210,17 @@ nl:
         Deze grafiek toont de waterstofopslagvolumes van zoutcavernes en lege gasvelden gedurende het jaar. 
         De opslagvolumes kunnen op jaarbasis, per maand of per week worden bekeken.
     hydrogen_production_cost_curve:
-      title: Waterstofproductiekosten per uur
+      title: Integrale waterstofproductiekosten per uur
       short_description:
       description: |
-        Deze grafiek toont de gewogen gemiddelde productiekosten in €/MWh voor elk uur van het jaar. 
+        Deze grafiek toont de integrale waterstofproductiekosten (<i>levelised costs of hydrogen production</i>) in €/MWh voor elk uur van het jaar. 
         Hoe groter het oppervlak van een bepaalde productiemethode, hoe meer invloed het heeft op de gemiddelde productiekosten van dat uur. 
         </br></br>
-        Let op: Dit zijn niet de marktprijzen van de waterstofmarkt, aangezien het ETM de waterstofmarkt niet modelleert.
+        Let op: dit zijn niet de marktprijzen van de waterstofmarkt, aangezien het ETM de prijzen op de waterstofmarkt niet modelleert.
         </br></br>
         Het kan nuttig zijn om deze grafiek te vergelijken met de <a href="#" class="open_chart" data-chart-key="hydrogen_production" data-chart-location="side">
         Waterstofproductie</a> grafiek om een beter begrip te krijgen van de kostendynamiek van de productiemethodes.</br></br>
-        Ook kan je de export van integrale kosten waterstof downloaden, die <a href="/scenario/data/data_export/hourly-curves-for-hydrogen">hier</a> te vinden is, voor meer informatie.
+        Ook kan je de export van de integrale kosten van waterstof downloaden, die <a href="/scenario/data/data_export/hourly-curves-for-hydrogen">hier</a> te vinden is, voor meer informatie.
     co2_intensity_of_hydrogen_production:
       title: CO<sub>2</sub>-intensiteit per type waterstofproductie
       short_description:

--- a/config/locales/interface/output_elements/nl_supply.yml
+++ b/config/locales/interface/output_elements/nl_supply.yml
@@ -213,7 +213,7 @@ nl:
       title: Integrale waterstofproductiekosten per uur
       short_description:
       description: |
-        Deze grafiek toont de integrale waterstofproductiekosten (<i>levelised costs of hydrogen production</i>) in €/MWh voor elk uur van het jaar. 
+        Deze grafiek toont de gemiddelde integrale waterstofproductiekosten (<i>levelised costs of hydrogen production</i>) in €/MWh voor elk uur van het jaar. 
         Hoe groter het oppervlak van een bepaalde productiemethode, hoe meer invloed het heeft op de gemiddelde productiekosten van dat uur. 
         </br></br>
         Let op: dit zijn niet de marktprijzen van de waterstofmarkt, aangezien het ETM de prijzen op de waterstofmarkt niet modelleert.

--- a/config/locales/interface/slides/en_data.yml
+++ b/config/locales/interface/slides/en_data.yml
@@ -174,7 +174,7 @@ en:
         <br/><br/>
         The "Hydrogen demand, production and storage per hour" export contains information about hydrogen demand, supply and storage per hour in your scenario.
         <br/><br/>
-        The "Hydrogen integral costs" export contains the integral costs of hydrogen production, the production of hydrogen, 
+        The "Levelised costs of hydrogen" export contains the levelised costs of hydrogen production, the production of hydrogen, 
         the production cost per MWh for each generation method and the production curve of hydrogen for each generation method on an hourly basis.
         <ul class="data-download">
           <li>
@@ -185,7 +185,7 @@ en:
           </li>
           <li>
             <a href="/passthru/%{scenario_id}/curves/hydrogen_integral_cost.csv" target="_blank">
-              <span class="name">Hydrogen integral costs</span>
+              <span class="name">Levelised costs of hydrogen</span>
               <span class="filetype">2MB CSV</span>
             </a>
           </li>

--- a/config/locales/interface/slides/nl_data.yml
+++ b/config/locales/interface/slides/nl_data.yml
@@ -192,7 +192,7 @@ nl:
           </li>
           <li>
             <a href="/passthru/%{scenario_id}/curves/hydrogen_integral_cost.csv" target="_blank">
-              <span class="name">Ingetrale kosten waterstof</span>
+              <span class="name">Integrale kosten waterstof</span>
               <span class="filetype">2MB CSV</span>
             </a>
           </li>


### PR DESCRIPTION
Locales changes in chart, data export and slide text.
- EN: levelised costs of hydrogen production
- NL: integrale waterstofproductiekosten