### PR TITLE
Update custom curves documentation

### DIFF
--- a/config/locales/interface/slides/en_flexibility.yml
+++ b/config/locales/interface/slides/en_flexibility.yml
@@ -733,10 +733,10 @@ en:
         in the ETM. Note that the uploaded custom profiles are scenario inputs; based on these profiles,
         the model calculates the resulting (hourly) flows.<br/><br/>
         Different types of profiles are distinguished. By selecting a category below, details of the relevant profile type
-        and file requirements are provided. More information can be found in the
+        and file requirements are provided. Uploaded curves can also be downloaded again, they will be obtained in the
+        same format as uploaded. More information can be found in the
         <a href="https://docs.energytransitionmodel.com/main/curves#modifying-profiles"
-        target =\"_blank\">documentation</a>. Uploaded curves can also be downloaded again here, they will be obtained in the
-        same format as uploaded.<br/><br/>
+        target =\"_blank\">documentation</a>.<br/><br/>
         The result of the uploaded custom profile is reflected in the chart on the right.
         Hourly supply and demand profiles containing the hourly energy flows (as a result of scenario
         calculations) can be downloaded in the <a href="/scenario/data/data_export/overview">Data export</a>

--- a/config/locales/interface/slides/en_flexibility.yml
+++ b/config/locales/interface/slides/en_flexibility.yml
@@ -735,7 +735,8 @@ en:
         Different types of profiles are distinguished. By selecting a category below, details of the relevant profile type
         and file requirements are provided. More information can be found in the
         <a href="https://docs.energytransitionmodel.com/main/curves#modifying-profiles"
-        target =\"_blank\">documentation</a>.<br/><br/>
+        target =\"_blank\">documentation</a>. Uploaded curves can also be downloaded again here, they will be obtained in the
+        same format as uploaded.<br/><br/>
         The result of the uploaded custom profile is reflected in the chart on the right.
         Hourly supply and demand profiles containing the hourly energy flows (as a result of scenario
         calculations) can be downloaded in the <a href="/scenario/data/data_export/overview">Data export</a>

--- a/config/locales/interface/slides/en_flexibility.yml
+++ b/config/locales/interface/slides/en_flexibility.yml
@@ -737,7 +737,8 @@ en:
         same format as uploaded. More information can be found in the
         <a href="https://docs.energytransitionmodel.com/main/curves#modifying-profiles"
         target =\"_blank\">documentation</a>.<br/><br/>
-        The result of the uploaded custom profile is reflected in the chart on the right.
-        Hourly supply and demand profiles containing the hourly energy flows (as a result of scenario
-        calculations) can be downloaded in the <a href="/scenario/data/data_export/overview">Data export</a>
+        Based on annual flows and the uploaded hourly supply or demand profiles, the model calculates the resulting
+        hourly flows as scenario output. The resulting profiles that represent the hourly energy flows are
+        depicted in the chart on the right per supply and demand category. The output profiles can also
+        be downloaded in the <a href="/scenario/data/data_export/overview">Data export</a>
         section.

--- a/config/locales/interface/slides/en_flexibility.yml
+++ b/config/locales/interface/slides/en_flexibility.yml
@@ -729,33 +729,14 @@ en:
       title: Upload curves
       short_description:
       description: |
-        The ETM calculates the hourly production and demand of gas, electricity, heat and hydrogen.
-        On this page you can upload your own hourly profiles to overwrite the default profiles used
-        in the ETM. You can upload three types of profiles:
-
-        <br /><br />
-
-        1. <b>Demand</b> profiles (e.g. electric buses, industry heating)
-
-        <br />
-
-        2. <b>Production</b> profiles (e.g. solar PV, wind offshore)
-        <br />
-
-        3. <b>Price</b> curves (e.g. for power interconnectors)
-
-        <br /><br />
-        In the form below, you can select a category and upload a CSV file with your own profile.
-        More information about the file requirements for each type of profile can be found on the
-        <a href="https://docs.energytransitionmodel.com/main/curves#modifying-profiles">documentation page</a>
-        and by clicking on the question mark ('?') in the form below.
-
-        <br /><br />
-        The chart on the right shows the profiles of all categories that can be modified. If you upload a custom profile,
-        this is reflected in the chart. Note that if a technology is not present in your scenario, the chart series will be empty.
-        By default, the chart shows the <i>daily</i> peak capacity of the profile for the whole year. Select a month or week in
-        the dropdown menu to see the <i>hourly</i> values.
-        <br /><br />
-        You can download the hourly demand and supply curves in your scenario in the
-        <a href="/scenario/data/data_export/energy-flows">Results → Data export</a> section.
-        <br /><br />
+        In this section, custom hourly profiles can be uploaded in CSV format to overwrite the default profiles used
+        in the ETM. Note that the uploaded custom profiles are scenario inputs; based on these profiles,
+        the model calculates the resulting (hourly) flows.<br/><br/>
+        Different types of profiles are distinguished. By selecting a category below, details of the relevant profile type
+        and file requirements are provided. More information can be found in the
+        <a href="https://docs.energytransitionmodel.com/main/curves#modifying-profiles"
+        target =\"_blank\">documentation</a>.<br/><br/>
+        The result of the uploaded custom profile is reflected in the chart on the right.
+        Hourly supply and demand profiles containing the hourly energy flows (as a result of scenario
+        calculations) can be downloaded in the <a href="/scenario/data/data_export/overview">Data export</a>
+        section.

