### PR TITLE
Correct for duplicate lines in slide descriptions

### DIFF
--- a/config/locales/interface/slides/en_flexibility.yml
+++ b/config/locales/interface/slides/en_flexibility.yml
@@ -13,25 +13,16 @@ en:
         neighbouring countries are willing to pay more than the domestic
         (production) price. </br></br>
         In the tabs below you can determine the capacity of interconnectors in
-        In the tabs below you can determine the capacity of interconnectors in
         your scenario, as well as a number of other attributes.
     flexibility_electricity_import_export_interconnectivity:
       title: Interconnector 1
       short_description:
       description:
         Many countries import and export electricity with their neighboring countries through different
-        Many countries import and export electricity with their neighboring countries through different
         interconnectors. In the ETM it is possible to model up to twelve different electrical interconnectors
         between countries. You add an interconnector by setting interconnection capacity for that
         interconnector. If you prefer to model all interconnectors together, you only set interconnector
-        between countries. You add an interconnector by setting interconnection capacity for that
-        interconnector. If you prefer to model all interconnectors together, you only set interconnector
         capacity for interconnector 1. <br/><br/>
-        You can set the capacity per interconnector. However, not all of this capacity may be available for
-        export, for example because the neighboring country suffers from electricity surpluses at the same
-        time. It is therefore possible to limit the percentage of interconnection capacity available for
-        export. In addition to capacity, it is also possible to set the corresponding CO<sub>2</sub>
-        emissions and price. The price determines the deployment order of interconnectors for import and
         You can set the capacity per interconnector. However, not all of this capacity may be available for
         export, for example because the neighboring country suffers from electricity surpluses at the same
         time. It is therefore possible to limit the percentage of interconnection capacity available for
@@ -118,9 +109,7 @@ en:
         The COP becomes lower as the outside temperature decreases. Below you can
         set the so-called 'threshold COP': if the COP of the heat pump falls below this
         threshold then the HHP switches from electricity to a backup fuel. This can be network gas, hydrogen or oil.
-        threshold then the HHP switches from electricity to a backup fuel. This can be network gas, hydrogen or oil.
         You can choose a setting that is most financially attractive for the consumer, but you can
-        also choose a setting that produces less impact on the electricity network.
         also choose a setting that produces less impact on the electricity network.
         See the <a href="https://docs.energytransitionmodel.com/main/heat-pumps" target=\"_blank\">documentation</a>
         for more information on the threshold COP.
@@ -135,17 +124,12 @@ en:
       short_description:
       description: |
         Demand response is a form of flexibility where energy demand is adjusted or shifted in time.
-        Demand response is a form of flexibility where energy demand is adjusted or shifted in time.
         One type of demand response is load shifting. With the sliders in this section you can implement
-        load shifting for the electricity demand of the industrial sectors
         load shifting for the electricity demand of the industrial sectors
         metal, chemical, central ICT and other industry. </br></br>
         If you install load shifting capacity for sector, it will use that capacity to decrease part of its electricity
         consumption when the electricity price is too high. The reduced consumption is caught up when the price
-        If you install load shifting capacity for sector, it will use that capacity to decrease part of its electricity
-        consumption when the electricity price is too high. The reduced consumption is caught up when the price
         drops. This means that the total electricity consumption over the year stays the same. </br></br>
-        The aim is to avoid high electricity costs for industry, while at the same time decreasing demand
         The aim is to avoid high electricity costs for industry, while at the same time decreasing demand
         peaks on the electricity network. This could decrease the need for peak power plants in your scenario.
     flexibility_power_storage_wind_turbine_inland:
@@ -175,19 +159,11 @@ en:
         <a href="https://docs.energytransitionmodel.com/main/battery-forecasting/" target=\"_blank\">
         forecasting algorithm</a> to determine the behaviour of electricity storage technologies.
         Below you can change the merit order of storage technologies
-        Electricity storage</a> section, you can choose to use a
-        <a href="https://docs.energytransitionmodel.com/main/battery-forecasting/" target=\"_blank\">
-        forecasting algorithm</a> to determine the behaviour of electricity storage technologies.
-        Below you can change the merit order of storage technologies
         for which the system forecasting algorithm is enabled. </br></br>
