### PR TITLE
Bug fix synthetic kerosene query

### DIFF
--- a/config/interface/output_element_series/energy_use_of_ccus.yml
+++ b/config/interface/output_element_series/energy_use_of_ccus.yml
@@ -18,7 +18,7 @@
   show_at_first: false
   is_target_line: false
   target_line_position: ''
-  gquery: energy_use_of_synthetic_kerosene_production_must_run
+  gquery: energy_use_of_synthetic_kerosene_must_run_production
   is_1990: false
   dependent_on:
   output_element_key: energy_use_of_ccus
@@ -30,7 +30,7 @@
   show_at_first: false
   is_target_line: false
   target_line_position: ''
-  gquery: energy_use_of_synthetic_kerosene_production_dispatchable
+  gquery: energy_use_of_synthetic_kerosene_dispatchable_production
   is_1990: false
   dependent_on:
   output_element_key: energy_use_of_ccus


### PR DESCRIPTION
Chart 'Energy use of CCUS' contained incorrect queries for production synthetic kerosene must run and dispatchable. This PR solves this bug. 