### PR TITLE
Fixing typo in sankey.coffee

### DIFF
--- a/app/assets/javascripts/d3/sankey.coffee
+++ b/app/assets/javascripts/d3/sankey.coffee
@@ -554,7 +554,7 @@ D3.sankey =
           {left: 'dry',                             right: 'agriculture',                 gquery: 'dry_biomass_to_agriculture_in_biomass_sankey', color: '#009432'},
           {left: 'dry',                             right: 'other',                       gquery: 'dry_biomass_to_other_in_biomass_sankey', color: '#009432'},
           {left: 'dry',                             right: 'bunkers',                     gquery: 'dry_biomass_to_bunkers_in_biomass_sankey', color: '#009432'},
-          {left: 'dry',                             right: 'export',                      gquery: 'dry_biomass_to_export_i3n_biomass_sankey', color: '#009432'},
+          {left: 'dry',                             right: 'export',                      gquery: 'dry_biomass_to_export_in_biomass_sankey', color: '#009432'},
           {left: 'dry',                             right: 'losses',                      gquery: 'dry_biomass_to_losses_in_biomass_sankey', color: '#DCDCDC'},
           {left: 'dry',                             right: 'biofuels',                    gquery: 'dry_biomass_to_biofuels_in_biomass_sankey', color: '#009432'},
           {left: 'dry',                             right: 'non_biogenic_carriers_demand',gquery: 'dry_biomass_to_non_biogenic_carriers_in_biomass_sankey', color: '#009432'},

--- a/config/locales/interface/output_elements/labels_groups/en_labels.yml
+++ b/config/locales/interface/output_elements/labels_groups/en_labels.yml
@@ -193,7 +193,7 @@ en:
       ambient_heat: "ambient heat"
       ammonia: "ammonia"
       biomass_products: "biomass products"
-      non_biogenic_carriers: "Non-biogenic carriers"
+      non_biogenic_carriers: "non-biogenic carriers"
       captured: "captured"
       coal: "coal"
       coal_households: "coal for households"

--- a/config/locales/interface/output_elements/labels_groups/nl_labels.yml
+++ b/config/locales/interface/output_elements/labels_groups/nl_labels.yml
@@ -191,7 +191,7 @@ nl:
       ambient_heat: "omgevingswarmte"
       ammonia: "ammoniak"
       biomass_products: "biomassaproducten"
-      non_biogenic_carriers: "Niet-biogene dragers"
+      non_biogenic_carriers: "niet-biogene dragers"
       captured: "afgevangen"
       coal: "kolen"
       coal_households: "Kolen voor huishoudens"


### PR DESCRIPTION
This PR fixes a typo in the configuration of the chart "Biomass future flows".