-        The first technology in this merit order will try to flatten the
         The first technology in this merit order will try to flatten the
         <a href="/scenario/flexibility/flexibility_overview/residual-load-curves">residual load curve</a>.
         Each following technology will then use the resulting curve of the previous technology to try and
-        Each following technology will then use the resulting curve of the previous technology to try and
         flatten it even further. </br></br>
-        Technologies higher in the merit order will typically apply their forecasting algorithm
-        to more variable curves. Whether a technology is suitable to deal with high variability depends on
         Technologies higher in the merit order will typically apply their forecasting algorithm
         to more variable curves. Whether a technology is suitable to deal with high variability depends on
         its specifications. The table on the right gives an overview of these specifications.
@@ -203,16 +179,10 @@ en:
         Flexibility overview</a> for background information). </br></br> The ETM models three types of storage behaviour.
         <br /><ol><li>By default, storage behaves like any other flexible technology. Each storage technology has a
         <i>willingness to pay</i> that indicates the maximum electricity price for which it is willing to charge electricity.
-        Flexibility overview</a> for background information). </br></br> The ETM models three types of storage behaviour.
-        <br /><ol><li>By default, storage behaves like any other flexible technology. Each storage technology has a
-        <i>willingness to pay</i> that indicates the maximum electricity price for which it is willing to charge electricity.
         If the electricity price in a given hour is lower than a technology's willingness to pay, the storage technology will charge. </br></br>
-        Similarly, each technology also has a <i>willingness to accept</i>, which indicates the minimum
         Similarly, each technology also has a <i>willingness to accept</i>, which indicates the minimum
         electricity price for which it is willing to discharge the stored electricity. This
         is similar to the concept of 'marginal costs' for flexible power plants.</li> </br>
-        <li>Optionally you can choose to activate a
-        <a href="https://docs.energytransitionmodel.com/main/battery-forecasting/" target=\"_blank\">
         <li>Optionally you can choose to activate a
         <a href="https://docs.energytransitionmodel.com/main/battery-forecasting/" target=\"_blank\">
         forecasting algorithm</a> that tries to improve the
@@ -229,11 +199,8 @@ en:
         determine their behaviour. Note that the specific behaviour of these
         technologies is more complicated than stated in this short description. Our
         <a href="https://docs.energytransitionmodel.com/main/electricity-storage" target=\"_blank\"> documentation</a>
-        technologies is more complicated than stated in this short description. Our
-        <a href="https://docs.energytransitionmodel.com/main/electricity-storage" target=\"_blank\"> documentation</a>
         contains more details.<br/><br/>
         <a href="#" class="open_chart" data-chart-key="mekko_of_storage_volume" data-chart-location="side">
-        This chart</a> shows the installed volume of electricity storage technologies in comparison to storage volumes for other
         This chart</a> shows the installed volume of electricity storage technologies in comparison to storage volumes for other
         energy carriers.
     flexibility_power_storage_households_flexibility_p2p_electricity:
@@ -242,14 +209,10 @@ en:
       description: |
         It is possible to install batteries in households. By default, if the electricity price is lower than the willingness
         to pay of the battery in a given hour, it will charge electricity in that hour. If the electricity price exceeds the
-        It is possible to install batteries in households. By default, if the electricity price is lower than the willingness
-        to pay of the battery in a given hour, it will charge electricity in that hour. If the electricity price exceeds the
         willingness to accept, it will discharge the stored electricity. <br/><br/>
-        Optionally, you can override this behaviour by switching to a
         Optionally, you can override this behaviour by switching to a
         <a href="https://docs.energytransitionmodel.com/main/battery-forecasting" target=\"_blank\">
         forecasting algorithm</a>. Two types of forecasting are available for household batteries. The first type uses