--- a/config/locales/interface/slides/nl_flexibility.yml
+++ b/config/locales/interface/slides/nl_flexibility.yml
@@ -757,7 +757,8 @@ nl:
         categorie hieronder wordt aangegeven welk type profiel moet worden
         geüpload en wat de bestandsvereisten zijn.
         Raadpleeg de <a href="https://docs.energytransitionmodel.com/main/curves#modifying-profiles"
-        target =\"_blank\">documentatie</a> voor meer informatie.<br/><br/>
+        target =\"_blank\">documentatie</a> voor meer informatie. Geüploade profielen kunnen hier ook weer
+        worden gedownload, deze worden verkregen in hetzelfde format als dat deze zijn geüpload.<br/><br/>
         Het resultaat van geüploade profielen kan in de grafiek hiernaast worden ingezien.
         De uurlijkse vraag- en aanbodprofielen met de uurlijkse energiestromen (als resultaat van de
         modellering) kunnen worden gedownload in de <a href="/scenario/data/data_export/overview">

--- a/config/locales/interface/slides/nl_flexibility.yml
+++ b/config/locales/interface/slides/nl_flexibility.yml
@@ -759,7 +759,9 @@ nl:
         worden gedownload, waarin ze in hetzelfde format worden verkregen als dat deze zijn geüpload.
         Raadpleeg de <a href="https://docs.energytransitionmodel.com/main/curves#modifying-profiles"
         target =\"_blank\">documentatie</a> voor meer informatie. <br/><br/>
-        Het resultaat van geüploade profielen kan in de grafiek hiernaast worden ingezien.
-        De uurlijkse vraag- en aanbodprofielen met de uurlijkse energiestromen (als resultaat van de
-        modellering) kunnen worden gedownload in de <a href="/scenario/data/data_export/overview">
+        Op basis van jaarlijkse energiestromen en de geüploade vraag- en aanbodprofielen berekent het model
+        de resulterende uurlijkse energiestromen als scenario-output. De resulterende profielen die de
+        uurlijkse energiestromen representeren, worden in de grafiek hiernaast getoond per vraag- en
+        aanbodcategorie. De outputprofielen kunnen ook worden gedownload in de
+        <a href="/scenario/data/data_export/overview">
         Data-export</a> sectie.

--- a/config/locales/interface/slides/nl_flexibility.yml
+++ b/config/locales/interface/slides/nl_flexibility.yml
@@ -755,10 +755,10 @@ nl:
         van deze profielen berekent het model de resulterende (uurlijkse) energiestromen.<br/><br/>
         Er wordt onderscheid gemaakt in verschillende typen profielen. Bij het selecteren van een
         categorie hieronder wordt aangegeven welk type profiel moet worden
-        geüpload en wat de bestandsvereisten zijn.
+        geüpload en wat de bestandsvereisten zijn. Geüploade profielen kunnen ook weer
+        worden gedownload, waarin ze in hetzelfde format worden verkregen als dat deze zijn geüpload.
         Raadpleeg de <a href="https://docs.energytransitionmodel.com/main/curves#modifying-profiles"
-        target =\"_blank\">documentatie</a> voor meer informatie. Geüploade profielen kunnen hier ook weer
-        worden gedownload, deze worden verkregen in hetzelfde format als dat deze zijn geüpload.<br/><br/>
+        target =\"_blank\">documentatie</a> voor meer informatie. <br/><br/>
         Het resultaat van geüploade profielen kan in de grafiek hiernaast worden ingezien.
         De uurlijkse vraag- en aanbodprofielen met de uurlijkse energiestromen (als resultaat van de
         modellering) kunnen worden gedownload in de <a href="/scenario/data/data_export/overview">

--- a/config/locales/interface/slides/nl_flexibility.yml
+++ b/config/locales/interface/slides/nl_flexibility.yml
@@ -425,7 +425,7 @@ nl:
     flexibility_merit_order_merit_order:
       title: Merit order
       short_description:
-      description: 
+      description:
         Over het algemeen volgt de elektriciteitsproductie de vraag naar
         elektriciteit. De volgorde waarin elektriciteitscentrales worden ingeschakeld
         wordt bepaald door de 'merit order'. De merit order rangschikt de elektriciteitscentrales
@@ -750,32 +750,15 @@ nl:
     multi_curve_upload:
       title: Curve upload
       description: |
