### PR TITLE
Functional inputs serialisation to csv

### DIFF
--- a/config/interface/slides/data_export.yml
+++ b/config/interface/slides/data_export.yml
@@ -3,6 +3,10 @@
   position: 100
   sidebar_item_key: data_export
   output_element_key: final_energy_demand_per_sector_joule
+- key: data_export_inputs
+  position: 101
+  sidebar_item_key: data_export
+  output_element_key: data_export_inputs
 - key: data_export_energy_flows
   position: 105
   sidebar_item_key: data_export

--- a/config/interface/slides/data_export.yml
+++ b/config/interface/slides/data_export.yml
@@ -6,7 +6,7 @@
 - key: data_export_inputs
   position: 101
   sidebar_item_key: data_export
-  output_element_key: data_export_inputs
+  output_element_key: final_energy_demand_per_sector_joule
 - key: data_export_energy_flows
   position: 105
   sidebar_item_key: data_export

--- a/config/locales/interface/slides/en_data.yml
+++ b/config/locales/interface/slides/en_data.yml
@@ -41,12 +41,18 @@ en:
           <li><a href="/passthru/%{scenario_id}/application_demands.csv" target="_blank"><span class="name">Application primary and final demands</span> <span class="filetype">40KB CSV</span></a></li>
         </ul>
     data_export_inputs:
-      title: Overview of inputs
+      title: Overview of slider settings
       short_description:
       description: |
-        Download an overview of the inputs used in your scenario. This includes the slider keys, minimum and maximum values, default and user values, units, and share groups where applicable.
+        Download an overview of this scenario's slider settings. This includes the slider keys, the
+        minimum and maximum values, the default (start year) and user values (future year),
+        and (if applicable) the share group. For more information, see the
+        <a href="https://docs.energytransitionmodel.com/contrib/inputs/" target=\"_blank\">documentation</a>.
         <ul class="data-download">
-          <li><a href="/passthru/%{scenario_id}/inputs.csv"><span class="name">Overview of inputs</span> <span class="filetype">200KB CSV</span></a></li>
+          <li>
+            <a href="/passthru/%{scenario_id}/inputs.csv"><span class="name">Slider settings</span>
+            <span class="filetype">100KB CSV</span></a>
+          </li>
         </ul>
     data_export_costs:
       title: Specifications annual costs

--- a/config/locales/interface/slides/en_data.yml
+++ b/config/locales/interface/slides/en_data.yml
@@ -40,6 +40,14 @@ en:
         <ul class="data-download">
           <li><a href="/passthru/%{scenario_id}/application_demands.csv" target="_blank"><span class="name">Application primary and final demands</span> <span class="filetype">40KB CSV</span></a></li>
         </ul>
+    data_export_inputs:
+      title: Overview of inputs
+      short_description:
+      description: |
+        Download an overview of the inputs used in your scenario. This includes the slider keys, minimum and maximum values, default and user values, units, and share groups where applicable.
+        <ul class="data-download">
+          <li><a href="/passthru/%{scenario_id}/inputs.csv"><span class="name">Overview of inputs</span> <span class="filetype">200KB CSV</span></a></li>
+        </ul>
     data_export_costs:
       title: Specifications annual costs
       short_description:

--- a/config/locales/interface/slides/nl_data.yml
+++ b/config/locales/interface/slides/nl_data.yml
@@ -39,6 +39,14 @@ nl:
         <ul class="data-download">
           <li><a href="/passthru/%{scenario_id}/application_demands.csv" target="_blank"><span class="name">Primaire en finale vraag per toepassing</span> <span class="filetype">40KB CSV</span></a></li>
         </ul>
+    data_export_inputs:
+      title: Overzicht van invoerwaarden
+      short_description:
+      description: |
+        Download een overzicht van de invoerwaarden die in je scenario worden gebruikt. Dit omvat de schuifregelaar-sleutels, minimale en maximale waarden, standaard- en gebruikerswaarden, eenheden en indien van toepassing, de share-groepen.
+        <ul class="data-download">
+          <li><a href="/passthru/%{scenario_id}/inputs.csv"><span class="name">Overzicht van invoerwaarden</span> <span class="filetype">200KB CSV</span></a></li>
+        </ul>
     data_export_costs:
       title: Specificaties jaarlijkse kosten
       short_description:

--- a/config/locales/interface/slides/nl_data.yml
+++ b/config/locales/interface/slides/nl_data.yml
@@ -40,12 +40,19 @@ nl:
           <li><a href="/passthru/%{scenario_id}/application_demands.csv" target="_blank"><span class="name">Primaire en finale vraag per toepassing</span> <span class="filetype">40KB CSV</span></a></li>
         </ul>
     data_export_inputs:
-      title: Overzicht van invoerwaarden
+      title: Overzicht van schuifjesinstellingen
       short_description:
       description: |
-        Download een overzicht van de invoerwaarden die in je scenario worden gebruikt. Dit omvat de schuifregelaar-sleutels, minimale en maximale waarden, standaard- en gebruikerswaarden, eenheden en indien van toepassing, de share-groepen.
+        Download een overzicht van de schuifjesinstellingen van dit scenario. Dit bevat de keys, de
+        minimum- en maximumwaardes, de standaard- (startjaar) en gebruikerswaardes
+        (toekomstjaar) en (indien van toepassing) de <i>share group</i>. Zie de
+        <a href="https://docs.energytransitionmodel.com/contrib/inputs/" target=\"_blank\">documentatie</a>
+        voor meer informatie.
         <ul class="data-download">
-          <li><a href="/passthru/%{scenario_id}/inputs.csv"><span class="name">Overzicht van invoerwaarden</span> <span class="filetype">200KB CSV</span></a></li>
+          <li>
+            <a href="/passthru/%{scenario_id}/inputs.csv"><span class="name">Schuifjesinstellingen</span>
+            <span class="filetype">100KB CSV</span></a>
+          </li>
         </ul>
     data_export_costs:
       title: Specificaties jaarlijkse kosten


### PR DESCRIPTION
Functional inputs serialisation to csv, fetching from engine via passthru to serve in the data export section.

Dutch translation courtesy of ChatGPT.

Using locales for the inputs would be a nice addition, however at this stage it might be too much effort for the marginal gain.

Goes with this PR in etengine: https://github.com/quintel/etengine/pull/1506

Closes [#4448](https://github.com/quintel/etmodel/issues/4448)