-        them to balance the electricity system as a whole, while the second type aims to balance local household demand with
         them to balance the electricity system as a whole, while the second type aims to balance local household demand with
         local production from solar PV. In
         <a href="#" class="open_chart" data-chart-key="flexibility_hourly_carriers_inflexible_imbalance" data-chart-location="side">
@@ -260,10 +223,7 @@ en:
       description: |
         Electric vehicles are often plugged into the grid for more hours than it takes to fully recharge
         their batteries. During those idle hours, it can be cost-effective to utilize the batteries to provide
-        Electric vehicles are often plugged into the grid for more hours than it takes to fully recharge
-        their batteries. During those idle hours, it can be cost-effective to utilize the batteries to provide
         storage services for the electricity grid. </br></br>
-        Batteries in the ETM are flexible technologies, which
         Batteries in the ETM are flexible technologies, which
         means that they can choose at which moments to charge or discharge. By default, if the electricity price is lower than the willingness to pay of the battery in a given hour, it
         will charge electricity in that hour. If the electricity price exceeds the willingness to accept, it will
@@ -276,7 +236,6 @@ en:
       description: |
         This large-scale battery is typically connected to the medium voltage network. Although in the battery does
         not react to congestion events, its behavior can help prevent capacity issues in the electricity network. </br></br>
-        Batteries in the ETM are flexible technologies, which
         Batteries in the ETM are flexible technologies, which
         means that they can choose at which moments to charge or discharge. By default, if the electricity price is lower than the willingness to pay of the battery in a given hour, it
         will charge electricity in that hour. If the electricity price exceeds the willingness to accept, it will
@@ -316,7 +275,6 @@ en:
         Flow batteries allow for large-scale storage of electricity. This is because installing storage volume is relatively
         cheap and it can easily be scaled independent from the installed capacity. </br></br>
         Batteries in the ETM are flexible technologies, which
-        Batteries in the ETM are flexible technologies, which
         means that they can choose at which moments to charge or discharge. By default, if the electricity price is lower than the willingness to pay of the battery in a given hour, it
         will charge electricity in that hour. If the electricity price exceeds the willingness to accept, it will
         discharge the stored electricity. <br/><br/>Optionally, you can override this behaviour by switching the toggle below and use a forecasting algorithm to determine battery behaviour. In both cases the ETM respects the storage volume limits of the battery.
@@ -331,9 +289,6 @@ en:
         is considered flexible because it can be increased, reduced or shifted in time if needed (see the
         <a href="/scenario/flexibility/flexibility_overview/what-is-flexibility"> Flexibility overview </a>
         for background information). </br></br>
-        Each flexible demand technology has a <i>willingness to pay</i> that indicates the maximum
-        electricity price for which it is willing to consume electricity. If the electricity price
-        in a given hour is lower than a technology's willingness to pay, the technology will consume
         Each flexible demand technology has a <i>willingness to pay</i> that indicates the maximum
         electricity price for which it is willing to consume electricity. If the electricity price
         in a given hour is lower than a technology's willingness to pay, the technology will consume
@@ -363,7 +318,6 @@ en:
         documentation</a> for more information. </br></br>
         Note that a 1 MWth power-to-heat boiler uses more electricity than a 1 MWth power-to-heat heat
         pump, even though they produce the same amount of heat per hour. The produced heat is delivered
-        to the district heating network. You can then determine whether it supplies medium or high temperature
         to the district heating network. You can then determine whether it supplies medium or high temperature
         heat in the <a href="/scenario/supply/heat/allocation-of-power-to-heat">District heating</a> section.
     flexibility_flexibility_power_to_heat_for_industry:
@@ -415,10 +369,7 @@ en:
       description: |
         Electricity can be used to produce synthetic kerosene through transforming hydrogen, electricity and CO<sub>2</sub>.
         In the ETM, this can be used as a flexible demand technology, which means that kerosene is only produced when the
-        Electricity can be used to produce synthetic kerosene through transforming hydrogen, electricity and CO<sub>2</sub>.
-        In the ETM, this can be used as a flexible demand technology, which means that kerosene is only produced when the
         willingness to pay exceeds the hourly electricity price. See our <a href="https://docs.energytransitionmodel.com/main/electricity-conversion" target=\"_blank\">
