### PR TITLE
 Adding hybrid crude oil to number of residences per space heating graph

### DIFF
--- a/config/interface/output_element_series/residential_heating_technologies.yml
+++ b/config/interface/output_element_series/residential_heating_technologies.yml
@@ -191,6 +191,18 @@
   dependent_on: 
   output_element_key: residential_heating_technologies
   key: number_of_houses_before_1945_with_space_heater_hybrid_hydrogen_heatpump_air_water_electricity_residential_heating_technologies
+- label: households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity
+  color: "#5c2e17"
+  order_by: 85
+  group: residences_before_1945
+  show_at_first: 
+  is_target_line: false
+  target_line_position: 
+  gquery: number_of_houses_before_1945_with_space_heater_hybrid_crude_oil_heatpump_air_water_electricity
+  is_1990: 
+  dependent_on: 
+  output_element_key: residential_heating_technologies
+  key: number_of_houses_before_1945_with_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_residential_heating_technologies  
 
 - label: households_space_heater_coal
   color: "#333333"
@@ -384,6 +396,18 @@
   dependent_on: 
   output_element_key: residential_heating_technologies
   key: number_of_houses_1945_1964_with_space_heater_hybrid_hydrogen_heatpump_air_water_electricity_residential_heating_technologies
+- label: households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity
+  color: "#5c2e17"
+  order_by: 185
+  group: residences_1945_1964
+  show_at_first: 
+  is_target_line: false
+  target_line_position: 
+  gquery: number_of_houses_1945_1964_with_space_heater_hybrid_crude_oil_heatpump_air_water_electricity
+  is_1990: 
+  dependent_on: 
+  output_element_key: residential_heating_technologies
+  key: number_of_houses_1945_1964_with_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_residential_heating_technologies  
 
 - label: households_space_heater_coal
   color: "#333333"
@@ -577,6 +601,18 @@
   dependent_on: 
   output_element_key: residential_heating_technologies
   key: number_of_houses_1965_1984_with_space_heater_hybrid_hydrogen_heatpump_air_water_electricity_residential_heating_technologies
+- label: households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity
+  color: "#5c2e17"
+  order_by: 285
+  group: residences_1965_1984
+  show_at_first: 
+  is_target_line: false
+  target_line_position: 
+  gquery: number_of_houses_1965_1984_with_space_heater_hybrid_crude_oil_heatpump_air_water_electricity
+  is_1990: 
+  dependent_on: 
+  output_element_key: residential_heating_technologies
+  key: number_of_houses_1965_1984_with_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_residential_heating_technologies  
 
 - label: households_space_heater_coal
   color: "#333333"
@@ -770,6 +806,18 @@
   dependent_on: 
   output_element_key: residential_heating_technologies
   key: number_of_houses_1985_2004_with_space_heater_hybrid_hydrogen_heatpump_air_water_electricity_residential_heating_technologies
+- label: households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity
+  color: "#5c2e17"
+  order_by: 385
+  group: residences_1985_2004
+  show_at_first: 
+  is_target_line: false
+  target_line_position: 
+  gquery: number_of_houses_1985_2004_with_space_heater_hybrid_crude_oil_heatpump_air_water_electricity
+  is_1990: 
+  dependent_on: 
+  output_element_key: residential_heating_technologies
+  key: number_of_houses_1985_2004_with_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_residential_heating_technologies  
 
 - label: households_space_heater_coal
   color: "#333333"
@@ -963,6 +1011,18 @@
   dependent_on: 
   output_element_key: residential_heating_technologies
   key: number_of_houses_2005_present_with_space_heater_hybrid_hydrogen_heatpump_air_water_electricity_residential_heating_technologies
+- label: households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity
+  color: "#5c2e17"
+  order_by: 485
+  group: residences_2005_present
+  show_at_first: 
+  is_target_line: false
+  target_line_position: 
+  gquery: number_of_houses_2005_present_with_space_heater_hybrid_crude_oil_heatpump_air_water_electricity
+  is_1990: 
+  dependent_on: 
+  output_element_key: residential_heating_technologies
+  key: number_of_houses_2005_present_with_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_residential_heating_technologies  
 
 - label: households_space_heater_coal
   color: "#333333"
@@ -1156,3 +1216,15 @@
   dependent_on: 
   output_element_key: residential_heating_technologies
   key: number_of_houses_future_with_space_heater_hybrid_hydrogen_heatpump_air_water_electricity_residential_heating_technologies
+- label: households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity
+  color: "#5c2e17"
+  order_by: 585
+  group: residences_future
+  show_at_first: 
+  is_target_line: false
+  target_line_position: 
+  gquery: number_of_houses_future_with_space_heater_hybrid_crude_oil_heatpump_air_water_electricity
+  is_1990: 
+  dependent_on: 
+  output_element_key: residential_heating_technologies
+  key: number_of_houses_future_with_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_residential_heating_technologies  

--- a/config/locales/interface/output_element_series/en_labels.yml
+++ b/config/locales/interface/output_element_series/en_labels.yml
@@ -826,6 +826,7 @@ en:
         households_space_heater_heatpump_surface_water_water_ts_electricity: "Aquathermal heat pump with TS (surface water)"
         households_space_heater_hybrid_heatpump_air_water_electricity: "Hybrid air heat pump (gas)"
         households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity: "Hybrid air heat pump (hydrogen)"
+        households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity: "Hybrid air heat pump (crude oil)"
         households_space_heater_network_gas: "Gas-fired heater"
         households_space_heater_wood_pellets: "Wood pellet boiler"
         households_space_heater_hybrid_heatpump_electricity_input_curve: "Elektricity"

--- a/config/locales/interface/output_element_series/nl_labels.yml
+++ b/config/locales/interface/output_element_series/nl_labels.yml
@@ -836,6 +836,7 @@ nl:
         households_space_heater_heatpump_surface_water_water_ts_electricity: "Warmtepomp met aquathermie (TEO) en WKO"
         households_space_heater_hybrid_heatpump_air_water_electricity: "Hybride luchtwarmtepomp (gas)"
         households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity: "Hybride luchtwarmtepomp (waterstof)"
+        households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity: "Hybride luchtwarmtepomp (olie)"
         households_space_heater_network_gas: "Gasketel"
         households_space_heater_wood_pellets: "Houtpelletkachel"
         households_space_heater_hybrid_heatpump_electricity_input_curve: "Elektriciteit"


### PR DESCRIPTION
This PR closes https://github.com/quintel/etmodel/issues/4375

It uses labeling and coloring similar to the other labels and coloring of heat pumps and crude oil used in the "Number of residences per space heating technology" graph.

Goes together with:
https://github.com/quintel/etsource/pull/3175