### PR TITLE
Updated settings to avoid duplicates

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -110,12 +110,16 @@ class Setting
 
   def deactivate_coupling(group)
     active_couplings.delete(group)
-    inactive_couplings << group
+    unless inactive_couplings.include?(group)
+      inactive_couplings << group
+    end
   end
 
   def activate_coupling(group)
     inactive_couplings.delete(group)
-    active_couplings << group
+    unless active_couplings.include?(group)
+      active_couplings << group
+    end
   end
 
   def start_year


### PR DESCRIPTION
@noracato I did what you said and it worked! No surprises there :) 

One quirk that still exists which is that after coupling you need to exit and then re-enter to properly load settings. Refreshing the page isn't enough --> Note that this is only on the initial coupling when you make the change for example via ETEngine. Is this something we can easily deal with by forcing a full refresh of the scenario?

Closes: #4341

