### PR TITLE
Merge household appliances efficiency sliders into one

### DIFF
--- a/app/models/slide.rb
+++ b/app/models/slide.rb
@@ -118,6 +118,7 @@ class Slide < YModel::Base
   end
 
   def subheader_image_available?
+    return false unless respond_to?(:subheader_image)
     return false if subheader_image.blank?
     return true if subheader_image_dependent_on_country.blank?
 

--- a/config/interface/input_elements/demand_households_appliances.yml
+++ b/config/interface/input_elements/demand_households_appliances.yml
@@ -1,43 +1,6 @@
 ---
-- key: households_appliances_fridge_freezer_electricity_efficiency
-  step_value: 0.1
-  unit: "%"
-  position: 2
-  slide_key: demand_households_appliances
-- key: households_appliances_dishwasher_electricity_efficiency
+- key: households_appliances_electricity_efficiency
   step_value: 0.1
   unit: "%"
   position: 1
-  slide_key: demand_households_appliances
-- key: households_appliances_vacuum_cleaner_electricity_efficiency
-  step_value: 0.1
-  unit: "%"
-  position: 7
-  slide_key: demand_households_appliances
-- key: households_appliances_washing_machine_electricity_efficiency
-  step_value: 0.1
-  unit: "%"
-  position: 3
-  slide_key: demand_households_appliances
-- key: households_appliances_clothes_dryer_electricity_efficiency
-  step_value: 0.1
-  unit: "%"
-  position: 4
-  slide_key: demand_households_appliances
-- key: households_appliances_television_electricity_efficiency
-  step_value: 0.1
-  unit: "%"
-  position: 5
-  slide_key: demand_households_appliances
-- key: households_appliances_computer_media_electricity_efficiency
-  step_value: 0.1
-  unit: "%"
-  interface_group: appliances_without_label
-  position: 6
-  slide_key: demand_households_appliances
-- key: households_appliances_other_electricity_efficiency
-  step_value: 0.1
-  unit: "%"
-  interface_group: appliances_without_label
-  position: 8
   slide_key: demand_households_appliances

--- a/config/interface/slides/households.yml
+++ b/config/interface/slides/households.yml
@@ -28,7 +28,6 @@
   output_element_key: source_of_cooking_in_households
 - general_sub_header: change
   key: demand_households_appliances
-  subheader_image:
   position: 130
   sidebar_item_key: households
   output_element_key: use_of_final_electricity_demand_in_households

--- a/config/interface/slides/households.yml
+++ b/config/interface/slides/households.yml
@@ -3,57 +3,41 @@
   position: 0
   sidebar_item_key: households
   output_element_key: use_of_final_demand_in_households
-- image: house.gif
-  key: demand_households_population
+- key: demand_households_population
   position: 100
   sidebar_item_key: households
   output_element_key: number_of_residences_overview
-- image: house_insulation.gif
-  key: demand_households_insulation
+- key: demand_households_insulation
   position: 105
   sidebar_item_key: households
   output_element_key: residential_heating_demand
-- image: house_heating.gif
-  group_sub_header: share_in_residences
+- group_sub_header: share_in_residences
   key: demand_households_heating
   position: 110
   sidebar_item_key: households
-  alt_output_element_key: source_of_heat_used_in_households
   output_element_key: source_of_heat_used_in_households
-- image: house_heating.gif
-  general_sub_header: share
+- general_sub_header: share
   key: demand_households_cooling
   position: 120
   sidebar_item_key: households
-  alt_output_element_key: source_of_cooling_in_households
   output_element_key: source_of_cooling_in_households
-- image: house_heating.gif
-  general_sub_header: share
+- general_sub_header: share
   key: demand_households_cooking
   position: 125
   sidebar_item_key: households
-  alt_output_element_key: source_of_cooking_in_households
   output_element_key: source_of_cooking_in_households
-- image: house_appliances.gif
-  general_sub_header: change
-  group_sub_header: change
-  subheader_image: energy_label.png
+- general_sub_header: change
   key: demand_households_appliances
   position: 130
   sidebar_item_key: households
-  alt_output_element_key: use_of_final_electricity_demand_in_households
   output_element_key: use_of_final_electricity_demand_in_households
