### PR TITLE
Update locales for res region 2019 update

### DIFF
--- a/config/locales/en_areas.yml
+++ b/config/locales/en_areas.yml
@@ -754,7 +754,7 @@ en:
     RES10_hoeksewaard: Hoeksche Waard
     RES11_holland_rijnland: Holland Rijnland
     RES12_metropoolregio_eindhoven: Metropoolregio Eindhoven
-    RES13_rotterdam_denhaag: Rotterdam-Den Haag
+    RES13_rotterdam_den_haag: Rotterdam-Den Haag
     RES14_midden_holland: Midden-Holland
     RES16_noord_holland_noord: Noord-Holland Noord
     RES17_noord_holland_zuid: Noord-Holland Zuid

--- a/config/locales/en_areas.yml
+++ b/config/locales/en_areas.yml
@@ -768,6 +768,7 @@ en:
     RES24_u16: U16
     RES25_rivierenland_fruitdelta: Rivierenland (Fruitdelta)
     RES26_cleantechregio: Cleantechregio
+    RES26_stedendriehoek: Stedendriehoek
     RES27_twente: Twente
     RES28_west_brabant: West-Brabant
     RES29_west_overijssel: West-Overijssel

--- a/config/locales/nl_areas.yml
+++ b/config/locales/nl_areas.yml
@@ -758,7 +758,7 @@ nl:
     RES10_hoeksewaard: Hoeksche Waard
     RES11_holland_rijnland: Holland Rijnland
     RES12_metropoolregio_eindhoven: Metropoolregio Eindhoven
-    RES13_rotterdam_denhaag: Rotterdam-Den Haag
+    RES13_rotterdam_den_haag: Rotterdam-Den Haag
     RES14_midden_holland: Midden-Holland
     RES16_noord_holland_noord: Noord-Holland Noord
     RES17_noord_holland_zuid: Noord-Holland Zuid

--- a/config/locales/nl_areas.yml
+++ b/config/locales/nl_areas.yml
@@ -772,6 +772,7 @@ nl:
     RES24_u16: U16
     RES25_rivierenland_fruitdelta: Rivierenland (Fruitdelta)
     RES26_cleantechregio: Cleantechregio
+    RES26_stedendriehoek: Stedendriehoek
     RES27_twente: Twente
     RES28_west_brabant: West-Brabant
     RES29_west_overijssel: West-Overijssel


### PR DESCRIPTION
This PR updates the locales for the RES regions.

Notable changes:
- Rename of RES region Cleantech to Stedendriehoek
- Change of Rotterdam Den Haag key for etlocal.

Goes together with:
https://github.com/quintel/etlocal/pull/589
https://github.com/quintel/etsource/pull/3234