### PR TITLE
Update slider texts transport

### DIFF
--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -550,7 +550,7 @@ en:
     insulation_terraced_houses: "Typical heat demand terraced houses"
     insulation_semi_detached_houses: "Typical heat demand semi-detached houses"
     insulation_detached_houses: "Typical heat demand detached houses"
-    electric_vehicles_charging_strategy: "Charging strategy for electric vehicles"
+    electric_vehicles_charging_strategy: "Charging strategy for electric cars"
     flexibility_buffers_space: "Buffer size for households space heating"
     flexibility_buffers_water: "Buffer size for households hot water"
     flexibility_cop: "Threshold COP for hybrid heat pumps"

--- a/config/locales/interface/input_elements/en_demand_transport.yml
+++ b/config/locales/interface/input_elements/en_demand_transport.yml
@@ -105,7 +105,7 @@ en:
         electric cars. Electric cars typically use less energy than fuel-powered cars
         such as diesel and gasoline cars.<br/><br/>
         The charging behavior of electric cars can be adjusted in the
-        <a href="/scenario/flexibility/flexibility_net_load/demand-response-electric-vehicles">
+        <a href="/scenario/flexibility/flexibility_net_load/demand-response-electric-cars">
         Net load</a> section. Additionally, the batteries of electric vehicles can be used for
         electricity storage. Go to the
         <a href="/scenario/flexibility/flexibility_storage/batteries-in-electric-vehicles">

--- a/config/locales/interface/input_elements/nl_demand_transport.yml
+++ b/config/locales/interface/input_elements/nl_demand_transport.yml
@@ -111,7 +111,7 @@ nl:
         elektrische auto's. Elektrische auto's gebruiken typisch minder energie dan brandstofauto's
         zoals diesel- en benzineauto's.<br/><br/>
         Het laadgedrag van elektrische auto's kan worden aangepast in de sectie
-        <a href="/scenario/flexibility/flexibility_net_load/demand-response-electric-vehicles">
+        <a href="/scenario/flexibility/flexibility_net_load/demand-response-electric-cars">
         Netbelasting</a>. Daarnaast kunnen de batterijen van elektrische voertuigen worden ingezet
         voor elektriciteitsopslag. Ga naar de sectie
         <a href="/scenario/flexibility/flexibility_storage/batteries-in-electric-vehicles">

--- a/config/locales/interface/slides/en_demand.yml
+++ b/config/locales/interface/slides/en_demand.yml
@@ -348,7 +348,7 @@ en:
       description:  Will there be a shift away from cars that run on fossil fuels? How
         will a massive roll-out of electric cars affect energy use? Please indicate
         what cars we drive in the future. In the <a href="/scenario/demand/transport_fuels/road-transport">road fuels section</a> you can determine which fuel blends cars will use
-        and in the <a href="/scenario/flexibility/flexibility_demand/demand-response-electric-vehicles">demand response ev section</a> you can determine where electric cars will
+        and in the <a href="/scenario/flexibility/flexibility_demand/demand-response-electric-cars">demand response ev section</a> you can determine where electric cars will
         charge.
     demand_transport_bicycle_technology:
       title: Bicycle technology
@@ -362,7 +362,7 @@ en:
         How will a massive roll-out of electric cars affect energy use? Please indicate
         what cars we drive in the future. In the <a href="/scenario/demand/transport_fuels/road-transport"
         >road fuels section</a> you can determine which fuel blends cars will use
-        and in the <a href="/scenario/flexibility/flexibility_net_load/demand-response-electric-vehicles"
+        and in the <a href="/scenario/flexibility/flexibility_net_load/demand-response-electric-cars"
         >demand response - electric vehicles section</a> you can determine where electric cars will
         charge.
     demand_transport_domestic_aviation_technology:

--- a/config/locales/interface/slides/en_flexibility.yml
+++ b/config/locales/interface/slides/en_flexibility.yml
@@ -91,15 +91,17 @@ en:
         on the investments costs per grid level. These can be set in the <a href=\"/scenario/costs/infrastructure/electricity-infrastructure-costs\"
         >Costs</a> section."
     flexibility_flexibility_demand_response_ev:
-      title: Demand response - electric vehicles
+      title: Demand response - electric cars
       short_description:
-      description: "Demand response is a form of flexibility where energy demand is
+      description: |
+        Demand response is a form of flexibility where energy demand is
         adjusted or shifted in time. The goal is to reduce peaks in energy demand.
-        With the sliders in this section, you can adjust the charging behaviour of
-        electric vehicles. The chart shows the impact this has on the shape of the
-        electricity demand curve. \r\n<p>\r\nThe total set of electric vehicles can
-        be set in the <a href=\"/scenario/demand/transport_passenger_transport/car-technology\"
-        >car technology section</a>."
+        With the sliders in this section, the charging behaviour of
+        electric cars can be adjusted. The chart shows the impact this has on the shape of the
+        electricity demand curve. <br/><br/>
+        The total set of electric cars can
+        be set in the <a href="/scenario/demand/transport_passenger_transport/car-technology"
+        >car technology section</a>.
     flexibility_flexibility_demand_response_hhp:
       title: Demand response - behavior of hybrid heat pumps
       short_description:

--- a/config/locales/interface/slides/nl_demand.yml
+++ b/config/locales/interface/slides/nl_demand.yml
@@ -366,7 +366,7 @@ nl:
         Wat gebeurt er als we allemaal overstappen op elektrische auto's? Hier kun
         je aangeven in wat voor auto's we in de toekomst rijden. In de <a href="/scenario/demand/transport_fuels/road-transport"
         >sectie brandstoffen wegverkeer </a> kun je bepalen op welke brandstofmix
-        auto's zullen rijden en in de <a href="/scenario/flexibility/flexibility_net_load/demand-response-electric-vehicles"
+        auto's zullen rijden en in de <a href="/scenario/flexibility/flexibility_net_load/demand-response-electric-cars"
         >sectie vraagsturing - elektrische auto's</a> kun je aangeven waar auto's
         zullen opladen.
     demand_transport_international_transport:


### PR DESCRIPTION
As part of the slider description updates, I have drafted new proposed slider texts (currently in Dutch) for the Transport sector. Once these have been reviewed and approved, I will provide the English translations.

Please refer to the [Documentation](https://docs.energytransitionmodel.com/contrib/authoring-slider-texts) for the guidelines on writing slider descriptions.