### PR TITLE
Update Collections references in What's new and landing page

### DIFF
--- a/app/views/content/whats_new.en.html.md
+++ b/app/views/content/whats_new.en.html.md
@@ -13,6 +13,7 @@ ___
     * Generate Personal Access Tokens
     * Subscribe to the newsletter
     * Update personal infomation
+* New term ***Collections*** is now used for the interface formerly referred to as *Multi-year-charts* or *Transition paths*. A *Collection* is a group of scenarios and a *Transition path* is a type of *Collection*: a single scenario that is interpolated to intermediate years. As part of this update, the prefix in the link to the *Collections* interface is changed from 'myc.' to 'collections.'. Explore *Collections* yourself: <a href="https://collections.energytransitionmodel.com" target="_blank">https://collections.energytransitionmodel.com</a>
 * New charts added to the chart selection:
   * ‘Electricity supply and demand’
   * ‘Network gas supply and demand’

--- a/app/views/content/whats_new.nl.html.md
+++ b/app/views/content/whats_new.nl.html.md
@@ -13,6 +13,7 @@ ___
     * Persoonlijke *Access Tokens* te genereren
     * Aan te melden voor de nieuwsbrief
     * Persoonlijke gegevens bij te werken
+* Nieuw begrip ***Collecties*** wordt nu gebruikt voor de interface dat voorheen *Multi-year-charts* of *Transitiepaden* werd genoemd. Een *Collectie* is een verzameling scenario's en een *Transitiepad* is een type *Collectie*: een individueel scenario dat is geïnterpoleerd naar tussentijdse jaren. Als onderdeel van deze update is de prefix in de link naar de *Collecties* interface aangepast van 'myc.' naar 'collections.'. Ontdek *Collecties* nu zelf: <a href="https://collections.energytransitionmodel.com" target="_blank">https://collections.energytransitionmodel.com</a>
 * Nieuwe grafieken zijn toegevoegd aan het grafiekenoverzicht:
   * ‘Elektriciteit vraag en aanbod’
   * ‘Netwerkgas vraag en aanbod’

--- a/config/locales/en_intro.yml
+++ b/config/locales/en_intro.yml
@@ -35,10 +35,10 @@ en:
         larger whole.
       try_it: Try it now
     multi_year_charts:
-      title: Transition Paths
+      title: Collections
       description: |
-        Explore the possible transition paths to a scenario for 2050 and discover
-        the actions and consequences for aspired goals in 2030 and 2040.
+        Explore transition paths to a scenario for 2050 with intermediate aspired goals for
+        2030 and 2040, or investigate the outcomes of a collection of various scenarios.
       try_it: Try it now
     docs:
       title: Documentation

--- a/config/locales/nl_intro.yml
+++ b/config/locales/nl_intro.yml
@@ -37,11 +37,11 @@ nl:
         aan het grote geheel.
       try_it: Probeer nu
     multi_year_charts:
-      title: Transitiepaden
+      title: Collecties
       description: |
-        Verken de mogelijke transitiepaden naar een 2050 toekomstbeeld en ontdek
-        wat dit zou kunnen betekenen voor de tussentijdse doelstellingen in
-        2030 en 2040.
+        Verken de transitiepaden naar een 2050 toekomstbeeld met tussentijdse
+        doelstellingen voor 2030 en 2040, of onderzoek de uitkomsten van een
+        collectie van verschillende scenario's.
       try_it: Probeer nu
     esdl:
       title: Mondaine Suite


### PR DESCRIPTION
Updates of text and heading related to Collections:

- Change 'Transition paths' heading to 'Collections' in section on landing page, and update descriptive text
- Add changes related to Collections to What's new