### PR TITLE
Adjusted margins and value formatter

### DIFF
--- a/app/assets/javascripts/d3/merit_order_price_curve.coffee
+++ b/app/assets/javascripts/d3/merit_order_price_curve.coffee
@@ -6,9 +6,9 @@ D3.merit_order_price_curve =
     margins:
       top: 20
       bottom: 20
-      left: 50
+      left: 70
       right: 20
-      label_left: 20
+      label_left: 25
 
     visibleData: =>
       @rawChartData
@@ -68,7 +68,7 @@ D3.merit_order_price_curve =
         .interpolate('step-after')
 
     main_formatter: () ->
-      (value) -> "€ #{Math.round(value)}"
+      (value) -> "€/MWh #{Math.round(value)}"
 
     refresh: ->
       super


### PR DESCRIPTION
Made minor adjustments to margins to accommodate the broader label. The label now reads €/MWh <value>.

An example:
![Screenshot 2024-07-24 at 11 47 44](https://github.com/user-attachments/assets/569afb8f-b20f-46e9-8426-6639d99ea346)

Closes: [#3665](https://github.com/quintel/etmodel/issues/3665)
