### PR TITLE
Fix broken links to gas mix in gas network

### DIFF
--- a/config/locales/interface/input_elements/en_emissions_ccus.yml
+++ b/config/locales/interface/input_elements/en_emissions_ccus.yml
@@ -138,7 +138,7 @@ en:
         CCGT capacity can be set in
         <a href="/scenario/supply/electricity/gas-plants">the Supply → Electricity → Gas plants section</a>.
         <br/><br/>
-        If <a href="/scenario/supply/biomass/green-gas-in-gas-network">green gas</a> is used,
+        If <a href="/scenario/supply/biomass/gas-mix-in-gas-network">green gas</a> is used,
         capture of CO<sub>2</sub> emissions could lead to so-called 'biogenic' or 'negative' emissions. 
         You can set the price you receive for biogenic CO<sub>2</sub> in the <a href="/scenario/costs/co2/prices">Costs & efficiencies</a> section.
         <br/><br/>

--- a/config/locales/interface/input_elements/en_supply_heat.yml
+++ b/config/locales/interface/input_elements/en_supply_heat.yml
@@ -400,8 +400,8 @@ en:
         supply side of the graph on the right.
         \r\n<br/><br/>\r\n 
         Note: network gas can be a mixture of natural gas and green gas. 
-        Checkout Supply > Biomass > <a href=\"/scenario/supply/biomass/green-gas-in-gas-network\" 
-        >(Green) gas in gas network</a> for more information."
+        Checkout Supply > Biomass > <a href=\"/scenario/supply/biomass/gas-mix-in-gas-network\" 
+        > Gas mix in gas network</a> for more information."
     capacity_of_energy_heat_burner_ht_waste_mix:
       title: Waste heater
       short_description:
@@ -473,7 +473,7 @@ en:
         supply side of the graph on the right.
         \r\n<br/><br/>\r\n 
         Note: network gas can be a mixture of natural gas and green gas. 
-        Checkout Supply > Biomass > <a href=\"/scenario/supply/biomass/green-gas-in-gas-network\" 
+        Checkout Supply > Biomass > <a href=\"/scenario/supply/biomass/gas-mix-in-gas-network\" 
         >(Green) gas in gas network</a> for more information."
     capacity_of_energy_heat_burner_mt_waste_mix:
       title: Waste heater

--- a/config/locales/interface/input_elements/nl_emissions_ccus.yml
+++ b/config/locales/interface/input_elements/nl_emissions_ccus.yml
@@ -147,7 +147,7 @@ nl:
         prijsontwikkelingen.<br/><br/>
         Het opgestelde vermogen aan STEG gascentrales is in te stellen op de
         <a href="/scenario/supply/electricity/gas-plants">elektriciteitspagina</a>.<br/><br/>
-        Als er <a href="/scenario/supply/biomass/green-gas-in-gas-network">groen gas</a> wordt
+        Als er <a href="/scenario/supply/biomass/gas-mix-in-gas-network">groen gas</a> wordt
         gebruikt in deze centrales voor het produceren van elektriciteit, ontstaan er
         (boekhoudkundig) "biogene" of "negatieve" emissies in jouw scenario als deze CO<sub>2</sub>
         wordt afgevangen. Meer hierover lees je in de

--- a/config/locales/interface/input_elements/nl_supply_heat.yml
+++ b/config/locales/interface/input_elements/nl_supply_heat.yml
@@ -344,8 +344,8 @@ nl:
         aanbodkant van de grafiek rechts.
         \r\n<br/><br/>\r\n 
         Let op: netwerkgas kan bestaan uit een mengsel van aardgas en biogas.
-        Zie Aanbod > Biomassa > <a href=\"/scenario/supply/biomass/green-gas-in-gas-network\" 
-        >(Groen) gas in gasnetwerk</a> voor meer informatie."
+        Zie Aanbod > Biomassa > <a href=\"/scenario/supply/biomass/gas-mix-in-gas-network\" 
+        > Gasmix in gasnetwerk</a> voor meer informatie."
     capacity_of_energy_heat_burner_ht_waste_mix:
       title: Afvalketel
       short_description:
