### PR TITLE
Removing line that sets scenarios back to blank in revert unsaved changes button.

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -97,7 +97,6 @@ class Setting
   #
   def reset_scenario
     self.api_session_id = nil
-    self.preset_scenario_id = nil # to go back to a blank slate scenario
 
     %i[network_parts_affected locked_charts].each do |key|
       reset_attribute(key)


### PR DESCRIPTION
This PR aims to close #4399. 

The issue was that the "removed unsaved changes" button removed all scenario-settings in one scenario.
This meant that when you would alter a scenario, and wanted to revert your changes a blank scenario would return. 

This PR removes the line of code in etmodel that resets the scenario when this button is pressed, as proposed by @noracato [in this comment](https://github.com/quintel/etmodel/issues/4399#issuecomment-2633043567).

It's important to note that with this fix, reverting unsaved changes will only work when:

1. You save your (non-blank) scenario.
2. Open a different or new scenario
3. Open your saved scenario.
4. Make changes
5. Press the 'revert unsaved changes' button. 

If you don't open a different scenario in between, the revert unsaved changes button will revert to a blank scenario since your sessionID will not have changed, causing etmodel to think there is no scenario to revert to. 
