### PR TITLE
Changes for external coupling of must-run interconnectors

### DIFF
--- a/config/interface/input_elements/external_coupling_interconnectors.yml
+++ b/config/interface/input_elements/external_coupling_interconnectors.yml
@@ -1,0 +1,204 @@
+---
+- key: external_coupling_interconnector_1_flh_imported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 100
+  slide_key: flexibility_electricity_import_export_interconnectivity
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true
+- key: external_coupling_interconnector_1_flh_exported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 105
+  slide_key: flexibility_electricity_import_export_interconnectivity
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true
+
+- key: external_coupling_interconnector_2_flh_imported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 110
+  slide_key: flexibility_electricity_import_export_interconnectivity_2
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true
+- key: external_coupling_interconnector_2_flh_exported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 115
+  slide_key: flexibility_electricity_import_export_interconnectivity_2
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true
+
+- key: external_coupling_interconnector_3_flh_imported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 120
+  slide_key: flexibility_electricity_import_export_interconnectivity_3
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true
+- key: external_coupling_interconnector_3_flh_exported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 125
+  slide_key: flexibility_electricity_import_export_interconnectivity_3
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true
+
+- key: external_coupling_interconnector_4_flh_imported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 130
+  slide_key: flexibility_electricity_import_export_interconnectivity_4
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true
+- key: external_coupling_interconnector_4_flh_exported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 135
+  slide_key: flexibility_electricity_import_export_interconnectivity_4
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true
+
+- key: external_coupling_interconnector_5_flh_imported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 140
+  slide_key: flexibility_electricity_import_export_interconnectivity_5
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true
+- key: external_coupling_interconnector_5_flh_exported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 145
+  slide_key: flexibility_electricity_import_export_interconnectivity_5
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true
+
+- key: external_coupling_interconnector_6_flh_imported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 150
+  slide_key: flexibility_electricity_import_export_interconnectivity_6
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true
+- key: external_coupling_interconnector_6_flh_exported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 155
+  slide_key: flexibility_electricity_import_export_interconnectivity_6
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true
+
+- key: external_coupling_interconnector_7_flh_imported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 160
+  slide_key: flexibility_electricity_import_export_interconnectivity_7
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true
+- key: external_coupling_interconnector_7_flh_exported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 165
+  slide_key: flexibility_electricity_import_export_interconnectivity_7
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true
+
+- key: external_coupling_interconnector_8_flh_imported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 170
+  slide_key: flexibility_electricity_import_export_interconnectivity_8
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true
+- key: external_coupling_interconnector_8_flh_exported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 175
+  slide_key: flexibility_electricity_import_export_interconnectivity_8
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true
+
+- key: external_coupling_interconnector_9_flh_imported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 180
+  slide_key: flexibility_electricity_import_export_interconnectivity_9
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true
+- key: external_coupling_interconnector_9_flh_exported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 185
+  slide_key: flexibility_electricity_import_export_interconnectivity_9
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true
+
+- key: external_coupling_interconnector_10_flh_imported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 190
+  slide_key: flexibility_electricity_import_export_interconnectivity_10
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true
+- key: external_coupling_interconnector_10_flh_exported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 195
+  slide_key: flexibility_electricity_import_export_interconnectivity_10
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true
+
+- key: external_coupling_interconnector_11_flh_imported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 200
+  slide_key: flexibility_electricity_import_export_interconnectivity_11
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true
+- key: external_coupling_interconnector_11_flh_exported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 205
+  slide_key: flexibility_electricity_import_export_interconnectivity_11
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true
+
+- key: external_coupling_interconnector_12_flh_imported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 210
+  slide_key: flexibility_electricity_import_export_interconnectivity_12
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true
+- key: external_coupling_interconnector_12_flh_exported_electricity
+  step_value: 1.0
+  unit: 'flh'
+  position: 215
+  slide_key: flexibility_electricity_import_export_interconnectivity_12
+  share_group:
+  interface_group: full_load_hours
+  coupling_icon: true

--- a/config/locales/interface/input_elements/en_external_coupling.yml
+++ b/config/locales/interface/input_elements/en_external_coupling.yml
@@ -1164,3 +1164,99 @@ en:
       title: Power-to-heat boiler for food industy
       description: |
         Willingness to pay (WTP) of hybrid hydrogen and network gas heaters