-- image: house_lighting.gif
-  general_sub_header: share
+- general_sub_header: share
   key: demand_households_lighting
   position: 135
   sidebar_item_key: households
-  alt_output_element_key: use_of_final_electricity_demand_in_households
   output_element_key: use_of_final_electricity_demand_in_households
-- image: house.gif
-  group_sub_header: "%/year"
+- group_sub_header: "%/year"
   key: demand_households_demand_growth
   position: 140
   sidebar_item_key: households
-  alt_output_element_key: use_of_final_demand_in_households
   output_element_key: use_of_final_demand_in_households

--- a/config/interface/slides/households.yml
+++ b/config/interface/slides/households.yml
@@ -28,6 +28,7 @@
   output_element_key: source_of_cooking_in_households
 - general_sub_header: change
   key: demand_households_appliances
+  subheader_image:
   position: 130
   sidebar_item_key: households
   output_element_key: use_of_final_electricity_demand_in_households

--- a/config/locales/interface/input_elements/en_demand_households.yml
+++ b/config/locales/interface/input_elements/en_demand_households.yml
@@ -560,7 +560,7 @@ en:
         By increasing the slider, the efficency of household appliances is increased. This means the
         demand for electricity from appliances decreases. Conversely, decreasing the efficiency will
         increase the demand for electricity. </br></br>
-        Household appliances are divided into computers, dish washers, dryers, fridges, televisions,
+        This sliders sets the efficiency of computers, dish washers, dryers, fridges, televisions,
         vacuum cleaners, washing machines and other appliances.
     households_water_heater_solar_thermal_share:
       title: Solar thermal collectors

--- a/config/locales/interface/input_elements/en_demand_households.yml
+++ b/config/locales/interface/input_elements/en_demand_households.yml
@@ -553,85 +553,15 @@ en:
         <a href="https://docs.energytransitionmodel.com/main/heat-pumps/#air-source-heat-pumps" target=\"_blank\">documentation</a>.
         To influence the efficiency of this heatpump you can go to the <a href="/scenario/costs/costs_heat/heating-in-houses-and-buildings">Costs & efficiencies</a> section
         or choose to adjust the <a href="/scenario/flexibility/flexibility_weather/temperature-and-full-load-hours" >weather curve</a>.
