### PR TITLE
Clarify terminology for coupled external models

### DIFF
--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -59,12 +59,12 @@ en:
     current_scenario: "Current scenario"
     coupled: Coupled
     coupled_docs: What does this mean?
-    coupled_groups: "Active couplings"
-    coupling_settings: "Coupling settings"
+    coupled_groups: "Active coupled models"
+    coupling_settings: "Settings"
     disclaimer: "Disclaimer"
     education: "Education"
     feedback: "Feedback"
-    has_been_coupled: This scenario has been coupled with an external model
+    has_been_coupled: This scenario is coupled to an external model.
     information: "Information"
     load_scenario: "My Scenarios"
     merit_order_check: "Enable hourly calculations"
@@ -80,7 +80,7 @@ en:
         unsaved changes.
     uncouple_scenario: "Uncouple scenario"
     uncoupled: "Uncoupled"
-    uncoupled_groups: "Inactive couplings"
+    uncoupled_groups: "Inactive coupled models"
     save_scenario: "Save scenario"
     save_scenario_as: "Save scenario as"
     saved: "Saved"
@@ -746,12 +746,12 @@ en:
 
   user_settings:
     coupling:
-      header: Coupling Settings
-      manage_couplings: Manage couplings
+      header: Coupled Model Settings
+      manage_couplings: Manage coupled external models
       description: |
-        Here you can manage the coupling settings for your scenario.
-        Toggle the switches to soft activate or deactivate a coupling.
-        You can also remove couplings permanently if needed.
-      remove_couplings: Remove couplings
-      remove_couplings_description: Check the box below to permanently uncouple all couplings from this scenario. This is irreversible.
+        Manage the settings for coupled external models.
+        Toggle the switches to activate or deactivate the coupled external model.
+        External models can also be permanently uncoupled.
+      remove_couplings: Uncouple external models
+      remove_couplings_description: Check the box below to permanently uncouple external models. This is irreversible.
       permanent_uncouple: Uncouple permanently.

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -58,13 +58,13 @@ nl:
     current_scenario: "Huidig scenario"
     coupled: Gekoppeld
     coupled_docs: Wat betekent dit?
-    coupled_groups: "Actieve koppelingen"
-    coupling_settings: "Koppelingen beheren"
+    coupled_groups: "Actieve gekoppelde modellen"
+    coupling_settings: "Instellingen"
     disclaimer: "Disclaimer"
     documentation: "Documentatie"
     education: "Onderwijs"
     feedback: "Feedback"
-    has_been_coupled: Dit scenario is gekoppeld aan een extern model
+    has_been_coupled: Dit scenario is gekoppeld aan een extern model.
     information: "Informatie"
     load_scenario: "Mijn Scenario's"
     merit_order_check: "Gebruik uurlijkse berekeningen"
@@ -80,7 +80,7 @@ nl:
       niet-opgeslagen wijzigingen zullen hiermee verloren gaan.
     uncouple_scenario: "Scenario ontkoppelen"
     uncoupled: "Ontkoppeld"
-    uncoupled_groups: "Inactieve koppelingen"
+    uncoupled_groups: "Inactieve gekoppelde modellen"
     save_scenario: "Scenario opslaan"
     save_scenario_as: "Scenario opslaan als"
     saved: "Opgeslagen"
@@ -760,13 +760,12 @@ nl:
 
   user_settings:
     coupling:
-      header: Koppelingen beheren
-      manage_couplings: Koppelingen aan en uit zetten
+      header: Instellingen Gekoppelde Modellen
+      manage_couplings: Beheer gekoppelde externe modellen
       description: |
-        Zet koppelingen aan of uit voor dit scenario. De instellingen van de
-        koppeling blijven bewaard als deze wordt gedeactiveerd, een koppeling
-        kan weer geactiveerd worden vanuit dit menu. Je kan
-        ook permanent alle koppelingen verwijderen.
-      remove_couplings: Koppelingen verwijderen
-      remove_couplings_description: Vink deze optie aan om alle koppelingen permanent te verwijderen. Dit is onomkeerbaar.
+        Beheer de instelling voor gekoppelde externe modellen.
+        Gebruik de toggle om een gekoppeld model te activeren of te deactiveren.
+        Externe modellen kunnen ook permanent ontkoppeld worden.
+      remove_couplings: Externe modellen ontkoppelen
+      remove_couplings_description: Vink deze optie aan om alle externe modellen te ontkoppelen. Dit is onomkeerbaar.
       permanent_uncouple: Permanent ontkoppelen.


### PR DESCRIPTION
Proposal to clarify terminology of coupled model.

- Activate coupled model
- Inactive coupled model ("soft uncoupling", the link is still there, but it's not active)
- Uncoupled model ("permanent uncoupling", the link is broken)

@kaskranenburgQ @noracato please see if you agree with the proposed terminology and check my work. If we push these changes we also need to update the documentation about external models accordingly.