-        Het ETM rekent vraag en aanbod van gas, elekriciteit, warmte en waterstof uit op uurbasis.
-        Op deze pagina kun je je eigen uurprofielen in het ETM laden om de standaardprofielen te
-        overschrijven. Er zijn drie typen uurprofielen die je kunt uploaden:
-
-        <br /><br />
-
-        1. <b>Vraag</b>profielen (bijv. elektrische bussen, warmte in industrie)
-
-        <br />
-
-        2. <b>Aanbod</b>profielen (bijv. zon PV, wind op zee)
-
-        <br />
-
-        3. <b>Prijs</b>curves (bijv. voor elektriciteitsinterconnectoren)
-        <br /><br />
-        In het formulier hieronder kun je een categorie selecteren en een CSV-bestand met jouw eigen profiel
-        uploaden. Meer informatie over de bestandsvereisten voor elk type profiel kun je vinden in de
-        <a href="https://docs.energytransitionmodel.com/main/curves#modifying-profiles" target=\"_blank\">documentatie</a>
-        en door te klikken op het vraagteken ('?') in het onderstaande formulier.
-
-        <br /><br />
-        De grafiek rechts laat de profielen zien van alle aanpasbare categorieën. Als je een profiel uploadt,
-        verandert de chart mee. Let op: als een technologie niet gebruikt wordt in jouw scenario laat de grafiek een
-        lege serie zien. Standaard geeft de grafiek de piekcapaciteit per <i>dag</i> weer voor het hele jaar.
-        Selecteer een maand of week in het dropdown-menu om de <i>uurlijkse</i> waardes te zien.
-        <br/><br/>
-        Je kunt de uurlijkse vraag- en aanbodprofielen in jouw scenario downloaden in de
-        <a href="/scenario/data/data_export/energy-flows">Resultaten → Data-export</a>sectie.
+        Hieronder kunnen de standaardprofielen van het ETM worden overschreven door eigen profielen
+        in CSV format te uploaden. Merk op dat geüploade eigen profielen scenario inputs zijn; op basis
+        van deze profielen berekent het model de resulterende (uurlijkse) energiestromen.<br/><br/>
+        Er wordt onderscheid gemaakt in verschillende typen profielen. Bij het selecteren van een
+        categorie hieronder wordt aangegeven welk type profiel moet worden
+        geüpload en wat de bestandsvereisten zijn.
+        Raadpleeg de <a href="https://docs.energytransitionmodel.com/main/curves#modifying-profiles"
+        target =\"_blank\">documentatie</a> voor meer informatie.<br/><br/>
+        Het resultaat van geüploade profielen kan in de grafiek hiernaast worden ingezien.
+        De uurlijkse vraag- en aanbodprofielen met de uurlijkse energiestromen (als resultaat van de
+        modellering) kunnen worden gedownload in de <a href="/scenario/data/data_export/overview">
+        Data-export</a> sectie.

--- a/config/locales/nl_custom_curves.yml
+++ b/config/locales/nl_custom_curves.yml
@@ -122,7 +122,7 @@ nl:
       interconnector_9_import_must_run: Interconnector 9 import must run
       interconnector_10_import_must_run: Interconnector 10 import must run
       interconnector_11_import_must_run: Interconnector 11 import must run
-      interconnector_12_import_must_run: Interconnector 12 import must run      
+      interconnector_12_import_must_run: Interconnector 12 import must run
       weather/air_temperature: Buitentemperatuur
       weather/buildings_heating: Verwarming gebouwen
       bunkers_ships_electricity: Bunkers elektrische scheepvaart
@@ -216,6 +216,6 @@ nl:
         type: Profiel
         help: |
           Je kunt profielen aanpassen door een CSV-bestand met een eigen profiel te uploaden. Dit
-          bestand moet uit 8760 rijen bestaan (één voor elk uur per jaar). Maakt de gebruikte
-          eenheid niet uit: het ETM gebruikt alleen de vorm van het profiel (de relatieve verdeling
+          bestand moet uit 8760 rijen bestaan (één voor elk uur per jaar). De gebruikte
+          eenheid maakt niet uit: het ETM gebruikt alleen de vorm van het profiel (de relatieve verdeling
           van de vraag over de tijd).


### PR DESCRIPTION
Related to this [PR](https://github.com/quintel/etengine/pull/1565) that ensures that uploaded custom curves with `capacity_profile` are also downloaded again in the same format, there is a need to update descriptions accordingly. 

This PR therefore updates descriptions to:
- Improve clarity about in which format custom curves should be uploaded
- Indicate that the downloaded custom curves are obtained in the same format
- Underline that these curves represent scenario input and are thus not the outcome of scenario calculations

Along the way, some outdated documentation regarding custom curves is deleted or updated where relevant. 

Goes with:
- https://github.com/quintel/etengine/pull/1565
- https://github.com/quintel/documentation/pull/230
- https://github.com/quintel/etmodel/pull/4494