### PR TITLE
First update dataset of Noord-Holland (WIP)

### DIFF
--- a/config/locales/en_areas.yml
+++ b/config/locales/en_areas.yml
@@ -43,6 +43,7 @@ en:
     PV22_drenthe: "Drenthe"
     PV30_noord_brabant: "Noord-Brabant"
     PV27_noord_holland: "Noord-Holland"
+    PV27_2022_noord_holland: "Noord-Holland (2022)"
     PV25_gelderland: "Gelderland"
     PV21_friesland: "Friesland"
     PV28_zuid_holland: "Zuid-Holland"

--- a/config/locales/nl_areas.yml
+++ b/config/locales/nl_areas.yml
@@ -40,6 +40,7 @@ nl:
     PV22_drenthe: "Drenthe"
     PV30_noord_brabant: "Noord-Brabant"
     PV27_noord_holland: "Noord-Holland"
+    PV27_2022_noord_holland: "Noord-Holland (2022)"
     PV25_gelderland: "Gelderland"
     PV21_friesland: "Friesland"
     PV28_zuid_holland: "Zuid-Holland"


### PR DESCRIPTION
Goes together with ETSource [PR 3118](https://github.com/quintel/etsource/pull/3118)

First update of the 2022 dataset for Noord-Holland, this is not the final form of the dataset.
We want to hide this dataset in the beta front-end, so that some initial testing can be performed by external parties. 
When the end product is done we will update the front-end again, so that the full work dataset is updated.

@mabijkerk Can you check if I took the right steps to hide this dataset in the front-end, and check if this could be put on beta?