### PR TITLE
Adding subgroup to land use graphs

### DIFF
--- a/config/interface/output_elements/data_visuals.yml
+++ b/config/interface/output_elements/data_visuals.yml
@@ -2,7 +2,7 @@
 - under_construction: false
   percentage: false
   group: Supply
-  sub_group: 
+  sub_group: land_use
   show_point_label: false
   growth_chart: false
   key: land_use_solar_wind
@@ -16,7 +16,7 @@
   unit: km2
   percentage: false
   group: Supply
-  sub_group: 
+  sub_group: land_use
   show_point_label: false
   growth_chart: false
   key: land_use_solar_wind_chart

--- a/config/locales/interface/output_elements/labels_groups/en_groups.yml
+++ b/config/locales/interface/output_elements/labels_groups/en_groups.yml
@@ -30,3 +30,4 @@ en:
     hydrogen: "Hydrogen carriers and ammonia"
     network_gas: "Network gas"
     hybrid_offshore_wind: "Hybrid offshore wind"
+    land_use : "Land use" 

--- a/config/locales/interface/output_elements/labels_groups/nl_groups.yml
+++ b/config/locales/interface/output_elements/labels_groups/nl_groups.yml
@@ -28,3 +28,4 @@ nl:
     hydrogen: "Waterstofdragers en ammoniak"
     network_gas: "Netwerkgas"
     hybrid_offshore_wind: "Hybride wind op zee"
+    land_use : "Ruimtegebruik"


### PR DESCRIPTION
This PR solves #4254 https://github.com/quintel/etmodel/issues/4254 by adding a subheader for the land use group.

<img width="506" alt="Screenshot 2024-07-12 at 12 21 59" src="https://github.com/user-attachments/assets/fdd98f3f-e002-4c2e-8de7-c148d5ebd2de">
