### PR TITLE
Allow price curves to be uploaded when must-run coupling is activated.

### DIFF
--- a/app/views/scenarios/slides/_interconnector_curves_upload.html.haml
+++ b/app/views/scenarios/slides/_interconnector_curves_upload.html.haml
@@ -5,7 +5,7 @@
   %p{ style: 'margin-top: 0' }
     = t("custom_curves.coupled_interconnector_intro_html", docs_path: 'https://docs.energytransitionmodel.com/main/costs-imported-electricity#uploaded-price-curves')
 
-  .curve-upload.multi-curve-upload.custom-curve{ data: { curve_name_match: "(?:^|_)interconnector_#{num}(?=_.*must_run)(?:$|_)" } }
+  .curve-upload.multi-curve-upload.custom-curve{ data: { curve_name_match: "(?:^|_)interconnector_#{num}(?!_.*(?:import_availability|export_availability))(?:$|_)" } }
     .loading
 
 - else

--- a/config/locales/en_custom_curves.yml
+++ b/config/locales/en_custom_curves.yml
@@ -12,12 +12,13 @@ en:
       Click on the drop-down icon to change which curve you want to upload. For more information on how this
       works, and examples of compatible CSV files, please <a href=%{docs_path} target="_blank">see our documentation</a>.
     coupled_interconnector_intro_html: |
-      If you set the import and export curves to must run via coupling, the capacity profiles provided to the ETM will
-      be treated as other must-run technologies. This means that the capacity profile will be used to determine the amount
-      of electricity that must be imported or exported in each hour, and the price curve will be used to determine
-      the price of this electricity. </br></br>
-      Click on the drop-down icon to change which curve you want to upload. For more information on how this
-      works, and examples of compatible CSV files, please <a href=%{docs_path} target="_blank">see our documentation</a>.
+      When the interconnector's behaviour is set by an external model, it no longer responds to supply
+      and demand of electricity based on the electricity price in the external market. Instead,
+      import and export become must-run and are set by the uploaded must-run profiles, which
+      determine the full load hours, and by the interconnector capacity. </br></br>
+      Click on the drop-down icon to change which curve to upload. For more information on how this
+      works, and examples of compatible CSV files, see the
+      <a href="https://docs.energytransitionmodel.com/main/curves#uploading-a-custom-profile" target="_blank">documentation</a>.
     interface_group_title: Custom curves
     coupled_interface_group_title: Coupled custom curves
     loading: Loading...

--- a/config/locales/nl_custom_curves.yml
+++ b/config/locales/nl_custom_curves.yml
@@ -14,12 +14,14 @@ nl:
       <a href=%{docs_path} target="_blank">documentatie</a> voor meer uitleg en voorbeelden van
       geschikte CSV-bestanden.
     coupled_interconnector_intro_html: |
-      Als je de import- en exportcurves instelt op 'must run via coupling', zullen de capaciteitprofielen die aan de ETM worden verstrekt,
-      worden behandeld als andere 'must-run'-technologieën. Dit betekent dat het capaciteitprofiel zal worden gebruikt om te bepalen hoeveel
-      elektriciteit er elk uur moet worden geïmporteerd of geëxporteerd, en de prijscurve zal worden gebruikt om de prijs van deze elektriciteit
-      te bepalen. </br></br>
-      Klik op het drop-down pictogram om te wijzigen welke curve je wilt uploaden. Voor meer informatie over hoe dit werkt, en voorbeelden van
-      compatibele CSV-bestanden, <a href=%{docs_path} target="_blank">raadpleeg onze documentatie</a>.
+      Wanneer het gedrag van een interconnector is ingesteld door meen extern model, reageert deze
+      niet meer op vraag en aanbod van elektriciteit op basis van de elektriciteitsprijs in de
+      externe markt. In plaats daarvan worden import en export must-run, waarbij het gedrag wordt
+      bepaald door de geüploade must-run profielen, die de vollasturen bepalen, en door het vermogen
+      van de intreconnector. </br></br>
+      Klik op het drop-down icoon om te wijzigen welke curve geüploaded wordt. Voor meer informatie
+      over hoe dit werkt, en voorbeelden van compatibele CSV-bestanden, zie de
+      <a href="https://docs.energytransitionmodel.com/main/curves#uploading-a-custom-profile" target="_blank">documentatie</a>.
     interface_group_title: Aanpasbare profielen
     coupled_interface_group_title: Gekoppelde profielen
     loading: Laden...


### PR DESCRIPTION
This PR goes with: https://github.com/quintel/etsource/pull/3211

This change just allows the price curve to still be uploaded when must-run is activated.