### PR TITLE
Add subheader 'electricity input' to storage capacity sliders

### DIFF
--- a/config/interface/slides/flexibility_storage.yml
+++ b/config/interface/slides/flexibility_storage.yml
@@ -13,23 +13,27 @@
   sidebar_item_key: flexibility_storage
   alt_output_element_key: energy_storage
   output_element_key: flexibility_hourly_p2p_storage
-- key: flexibility_power_storage_energy_flexibility_mv_batteries_electricity
+- general_sub_header: electricity_input
+  key: flexibility_power_storage_energy_flexibility_mv_batteries_electricity
   position: 300
   sidebar_item_key: flexibility_storage
   alt_output_element_key: energy_storage
   output_element_key: flexibility_hourly_p2p_storage
-- key: flexibility_power_storage_energy_flexibility_pumped_storage_electricity
+- general_sub_header: electricity_input
+  key: flexibility_power_storage_energy_flexibility_pumped_storage_electricity
   dependent_on: has_mountains
   position: 400
   sidebar_item_key: flexibility_storage
   alt_output_element_key: energy_storage
   output_element_key: flexibility_hourly_p2p_storage
-- key: flexibility_power_storage_energy_flexibility_hv_opac_electricity
+- general_sub_header: electricity_input
+  key: flexibility_power_storage_energy_flexibility_hv_opac_electricity
   position: 500
   sidebar_item_key: flexibility_storage
   alt_output_element_key: energy_storage
   output_element_key: flexibility_hourly_p2p_storage
-- key: flexibility_power_storage_energy_flexibility_flow_batteries_electricity
+- general_sub_header: electricity_input
+  key: flexibility_power_storage_energy_flexibility_flow_batteries_electricity
   position: 550
   sidebar_item_key: flexibility_storage
   alt_output_element_key: energy_storage

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -623,6 +623,7 @@ en:
     flexible_chps: "Dispatchable capacity"
     relative_capacity: "Relative capacity"
     technical_specifications: "Technical specifications"
+    technical_specifications_storage: "Technical specifications"
     technical_specifications_cars: "Technical specifications cars"
     technical_specifications_buses: "Technical specifications buses"
     technical_specifications_trucks: "Technical specifications trucks"


### PR DESCRIPTION
For clarification, the subheader 'electricity input' is added to storage technology capacity sliders, to indicate that sliders set the electricity input capacity. 