### PR TITLE
Removing intelligent control lighting nodes and inputs

### DIFF
--- a/config/interface/input_elements/demand_buildings_lighting.yml
+++ b/config/interface/input_elements/demand_buildings_lighting.yml
@@ -17,15 +17,4 @@
   unit: "%"
   position: 3
   slide_key: demand_buildings_lighting
-- key: buildings_lighting_savings_from_motion_detection_light
-  step_value: 0.1
-  unit: "%"
-  interface_group: intelligent_control
-  position: 4
-  slide_key: demand_buildings_lighting
-- key: buildings_lighting_savings_from_daylight_control_light
-  step_value: 0.1
-  unit: "%"
-  interface_group: intelligent_control
-  position: 5
-  slide_key: demand_buildings_lighting
+

--- a/config/locales/interface/input_elements/en_demand_buildings.yml
+++ b/config/locales/interface/input_elements/en_demand_buildings.yml
@@ -287,29 +287,6 @@ en:
         make the LED tube cheaper. Their chief disadvantage at this moment is that
         they are not (yet) optimally suited for evenly lighting up a room and producing
         enough light for an office enviroment.\r\n"
-    buildings_lighting_savings_from_motion_detection_light:
-      title: Motion detection
-      short_description: ''
-      description: "How many buildings will employ motion detection?\r\n<br/><br/>\r\nMotion
-        detection is a mechanism that 'sees' whether someone is in the room. As soon
-        as someone enters the room the light switches on automatically and once nobody
-        is left in the room the light will turn off automatically.\r\n<br/><br/>\r\nThis
-        type of energy saving measure limits the amount of time a light is on to the
-        minimum required. It prevents lights from being switched on uselessly at night
-        or during lunch breaks for example."
-    buildings_lighting_savings_from_daylight_control_light:
-      title: Daylight-dependent control
-      short_description: ''
-      description: "How many buildings use daylight-dependent control?\r\n<br/><br/>\r\nDaylight-dependent
-        control is a mechanism that varies the amount of light from lamps in a room
-        by the light that comes from outside. If the sun is shining and it is already
-        light in the room it will switch off or dim the lights automatically. But
-        if it is dark or cloudy the system will make sure that the lamps in the room
-        give of enough light to work.\r\n<br/><br/>\r\nThis technology ensures that
-        lights are not on needlessly if there is already enough light coming from
-        outside. In combination with a motion detection system the lights will only
-        be on when someone is in the office and there is not enough light coming in
-        from outside."
     buildings_space_heater_solar_thermal_share:
       title: Solar thermal collectors
       short_description: ''

--- a/config/locales/interface/input_elements/nl_demand_buildings.yml
+++ b/config/locales/interface/input_elements/nl_demand_buildings.yml
@@ -279,28 +279,6 @@ nl:
         uiteindelijke goedkoper. Hun grootste nadeel op dit moment is dat ze (nog)
         niet geschikt zijn om een ruimte egaal te verlichten of om genoeg licht te
         produceren voor een kantooromgeving."
-    buildings_lighting_savings_from_motion_detection_light:
-      title: Bewegingsdetectie
-      short_description: ''
-      description: "Hoe veel gebouwen gebruiken bewegingsdetectie?\r\n<br/><br/>\r\nBewegingsdetectie
-        is een technologie dit 'ziet' of er iemand in een ruimte is. Zodra iemand
-        de ruimte binnenkomt gaat het licht aan en zodra iedereen weer weg is gaat
-        het licht automatisch weer uit.\r\n<br/><br/>\r\nOp deze manier wordt dus
-        de tijd dat een licht aanstaat verminderd tot het minimum. Het zorgt er bijvoorbeeld
-        voor dat lichten niet 's nachts of tijdens de lunch voor niets aan staan."
-    buildings_lighting_savings_from_daylight_control_light:
-      title: Daglicht afhankelijke regeling
-      short_description: ''
-      description: "In hoeveel gebouwen wordt daglicht afhankelijke regeling toegepast?\r\n<br/><br/>\r\nDaglicht
-        afhankelijke regeling is een technologie die aan de hand van de hoeveelheid
-        (dag)licht in een ruimte de lichtsterkte van de verlichting aanpast. Als de
-        zon schijnt en het is licht genoeg in een ruimte staat het licht niet aan,
-        of gedimd. Maar als het donker is of bewolkt past het systeem de verlichting
-        zo aan dat er toch genoeg licht is om te werken.\r\n<br/><br/>\r\nDeze technologie
-        zorgt er dus voor dat lichten niet nutteloos aanstaan omdat er al genoeg licht
-        van buiten komt. In combinatie met bewegingsdetectie kan er voor gezorgd worden
-        dat de lichten alleen aan staan als er mensen binnen in de ruimte zijn en
-        er niet al genoeg licht van buiten is."
     buildings_space_heater_solar_thermal_share:
       title: Zonthermische collectoren
       short_description: ''


### PR DESCRIPTION
This PR solves https://github.com/quintel/etmodel/issues/4490 by removing the intelligent control lighting nodes and inputs. 

Goes together with:
ETSource: https://github.com/quintel/etsource/pull/3264 
ETEngine: Migration; To be created
ETDataset: Removal of dataset keys; TBD