+    external_coupling_interconnector_1_flh_exported_electricity:
+      title: Export
+      description: |
+        Full load hours of must-run export through interconnector 1.
+    external_coupling_interconnector_1_flh_imported_electricity:
+      title: Import
+      description: |
+        Full load hours of must-run import through interconnector 1.
+    external_coupling_interconnector_2_flh_exported_electricity:
+      title: Export
+      description: |
+        Full load hours of must-run export through interconnector 2.
+    external_coupling_interconnector_2_flh_imported_electricity:
+      title: Import
+      description: |
+        Full load hours of must-run import through interconnector 2.
+    external_coupling_interconnector_3_flh_exported_electricity:
+      title: Export
+      description: |
+        Full load hours of must-run export through interconnector 3.
+    external_coupling_interconnector_3_flh_imported_electricity:
+      title: Import
+      description: |
+        Full load hours of must-run import through interconnector 3.
+    external_coupling_interconnector_4_flh_exported_electricity:
+      title: Export
+      description: |
+        Full load hours of must-run export through interconnector 4.
+    external_coupling_interconnector_4_flh_imported_electricity:
+      title: Import
+      description: |
+        Full load hours of must-run import through interconnector 4.
+    external_coupling_interconnector_5_flh_exported_electricity:
+      title: Export
+      description: |
+        Full load hours of must-run export through interconnector 5.
+    external_coupling_interconnector_5_flh_imported_electricity:
+      title: Import
+      description: |
+        Full load hours of must-run import through interconnector 5.
+    external_coupling_interconnector_6_flh_exported_electricity:
+      title: Export
+      description: |
+        Full load hours of must-run export through interconnector 6.
+    external_coupling_interconnector_6_flh_imported_electricity:
+      title: Import
+      description: |
+        Full load hours of must-run import through interconnector 6.
+    external_coupling_interconnector_7_flh_exported_electricity:
+      title: Export
+      description: |
+        Full load hours of must-run export through interconnector 7.
+    external_coupling_interconnector_7_flh_imported_electricity:
+      title: Import
+      description: |
+        Full load hours of must-run import through interconnector 7.
+    external_coupling_interconnector_8_flh_exported_electricity:
+      title: Export
+      description: |
+        Full load hours of must-run export through interconnector 8.
+    external_coupling_interconnector_8_flh_imported_electricity:
+      title: Import
+      description: |
+        Full load hours of must-run import through interconnector 8.
+    external_coupling_interconnector_9_flh_exported_electricity:
+      title: Export
+      description: |
+        Full load hours of must-run export through interconnector 9.
+    external_coupling_interconnector_9_flh_imported_electricity:
+      title: Import
+      description: |
+        Full load hours of must-run import through interconnector 9.
+    external_coupling_interconnector_10_flh_exported_electricity:
+      title: Export
+      description: |
+        Full load hours of must-run export through interconnector 10.
+    external_coupling_interconnector_10_flh_imported_electricity:
+      title: Import
+      description: |
+        Full load hours of must-run import through interconnector 10.
+    external_coupling_interconnector_11_flh_exported_electricity:
+      title: Export
+      description: |
+        Full load hours of must-run export through interconnector 11.
+    external_coupling_interconnector_11_flh_imported_electricity:
+      title: Import
+      description: |
+        Full load hours of must-run import through interconnector 11.
+    external_coupling_interconnector_12_flh_exported_electricity:
+      title: Export
+      description: |
+        Full load hours of must-run export through interconnector 12.
+    external_coupling_interconnector_12_flh_imported_electricity:
+      title: Import
+      description: |
+        Full load hours of must-run import through interconnector 12.

--- a/config/locales/interface/input_elements/nl_external_coupling.yml
+++ b/config/locales/interface/input_elements/nl_external_coupling.yml
@@ -1164,3 +1164,99 @@ nl:
       title: Power-to-heat boiler voor voedingsmiddelenindustrie
       description: |
         Betalingsbereidheid (willingness to pay, WTP) van hybride waterstof- en gasketels