-        documentation</a> for more information. </br></br>
         documentation</a> for more information. </br></br>
         In the <a href="/scenario/emissions/ccus/utilisation-and-storage-of-co2">Utilisation and storage of CO<sub>2</sub> </a> section you can
         set the dispatchable capacity (in MWe-input) for synthetic kerosene production.
@@ -445,7 +396,6 @@ en:
       title: Hybrid offshore wind - components
       short_description:
       description: |
-        In this section, the capacity relative to the installed capacity of hybrid offshore wind
         In this section, the capacity relative to the installed capacity of hybrid offshore wind
         turbines (see the <a href="/scenario/supply/electricity_renewable/wind-turbines">Renewable electricity</a>
         section) can be set for the offshore electrolyser and electricity cable.
@@ -558,28 +508,17 @@ en:
       description: |
         This table takes the concepts learned in the previous sections a step further by analyzing
         the need for flexibility on different timescales for network gas and hydrogen. It shows the
-        This table takes the concepts learned in the previous sections a step further by analyzing
-        the need for flexibility on different timescales for network gas and hydrogen. It shows the
         need for flexible capacity and flexible volume for both supply and demand. </br></br>
-        The basis of the analysis is the <i>original imbalance</i> (the
-        <a href="/scenario/flexibility/flexibility_overview/residual-load-curves">residual load curve</a>),
-        which is shown first. The curve is then split into two timescales by applying a moving average. You
         The basis of the analysis is the <i>original imbalance</i> (the
         <a href="/scenario/flexibility/flexibility_overview/residual-load-curves">residual load curve</a>),
         which is shown first. The curve is then split into two timescales by applying a moving average. You
         can set the period of the moving average with the slider below.
         <ul>
         <li> The <i>short timescale</i> is given by the difference between the original residual
-        <li> The <i>short timescale</i> is given by the difference between the original residual
         load curve and the moving average, and is typically very variable. </li>
-        <li>The <i>long timescale</i> is given by the moving average, and is typically much more
         <li>The <i>long timescale</i> is given by the moving average, and is typically much more
         smooth. </li>
         </ul> </br>
-        For network gas and hydrogen, flexibility is provided by storage in the ETM. Large-scale storage
-        volumes for these carriers are typically realized underground. Two viable types of underground
-        storage are salt caverns and empty gas fields. Salt caverns are better suited to deliver short-term
-        flexibility, while empty gas fields can handle long-term flexibility better. There will be
         For network gas and hydrogen, flexibility is provided by storage in the ETM. Large-scale storage
         volumes for these carriers are typically realized underground. Two viable types of underground
         storage are salt caverns and empty gas fields. Salt caverns are better suited to deliver short-term
@@ -602,11 +541,7 @@ en:
         maximum excess and shortage for each energy carrier. This indicates whether you have installed enough flexible
         technologies to fully utilize the excesses and to fully meet the shortage. </br></br>
         Note that, for electricity, flexible supply technologies may also produce for flexible demand
-        Note that, for electricity, flexible supply technologies may also produce for flexible demand
         technologies. You can for example use electricity from batteries to produce hydrogen through power-to-gas.
-        This means that it is not necessarily inefficient to have more capacity installed than the maximum excess or
-        shortage. Also note that for the gaseous carriers the system is automatically balanced by storage. This means
-        that the storage capacity will align with the maximum excess and shortage by default.
         This means that it is not necessarily inefficient to have more capacity installed than the maximum excess or
         shortage. Also note that for the gaseous carriers the system is automatically balanced by storage. This means
         that the storage capacity will align with the maximum excess and shortage by default.


### PR DESCRIPTION
With this [commit](https://github.com/quintel/etmodel/commit/269ba7d8728f6f8c37902fbeb76a067aaa932567#diff-d2a0d14aef77ca601ae2b808741d3dc65d211aa11646e5852cee88a57775fa6f), some lines in `en_flexibility` were unintentionally duplicated. This is corrected with this PR. 