-    households_appliances_fridge_freezer_electricity_efficiency:
-      title: Fridge / Freezer
-      short_description: ''
-      description: "How much more efficient do you think fridges and freezers will
-        be in the future?\r\n<br/><br/>\r\nNational and European legislation is forcing
-        household appliances to use ever less energy. The energy labels that are mandatory
-        nowadays in all European countries give a good indication of the energy efficiency
-        of household appliances. \r\n<br/><br/>\r\nThe starting value of this slider
-        is the current average label of fridges and freezers. Use the slider to give
-        an estimation of the average label of fridges and freezers in the future.
-        The A+++ label corresponds to an energy reduction of 66% compared to today.
-        \r\n\r\n"
-    households_appliances_dishwasher_electricity_efficiency:
-      title: Dish washer
-      short_description: ''
-      description: "How much more efficient do you think dish washers will be in the
-        future?\r\n<br/><br/>\r\nNational and European legislation is forcing household
-        appliances to use ever less energy. The energy labels that are mandatory nowadays
-        in all European countries give a good indication of the energy efficiency
-        of household appliances. \r\n<br/><br/>\r\nThe starting value of this slider
-        is the current average label of dish washers. Use the slider to give an estimation
-        of the average label of dish washers in the future. The A+++ label corresponds
-        to an energy reduction of 35% compared to today. "
-    households_appliances_vacuum_cleaner_electricity_efficiency:
-      title: Vacuum cleaner
-      short_description: ''
-      description: "How much more efficient do you think vacuum cleaners will be in
-        the future?\r\n<br/><br/>\r\nNational and European legislation is forcing
-        household appliances to use ever less energy. The energy labels that are mandatory
-        nowadays in all European countries give a good indication of the energy efficiency
-        of household appliances. \r\n<br/><br/>\r\nThe starting value of this slider
-        is the current average label of vacuum cleaners. Use the slider to give an
-        estimation of the average label of vacuum cleaners in the future. The A+++
-        label corresponds to an energy reduction of 75% compared to today. "
-    households_appliances_washing_machine_electricity_efficiency:
-      title: Washing machine
-      short_description: ''
-      description: "How much more efficient do you think washing machines will be
-        in the future?\r\n<br/><br/>\r\nNational and European legislation is forcing
-        household appliances to use ever less energy. The energy labels that are mandatory
-        nowadays in all European countries give a good indication of the energy efficiency
-        of household appliances. \r\n<br/><br/>\r\nThe starting value of this slider
-        is the current average label of washing machines. Use the slider to give an
-        estimation of the average label of washing machines in the future. The A+++
-        label corresponds to an energy reduction of 28% compared to today. \r\n"
-    households_appliances_clothes_dryer_electricity_efficiency:
-      title: Dryer
-      short_description: ''
-      description: "How much more efficient do you think wash dryers will be in the
-        future?\r\n<br/><br/>\r\nNational and European legislation is forcing household
-        appliances to use ever less energy. The energy labels that are mandatory nowadays
-        in all European countries give a good indication of the energy efficiency
-        of household appliances. \r\n<br/><br/>\r\nThe starting value of this slider
-        is the current average label of dryers. Use the slider to give an estimation
-        of the average label of dryers in the future. The A+++ label corresponds to
-        an energy reduction of 69% compared to today."
-    households_appliances_television_electricity_efficiency:
-      title: Television
-      short_description: ''
-      description: "How much more efficient do you think televisions will be in the
-        future?\r\n<br/><br/>\r\nNew technologies such as LED displays reduce energy
-        consumption. But keep in mind that large televisions of course consume more
-        energy than small ones using the same technology. As a result, each television
-        uses more energy today than it did several years ago.\r\n<br/><br/>\r\nThe
-        starting value of this slider is the current average label of televisions.
-        Use the slider to give an estimation of the average label of televisions in
-        the future. The A+++ label corresponds to an energy reduction of 92% compared
-        to today. "
-    households_appliances_computer_media_electricity_efficiency:
-      title: Computer / Media
-      short_description: ''
-      description: How much more efficient do you think computers and other audio/video
-        appliances (excluding television) will be in the future?
-    households_appliances_other_electricity_efficiency:
-      title: Other
-      short_description: ''
-      description: "How much more efficient do you think other appliances will be
-        in the future?\r\n<br/><br/>\r\nThis category includes: <br/>\r\n- Personal
-        care <br/>\r\n- Leisure <br/>\r\n- Kitchenware (exclusive of cooking) <br/>\r\n- Ventilation"
+    households_appliances_electricity_efficiency:
+      title: Efficiency
+      short_description:
+      description: |
+        By increasing the slider, the efficency of household appliances is increased. This means the
+        demand for electricity from appliances decreases. Conversely, decreasing the efficiency will
+        increase the demand for electricity. </br></br>
+        Household appliances are divided into computers, dish washers, dryers, fridges, televisions,
+        vacuum cleaners, washing machines and other appliances.
     households_water_heater_solar_thermal_share:
       title: Solar thermal collectors
       short_description: ''

--- a/config/locales/interface/input_elements/nl_demand_households.yml
+++ b/config/locales/interface/input_elements/nl_demand_households.yml
@@ -785,10 +785,10 @@ nl:
       title: Efficiëntie
       short_description:
       description: |
-        Door dit schuifje te verhogen, worden huisehoudelijke apparaten efficiënter. Dit betekent dat
+        Door dit schuifje te verhogen, worden huishoudelijke apparaten efficiënter. Dit betekent dat
         het elektriciteitsverbruik van deze apparaten lager wordt. Door de efficiëntie te verlagen
         wordt het elektriciteitsverbruik juist hoger. </br></br>
-        Huishoudelijke apparaten zijn onderverdeeld in computers, drogers, koelkasten, stofzuigers,
+        Dit schuifje beïnvloedt de efficiëntie van computers, drogers, koelkasten, stofzuigers,
         televisies, vaatwassers, wasmachines en overige apparaten.
     households_solar_pv_solar_radiation_market_penetration:
       title: PV zonnepanelen

