### PR TITLE
Retire outdated dataset de (2015) and dk (2015)

### DIFF
--- a/config/locales/en_areas.yml
+++ b/config/locales/en_areas.yml
@@ -1,7 +1,5 @@
 en:
   areas:
-    de: "Germany"
-    dk: "Denmark"
     nl: "Netherlands"
     EU27_european_union_27_countries: "European Union (27 countries)"
     nl2019: "Netherlands"

--- a/config/locales/nl_areas.yml
+++ b/config/locales/nl_areas.yml
@@ -1,7 +1,5 @@
 nl:
   areas:
-    de: "Duitsland"
-    dk: "Denemarken"
     nl: "Nederland"
     EU27_european_union_27_countries: "Europese Unie (27 landen)"
     nl2019: "Nederland"


### PR DESCRIPTION
The datasets for Germany de (2015) and Denmark dk (2015) are outdated and are retired. See https://github.com/quintel/etsource/issues/3227.

Goes with:
- https://github.com/quintel/etsource/pull/3275
- https://github.com/quintel/etdataset/pull/1040
- https://github.com/quintel/etmodel/pull/4518
- https://github.com/quintel/my-etm/pull/145
- https://github.com/quintel/etengine/pull/1598