### PR TITLE
Update landing page English and Dutch texts

### DIFF
--- a/config/locales/en_intro.yml
+++ b/config/locales/en_intro.yml
@@ -48,7 +48,7 @@ en:
       description: |
         Curious about the data behind the ETM? In the Dataset Manager the data that is used to
         simulate the available regions can be found.
-      link: View our datasets
+      link: View the Dataset Manager
     api:
       title: API
       description: |

--- a/config/locales/en_intro.yml
+++ b/config/locales/en_intro.yml
@@ -4,7 +4,7 @@ en:
     introduction: Explore the future of energy systems
     your_current_scenario: "Your current scenario"
     root_text: |
-      The Energy Transition Model (ETM) enables exploration of possible future energy systems for 
+      The Energy Transition Model (ETM) enables the exploration of possible future energy systems for
       a country, region, or municipality. Select an area and future year to start an energy scenario!
     help_html: |
       To start a new scenario, choose one of the available regions and a year

--- a/config/locales/en_intro.yml
+++ b/config/locales/en_intro.yml
@@ -4,9 +4,8 @@ en:
     introduction: Explore the future of energy systems
     your_current_scenario: "Your current scenario"
     root_text: |
-      The Energy Transition Model (ETM) enables you to explore possible future energy systems for
-      your country, region or municipality. Choose your area and future year to start your energy
-      scenario!
+      The Energy Transition Model (ETM) enables exploration of possible future energy systems for 
+      a country, region, or municipality. Select an area and future year to start an energy scenario!
     help_html: |
       To start a new scenario, choose one of the available regions and a year
       in the future. The ETM is available on different geographical levels.

--- a/config/locales/nl_intro.yml
+++ b/config/locales/nl_intro.yml
@@ -25,7 +25,7 @@ nl:
         Drie nieuwe tabellen met informatie over de economische levensvatbaarheid van
         elektriciteitstechnologieën zijn toegevoegd.
       link:
-        Lees meer over de laatste updates.
+        Lees meer over de laatste updates
     game:
       title: Game
       description: |
@@ -49,13 +49,13 @@ nl:
       description: |
         Benieuwd naar de databronnen achter het ETM? In de Dataset Manager is de data te vinden
         die gebruikt is om de beschikbare regio's te simuleren.
-      link: View our datasets
+      link: Bekijk de Dataset Manager
     api:
       title: API
       description: |
         Gebruik de krachtige rekenmmodule achter het model via de API, in plaats van de
         standaard interface.
-      link: Get started
+      link: Aan de slag
     about_us:
       title: Over ons
       description: |

--- a/config/locales/nl_intro.yml
+++ b/config/locales/nl_intro.yml
@@ -4,9 +4,9 @@ nl:
     introduction: Verken het energiesysteem van de toekomst
     your_current_scenario: "Jouw huidige scenario"
     root_text: |
-      Met het Energietransitiemodel (ETM) kun je mogelijke toekomstige energiesystemen voor jouw
-      land, regio of gemeente verkennen. Kies een gebied en toekomstjaar om jouw eigen energiescenario
-      te starten!
+      Met het Energietransitiemodel (ETM) kunnen mogelijke toekomstige energiesystemen voor een 
+      land, regio of gemeente worden verkend. Kies een gebied en toekomstjaar om een eigen 
+      energiescenario te starten!
     help_html: |
       Een nieuw scenario kan je starten door één van de beschikbare gebieden
       te kiezen en het toekomstjaar waarvoor je het scenario wil maken. Het ETM

--- a/config/locales/nl_intro.yml
+++ b/config/locales/nl_intro.yml
@@ -4,8 +4,8 @@ nl:
     introduction: Verken het energiesysteem van de toekomst
     your_current_scenario: "Jouw huidige scenario"
     root_text: |
-      Met het Energietransitiemodel (ETM) kunnen mogelijke toekomstige energiesystemen voor een 
-      land, regio of gemeente worden verkend. Kies een gebied en toekomstjaar om een eigen 
+      Met het Energietransitiemodel (ETM) kunnen mogelijke toekomstige energiesystemen voor een
+      land, regio of gemeente worden verkend. Kies een gebied en toekomstjaar om een
       energiescenario te starten!
     help_html: |
       Een nieuw scenario kan je starten door één van de beschikbare gebieden


### PR DESCRIPTION
Minor changes in English and Dutch texts on landing page include:
- Avoid using 'our'
- Apply Dutch text when language is set on Dutch
- Remove "."