--- a/config/locales/interface/input_elements/nl_demand_households.yml
+++ b/config/locales/interface/input_elements/nl_demand_households.yml
@@ -781,87 +781,15 @@ nl:
         Om de efficientie (COP) te beïnvloeden kun je naar de
         <a href="/scenario/costs/costs_heat/heating-in-houses-and-buildings" >Kosten & efficiënties</a> gaan
         of het <a href="/scenario/flexibility/flexibility_weather/temperature-and-full-load-hours" >weerjaar</a> aanpassen.
-    households_appliances_fridge_freezer_electricity_efficiency:
-      title: Koelkast / Vriezer
-      short_description: ''
-      description: "Hoeveel efficiënter zullen koelkasten en vriezers in de toekomst
-        zijn? \r\n<br/><br/>\r\nNationale en Europese wetgeving dwingt producenten
-        om huishoudelijke apparaten ieder jaar zuiniger te maken. De energielabels
-        die tegenwoordig in alle Europese landen verplicht zijn geven een goede indicatie
-        van de efficiëntie van huishoudelijke apparaten.\r\n<br/><br/>\r\nDe startwaarde
-        van dit schuifje is het gemiddelde label van koel-en-vrieskasten die nu geïnstalleerd
-        zijn. Zet het schuifje op het label dat jij denkt dat de gemiddelde koel-en-vrieskasten
-        hebben in de toekomst. Het A+++ label komt overeen met een besparing van 66%
-        ten opzichte van vandaag."
-    households_appliances_dishwasher_electricity_efficiency:
-      title: Vaatwasser
-      short_description: ''
-      description: "Hoeveel efficiënter zullen afwasmachines in de toekomst zijn?
-        \r\n<br/><br/>\r\nNationale en Europese wetgeving dwingt producenten om huishoudelijke
-        apparaten ieder jaar zuiniger te maken. De energielabels die tegenwoordig
-        in alle Europese landen verplicht zijn geven een goede indicatie van de efficiëntie
-        van huishoudelijke apparaten.\r\n<br/><br/>\r\nDe startwaarde van dit schuifje
-        is het gemiddelde label van afwasmachines die nu geïnstalleerd zijn. Zet het
-        schuifje op het label dat jij denkt dat de gemiddelde afwasmachine heeft in
-        de toekomst. Het A+++ label komt overeen met een besparing van 35% ten opzichte
-        van vandaag."
-    households_appliances_vacuum_cleaner_electricity_efficiency:
-      title: Stofzuiger
-      short_description: ''
-      description: "Hoeveel efficiënter zullen stofzuigers in de toekomst zijn? \r\n<br/><br/>\r\nNationale
-        en Europese wetgeving dwingt producenten om huishoudelijke apparaten ieder
-        jaar zuiniger te maken. De energielabels die tegenwoordig in alle Europese
-        landen verplicht zijn geven een goede indicatie van de efficiëntie van huishoudelijke
-        apparaten.\r\n<br/><br/>\r\nDe startwaarde van dit schuifje is het gemiddelde
-        label van stofzuigers die nu geïnstalleerd zijn. Zet het schuifje op het label
-        dat jij denkt dat de gemiddelde stofzuigers hebben in de toekomst. Het A+++
-        label komt overeen met een besparing van 75% ten opzichte van vandaag.\r\n"
-    households_appliances_washing_machine_electricity_efficiency:
-      title: Wasmachine
-      short_description: ''
-      description: "Hoeveel efficiënter zullen wasmachines in de toekomst zijn? \r\n<br/><br/>\r\nNationale
-        en Europese wetgeving dwingt producenten om wasmachines ieder jaar zuiniger
-        te maken. De energielabels die tegenwoordig in alle Europese landen verplicht
-        zijn geven een goede indicatie van de efficiëntie van huishoudelijke apparaten.\r\n<br/><br/>\r\nDe
-        startwaarde van dit schuifje is het gemiddelde label van wasmachines die nu
-        geïnstalleerd zijn. Zet het schuifje op het label dat jij denkt dat de gemiddelde
-        wasmachine heeft in de toekomst. Het A+++ label komt overeen met een besparing
-        van 28% ten opzichte van vandaag.\r\n"
-    households_appliances_clothes_dryer_electricity_efficiency:
-      title: Droger
-      short_description: ''
-      description: "Hoeveel efficiënter zullen wasdrogers in de toekomst zijn? \r\n<br/><br/>\r\nNationale
-        en Europese wetgeving dwingt producenten om huishoudelijke apparaten ieder
-        jaar zuiniger te maken. De energielabels die tegenwoordig in alle Europese
-        landen verplicht zijn geven een goede indicatie van de efficiëntie van huishoudelijke
-        apparaten.\r\n<br/><br/>\r\nDe startwaarde van dit schuifje is het gemiddelde
-        label van wasdrogers die nu geïnstalleerd zijn. Zet het schuifje op het label
-        dat jij denkt dat de gemiddelde wasdroger heeft in de toekomst. Het A+++ label
-        komt overeen met een besparing van 69% ten opzichte van vandaag.\r\n"
-    households_appliances_television_electricity_efficiency:
-      title: Televisie
-      short_description: ''
-      description: "Hoeveel efficiënter zullen televisies in de toekomst zijn? \r\n<br/><br/>\r\nNieuwe
-        technologieën zoals LED televisies reduceren de energie consumptie. Maar vergeet
-        niet dat grotere televisies natuurlijk meer energie verbruiken dan kleinere
-        met dezelfde technologie. Daardoor gebruikt één televisie nu meer energie
-        dan enkele jaren geleden.\r\n<br/><br/>\r\nDe startwaarde van dit schuifje
-        is het gemiddelde label van televisies die nu geïnstalleerd zijn. Zet het
-        schuifje op het label dat jij denkt dat de gemiddelde televisies hebben in
-        de toekomst. Het A+++ label komt overeen met een besparing van 92% ten opzichte
-        van vandaag."
-    households_appliances_computer_media_electricity_efficiency:
-      title: Computer / Media
-      short_description: ''
-      description: 'Hoeveel efficiënter zullen computers en andere audio/video apparatuur
-        (exclusief televisies) in de toekomst zijn? '
-    households_appliances_other_electricity_efficiency:
-      title: Overig
-      short_description: ''
-      description: "Hoeveel efficiënter zullen andere huishoudelijke apparaten in
-        de toekomst zijn? \r\n<br/><br/>\r\nDeze categorie omvat:<br/>\r\n- Persoonlijke
-        verzorging <br/>\r\n- Vrije tijd (klus gereedschap, naaimachine, elektrisch
-        speelgoed, etc.) <br/>\r\n- Keukenapparatuur (exclusief koken) <br/>\r\n- Ventilatie"
+    households_appliances_electricity_efficiency:
+      title: Efficiëntie
+      short_description:
+      description: |
+        Door dit schuifje te verhogen, worden huisehoudelijke apparaten efficiënter. Dit betekent dat
+        het elektriciteitsverbruik van deze apparaten lager wordt. Door de efficiëntie te verlagen
+        wordt het elektriciteitsverbruik juist hoger. </br></br>
+        Huishoudelijke apparaten zijn onderverdeeld in computers, drogers, koelkasten, stofzuigers,
+        televisies, vaatwassers, wasmachines en overige apparaten.
     households_solar_pv_solar_radiation_market_penetration:
       title: PV zonnepanelen
       short_description: ''

--- a/spec/models/slide_spec.rb
+++ b/spec/models/slide_spec.rb
@@ -25,7 +25,6 @@ describe Slide do
     it { is_expected.to respond_to(:image) }
     it { is_expected.to respond_to(:general_sub_header) }
     it { is_expected.to respond_to(:group_sub_header) }
-    it { is_expected.to respond_to(:subheader_image) }
     it { is_expected.to respond_to(:key) }
     it { is_expected.to respond_to(:position) }
     it { is_expected.to respond_to(:sidebar_item_key) }


### PR DESCRIPTION
This PR adresses https://github.com/quintel/etmodel/issues/4479. There are currently 8 household appliances efficiency sliders. This seems excessive. They are merged into one.

Should not be merged before the Deploy. The migration in ETEngine still has to be finished.

Goes with: 
- https://github.com/quintel/etsource/pull/3255
- https://github.com/quintel/etengine/pull/1568