+    external_coupling_interconnector_1_flh_exported_electricity:
+      title: Export
+      description: |
+        Vollasturen van must-run export door interconnector 1.
+    external_coupling_interconnector_1_flh_imported_electricity:
+      title: Import
+      description: |
+        Vollasturen van must-run import door interconnector 1.
+    external_coupling_interconnector_2_flh_exported_electricity:
+      title: Export
+      description: |
+        Vollasturen van must-run export door interconnector 2.
+    external_coupling_interconnector_2_flh_imported_electricity:
+      title: Import
+      description: |
+        Vollasturen van must-run import door interconnector 2.
+    external_coupling_interconnector_3_flh_exported_electricity:
+      title: Export
+      description: |
+        Vollasturen van must-run export door interconnector 3.
+    external_coupling_interconnector_3_flh_imported_electricity:
+      title: Import
+      description: |
+        Vollasturen van must-run import door interconnector 3.
+    external_coupling_interconnector_4_flh_exported_electricity:
+      title: Export
+      description: |
+        Vollasturen van must-run export door interconnector 4.
+    external_coupling_interconnector_4_flh_imported_electricity:
+      title: Import
+      description: |
+        Vollasturen van must-run import door interconnector 4.
+    external_coupling_interconnector_5_flh_exported_electricity:
+      title: Export
+      description: |
+        Vollasturen van must-run export door interconnector 5.
+    external_coupling_interconnector_5_flh_imported_electricity:
+      title: Import
+      description: |
+        Vollasturen van must-run import door interconnector 5.
+    external_coupling_interconnector_6_flh_exported_electricity:
+      title: Export
+      description: |
+        Vollasturen van must-run export door interconnector 6.
+    external_coupling_interconnector_6_flh_imported_electricity:
+      title: Import
+      description: |
+        Vollasturen van must-run import door interconnector 6.
+    external_coupling_interconnector_7_flh_exported_electricity:
+      title: Export
+      description: |
+        Vollasturen van must-run export door interconnector 7.
+    external_coupling_interconnector_7_flh_imported_electricity:
+      title: Import
+      description: |
+        Vollasturen van must-run import door interconnector 7.
+    external_coupling_interconnector_8_flh_exported_electricity:
+      title: Export
+      description: |
+        Vollasturen van must-run export door interconnector 8.
+    external_coupling_interconnector_8_flh_imported_electricity:
+      title: Import
+      description: |
+        Vollasturen van must-run import door interconnector 8.
+    external_coupling_interconnector_9_flh_exported_electricity:
+      title: Export
+      description: |
+        Vollasturen van must-run export door interconnector 9.
+    external_coupling_interconnector_9_flh_imported_electricity:
+      title: Import
+      description: |
+        Vollasturen van must-run import door interconnector 9.
+    external_coupling_interconnector_10_flh_exported_electricity:
+      title: Export
+      description: |
+        Vollasturen van must-run export door interconnector 10.
+    external_coupling_interconnector_10_flh_imported_electricity:
+      title: Import
+      description: |
+        Vollasturen van must-run import door interconnector 10.
+    external_coupling_interconnector_11_flh_exported_electricity:
+      title: Export
+      description: |
+        Vollasturen van must-run export door interconnector 11.
+    external_coupling_interconnector_11_flh_imported_electricity:
+      title: Import
+      description: |
+        Vollasturen van must-run import door interconnector 11.
+    external_coupling_interconnector_12_flh_exported_electricity:
+      title: Export
+      description: |
+        Vollasturen van must-run export door interconnector 12.
+    external_coupling_interconnector_12_flh_imported_electricity:
+      title: Import
+      description: |
+        Vollasturen van must-run import door interconnector 12.


### PR DESCRIPTION
See https://github.com/quintel/etsource/pull/3155. I made the following changes:

- Added FLH external coupling inputs to front-end

Notifying @kaskranenburgQ and @louispt1. There are a couple of to-do's still left before we can merge:

- [ ] Depending on the discussion about the capacity profile in https://github.com/quintel/etsource/pull/3155, we may need to update locales
- [ ] When uploading the must-run curve through the front-end, it says that an error occurred, after refreshing however, the curves are actually uploaded
- [ ] After adding the FLH external coupling inputs, the disabled availability and costs inputs are no longer hidden