### PR TITLE
Clear up open session-scenario view

### DIFF
--- a/app/assets/stylesheets/_general_styles.sass
+++ b/app/assets/stylesheets/_general_styles.sass
@@ -12,6 +12,7 @@ $landing-background-color: #fbf7f6
 $landing-border-color: #d0d5d8
 $soft-grey: #fdfdfd
 $dark-cream: #fdece0
+$text-light-grey: #aba8a7
 
 @mixin etm-link
   color: $link-color

--- a/app/assets/stylesheets/_scenarios.sass
+++ b/app/assets/stylesheets/_scenarios.sass
@@ -75,14 +75,14 @@ table.default
       margin-left: 0
 
   &#show_scenario, &#feature_scenario, &#index
-    width: $landing-width + 400px
+    width: $landing-width
     margin: 0 auto 3rem
     display: flex
     min-height: 655px
 
     .internal-box
       width: 100%
-      background: white
+      background: $landing-background-color
       border-radius: 0 10px 10px 0
       padding: 15px 40px 40px
       display: flex
@@ -93,11 +93,12 @@ table.default
     .version-warning
       background: #f0f7ee image-url('icons/warning-information.svg') 1.5rem 1.25rem no-repeat
       background-size: 2rem
-      border-left: 3px solid #79a765
       color: #455f39
       font-size: 14px
       margin-bottom: 1rem
+      margin-top: auto
       padding: 1rem 1.5rem 1rem 4.5rem
+      border-radius: 8px
 
       dt
         font-weight: 600
@@ -603,7 +604,9 @@ table.default
         color: #333
 
     .note
-      font-size: 10px
+      font-size: 14px
+      line-height: 1.5
+      color: $text-light-grey
 
   &#feature_scenario
     .field_with_errors

--- a/app/views/scenarios/_share_links.html.haml
+++ b/app/views/scenarios/_share_links.html.haml
@@ -1,9 +1,0 @@
-.sharing-links
-  .copy-link
-    %a
-      .icon{ class: 'fa fa-copy' }
-      = t('scenario.share.copy')
-    .copy-box
-      .arrow
-      .cross{ class: 'fa fa-times', title: 'Close' }
-      .url= text_field_tag 'url', request.original_url

--- a/app/views/scenarios/show.html.haml
+++ b/app/views/scenarios/show.html.haml
@@ -19,47 +19,13 @@
         %li.with-button
           = link_to t("scenario.load"), load_scenario_path(@scenario), class: "scenario-button button load no-margin-right"
 
-      .row
-        %ul.details.stick-right
-          %li{ style: 'margin-right: 1rem; padding-right: 0' }
-            .dropdown#scenario-location<>
-              %button.scenario-actions#scenario-location-button{ aria: { expanded: 'false' }, data: { toggle: 'dropdown' }, type: 'button' }
-                = inline_svg_tag 'hero/20/cog.svg'
-                = t('settings')
-                %span.fa.fa-caret-down
-              %ul.dropdown-menu.dropdown-menu-right{ 'aria-labelledby': 'scenario-location-button', style: 'margin-top: 3px' }
-                %li
-                  = link_to load_scenario_path(@scenario), class: 'dropdown-item' do
-                    .fa.fa-folder-open
-                    = t("scenario.load")
-                %li
-                  = link_to energy_mix_scenario_path(@scenario.id), class: 'dropdown-item' do
-                    .fa.fa-map-signs
-                    = t("scenario.load_energy_mix")
-
-          :javascript
-            new DropdownView({ el: $('#scenario-location') }).render()
-
-          %li{ style: 'margin-right: 1rem; padding-right: 0' }
-            .dropdown#scenario-copy<>
-              %button.scenario-actions#scenario-copy-button{ aria: { expanded: 'false' }, data: { toggle: 'dropdown' }, type: 'button' }
-                .icon{ class: 'fa fa-copy' }
-                = t('scenario.share.copy')
-                %span.fa.fa-caret-down
-              %ul.dropdown-menu.dropdown-menu-right{ 'aria-labelledby': 'scenario-copy-button', style: 'margin-top: 3px' }
-                %li
-                  .info
-                    = t('scenario.share.copy_description')
-                %li.sep-above
-                  .url= text_field_tag 'url', request.original_url
-          :javascript
-            new DropdownView({ el: $('#scenario-copy') }).render()
       .bar
 
       - if @scenario.description
         = formatted_scenario_description(@scenario.description)
 
-      = render partial: 'scenarios/version_warning', locals: { scenario: @scenario }
-
       %p.note
-        = t("scenario.overwritten")
+        = t("scenario.overwritten").html_safe
+
+
+      = render partial: 'scenarios/version_warning', locals: { scenario: @scenario }

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -307,7 +307,11 @@ en:
     load_energy_mix: "Open energy mix infographic"
     no_title: "Scenario without title"
     overview: "overview"
-    overwritten: "Please note: Save your current scenario before opening another, or your changes might get lost."
+    overwritten: |
+      Save your current scenario before opening another, or your changes might get lost. </br>
+      Opening this scenario will open a copy of the originial. Changes to the copy will not
+      be directly reflected in the original scenario. You can later save the copy as a new version
+      using 'Save as..'.
     provide_title: "Please provide a title for the scenario."
     reset_to_preset_confirmation: "Are you sure you want to reset this scenario to its preset"
     save: "Save your scenario"

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -307,7 +307,12 @@ nl:
     load_energy_mix: "Open energie-mix infographic"
     no_title: "Scenario zonder titel"
     overview: "overzicht"
-    overwritten: "Let op: Sla je huidige scenario eerst op voor je een nieuwe opent. Je wijzigingen kunnen verloren gaan."
+    overwritten: |
+      Sla je huidige scenario eerst op voor je een nieuwe opent.
+      Je wijzigingen kunnen verloren gaan.</br>
+      Het openen van dit scenario opent een kopie van het origineel.
+      Aanpassingen die aan deze kopie worden gedaan, worden niet direct gereflecteerd in
+      het origineel. De kopie kan als nieuwe versie worden opgeslagen via 'Opslaan als...'.
     provide_title: "Geef het scenario een titel."
     reset_to_preset_confirmation: "Weet u zeker dat u dit scenario wilt resetten naar de preset?"
     save: "Sla uw scenario op"


### PR DESCRIPTION
Make sure open button is shown on smaller screens, add extra info about opening and saving scenarios and remove links to the energy-mix infographic from the open scenario session view.

<img width="1723" alt="Screenshot 2025-06-17 at 16 03 08" src="https://github.com/user-attachments/assets/ed10dc44-fa5e-4af1-9f75-26782f1da668" />

References #4483 