### PR TITLE
Adding other sector to Industry and energy section in co2 sheet

### DIFF
--- a/app/assets/javascripts/establishment_shot/charts.js
+++ b/app/assets/javascripts/establishment_shot/charts.js
@@ -54,7 +54,7 @@ EstablishmentShot.Charts = (function () {
                 { key: 'co2_sheet_buildings_households_appliances_light_co2_emissions' },
                 { key: 'co2_sheet_buildings_households_other_emissions' }
             ],
-            [
+            [   { key: 'co2_sheet_other_sector_co2_emissions' },
                 { key: 'co2_sheet_industry_chemical_all_emissions' },
                 { key: 'co2_sheet_industry_waste_management_all_emissions' },
                 { key: 'co2_sheet_industry_energy_sector_all_emissions' },
@@ -62,6 +62,7 @@ EstablishmentShot.Charts = (function () {
                 { key: 'co2_sheet_industry_food_co2_emissions' },
                 { key: 'co2_sheet_industry_paper_co2_emissions' },
                 { key: 'co2_sheet_industry_other_all_emissions' }
+                
             ],
             [
                 { key: 'co2_sheet_agriculture_energy_all_emissions' },
@@ -84,8 +85,8 @@ EstablishmentShot.Charts = (function () {
                 { key: 'co2_sheet_agriculture_total_emissions',
                   title: 'co2_sheet_agriculture_total_emissions',
                   fa_icon: '\uf06c' },
-                { key: 'co2_sheet_industry_energy_total_emissions',
-                  title: 'co2_sheet_industry_energy_total_emissions',
+                { key: 'co2_sheet_industry_energy_other_total_emissions',
+                  title: 'co2_sheet_industry_energy_other_total_emissions',
                   fa_icon: '\uf275' },
                 { key: 'co2_sheet_transport_total_emissions',
                   title: 'co2_sheet_transport_total_emissions',
@@ -167,7 +168,7 @@ EstablishmentShot.Charts = (function () {
                     top: false,
                     fa_icon: 'f015',
                 }, addQueries(), smallChartDefaults()),
-                co2_sheet_industry_energy_total_emissions: $.extend({
+                co2_sheet_industry_energy_other_total_emissions: $.extend({
                     left: false,
                     top: false,
                     fa_icon: 'f275'

--- a/app/assets/javascripts/establishment_shot/charts.js
+++ b/app/assets/javascripts/establishment_shot/charts.js
@@ -22,6 +22,7 @@ EstablishmentShot.Charts = (function () {
                 '#aaa69d'
             ],
             [
+                '#b9b9b9',
                 '#60a3bc',
                 '#f6b93b',
                 '#e55039',
@@ -62,7 +63,7 @@ EstablishmentShot.Charts = (function () {
                 { key: 'co2_sheet_industry_food_co2_emissions' },
                 { key: 'co2_sheet_industry_paper_co2_emissions' },
                 { key: 'co2_sheet_industry_other_all_emissions' }
-                
+
             ],
             [
                 { key: 'co2_sheet_agriculture_energy_all_emissions' },

--- a/app/views/pages/dataset.html.haml
+++ b/app/views/pages/dataset.html.haml
@@ -70,7 +70,7 @@
 
         .column
           .column-inner
-            .chart.industry{ data: { chart: 'co2_sheet_industry_energy_total_emissions' } }
+            .chart.industry{ data: { chart: 'co2_sheet_industry_energy_other_total_emissions' } }
             .chart.agriculture{ data: { chart: 'co2_sheet_agriculture_total_emissions' } }
 
         .clearfix

--- a/config/locales/en_establishment_shot.yml
+++ b/config/locales/en_establishment_shot.yml
@@ -17,7 +17,7 @@ en:
       bar_chart: "Greenhouse gas emissions"
       bar_chart_non_energy: "Total greenhouse gas emissions"
       co2_sheet_agriculture_total_emissions: Agriculture
-      co2_sheet_industry_energy_total_emissions: Industry & Energy
+      co2_sheet_industry_energy_other_total_emissions: Industry, Energy & Other
       co2_sheet_transport_total_emissions: Transport & Mobility
       co2_sheet_buildings_households_total_emissions: Built environment
     legend:
@@ -26,7 +26,7 @@ en:
       co2_sheet_renewability_percentage: "% Renewability"
       co2_sheet_buildings_households_total_emissions: Built environment
       co2_sheet_transport_total_emissions: Transport & Mobility
-      co2_sheet_industry_energy_total_emissions: Industry & Energy
+      co2_sheet_industry_energy_other_total_emissions: Industry, Energy & Other
       co2_sheet_agriculture_total_emissions: Agriculture
       co2_sheet_buildings_households_space_heating_cooling_co2_emissions: Heating & cooling
       co2_sheet_buildings_households_hot_water_co2_emissions: Hot water
@@ -52,3 +52,4 @@ en:
       co2_sheet_industry_metal_co2_emissions: Metal industry
       co2_sheet_industry_food_co2_emissions: Food industry
       co2_sheet_industry_paper_co2_emissions: Paper industry
+      co2_sheet_other_sector_co2_emissions: Other sector

--- a/config/locales/nl_establishment_shot.yml
+++ b/config/locales/nl_establishment_shot.yml
@@ -16,7 +16,7 @@ nl:
       bar_chart: "Broeikasgasemissies"
       bar_chart_non_energy: "Totale uitstoot broeikasgassen"
       co2_sheet_agriculture_total_emissions: Landbouw
-      co2_sheet_industry_energy_total_emissions: Industrie & Energie
+      co2_sheet_industry_energy_other_total_emissions: Industrie, Energie & Overig
       co2_sheet_transport_total_emissions: Transport & Mobiliteit
       co2_sheet_buildings_households_total_emissions: Gebouwde omgeving
     legend:
@@ -24,7 +24,7 @@ nl:
       co2_sheet_total_final_energy_demand: Totaal jaarlijks energiegebruik (finaal)
       co2_sheet_buildings_households_total_emissions: Gebouwde omgeving
       co2_sheet_transport_total_emissions: Transport & Mobiliteit
-      co2_sheet_industry_energy_total_emissions: Industrie & Energie
+      co2_sheet_industry_energy_other_total_emissions: Industrie, Energie & Overig
       co2_sheet_agriculture_total_emissions: Landbouw
       co2_sheet_buildings_households_space_heating_cooling_co2_emissions: Verwarming & koeling
       co2_sheet_buildings_households_hot_water_co2_emissions: Warm water
@@ -50,3 +50,4 @@ nl:
       co2_sheet_industry_metal_co2_emissions: Metaal
       co2_sheet_industry_food_co2_emissions: Voedsel
       co2_sheet_industry_paper_co2_emissions: Papier
+      co2_sheet_other_sector_co2_emissions: Overige sector


### PR DESCRIPTION
This PR solves the quick fix as proposed in [ETSource #3217](https://github.com/quintel/etsource/issues/3217) by adding the emissions of the Other sector to the Industry & Energy sectors. 

@noracato I also updated the file: app/views/pages/dataset.html.haml, since the old querie was mentioned in this file, could you tell me whether this is necessary or whether the file is outdated?

Goes together with:
https://github.com/quintel/etsource/pull/3236