@@ -414,7 +414,7 @@ nl:
         aanbodkant van de grafiek rechts.
         \r\n<br/><br/>\r\n 
         Let op: netwerkgas kan bestaan uit een mengsel van aardgas en biogas.
-        Zie Aanbod > Biomassa > <a href=\"/scenario/supply/biomass/green-gas-in-gas-network\" 
+        Zie Aanbod > Biomassa > <a href=\"/scenario/supply/biomass/gas-mix-in-gas-network\" 
         >(Groen) gas in gasnetwerk</a> voor meer informatie."
     capacity_of_energy_heat_burner_mt_waste_mix:
       title: Afvalketel

--- a/config/locales/interface/slides/en_supply.yml
+++ b/config/locales/interface/slides/en_supply.yml
@@ -4,7 +4,7 @@ en:
       title: Overview
       short_description:
       description: "Biomass can be used in different places throughout the model:\r\n<ul>\r\n
-        \ <li>as <a href=\"/scenario/supply/biomass/green-gas-in-gas-network\">green
+        \ <li>as <a href=\"/scenario/supply/biomass/gas-mix-in-gas-network\">green
         gas</a> in the gas network</li>\r\n  <li>in biomass heaters for <a href=\"/scenario/supply/heat/heat-sources\">(local)
         heat networks</a></li>\r\n  <li>as <a href=\"/scenario/supply/transport_fuels/road-transport\">transport
         fuel</a>: bio-ethanol, biodiesel, bio-LNG and bio-kerosene</li>\r\n  <li>as
@@ -178,7 +178,7 @@ en:
         technologies. In the <a href='/scenario/supply/ccus/capture-of-co2'>CCUS</a> section,
         it is possible to add a CO<sub>2</sub> capture unit to these power plants to reduce
         their emissions. In the
-        <a href='/scenario/supply/biomass/green-gas-in-gas-network'>green gas</a>
+        <a href='/scenario/supply/biomass/gas-mix-in-gas-network'>green gas</a>
         section, you can make assumptions about the amount of green gas in the gas network.
     supply_electricity_nuclear_plant:
       title: Nuclear plants

--- a/config/locales/interface/slides/nl_supply.yml
+++ b/config/locales/interface/slides/nl_supply.yml
@@ -5,7 +5,7 @@ nl:
       title: Overzicht
       short_description:
       description: "Biomassa kan op verschillende plekken in het model worden ingezet:\r\n<ul>\r\n
-        \ <li>als <a href=\"/scenario/supply/biomass/green-gas-in-gas-network\">groen gas</a>
+        \ <li>als <a href=\"/scenario/supply/biomass/gas-mix-in-gas-network\">groen gas</a>
         in het gas netwerk</li>\r\n  <li>in biomassaketels voor <a href=\"/scenario/supply/heat/heat-sources\">(lokale)
         warmtenetten</a></li>\r\n  <li>als <a href=\"/scenario/supply/transport_fuels/road-transport\">transportbrandstof</a>:
         bio-ethanol, biodiesel, bio-LNG and biokerosine</li>\r\n  <li>als meestook
@@ -186,7 +186,7 @@ nl:
         typen gascentrales. In de <a href='/scenario/supply/ccus/capture-of-co2'>CCUS</a>
         sectie kun je aangeven of deze centrales zijn uitgerust met een CO<sub>2</sub>-afvanginstallatie
         om de emissies omlaag te brengen. Op de
-        <a href='/scenario/supply/biomass/green-gas-in-gas-network'>groen gas</a>pagina
+        <a href='/scenario/supply/biomass/gas-mix-in-gas-network'>groen gas</a>pagina
         kun je aannames doen over de hoeveelheid groen gas in het gasnet.
     supply_electricity_nuclear_plant:
       title: Kerncentrales


### PR DESCRIPTION
This PR closes https://github.com/quintel/etmodel/issues/4492 by fixing the broken links to the gas mix section.
