### PR TITLE
Minor front-end fixes for external coupling CCS

### DIFF
--- a/config/interface/input_elements/external_coupling_ccus.yml
+++ b/config/interface/input_elements/external_coupling_ccus.yml
@@ -5,7 +5,7 @@
   position: 100
   slide_key: supply_ccus_capture_industry
   share_group:
-  interface_group: industry
+  interface_group:
   coupling_icon: true
 
 - key: external_coupling_molecules_other_utilisation_demand

--- a/config/locales/en_etm.yml
+++ b/config/locales/en_etm.yml
@@ -664,7 +664,7 @@ en:
     external_coupling_industry_chemical_fertilizers_processes_ccus: "Industry fertilizers (process emissions)"
     external_coupling_industry_chemical_fertilizers_transformation_input: "Transformation - carrier input"
     external_coupling_industry_chemical_fertilizers_transformation_output: "Transformation - carrier output"
-    external_coupling_industry_chemical_other_ccus: "Industry other"
+    external_coupling_industry_chemical_other_ccus: "Industry chemicals"
     external_coupling_industry_chemical_other_energetic: "Heat production"
     external_coupling_industry_chemical_other_general: "General"
     external_coupling_industry_chemical_other_non_energetic: "Non-energetic use"

--- a/config/locales/nl_etm.yml
+++ b/config/locales/nl_etm.yml
@@ -674,7 +674,7 @@ nl:
     external_coupling_industry_chemical_fertilizers_processes_ccus: "Kunstmestindustrie (procesemissies)"
     external_coupling_industry_chemical_fertilizers_transformation_input: "Transformatie - input van dragers"
     external_coupling_industry_chemical_fertilizers_transformation_output: "Transformatie - output van dragers"
-    external_coupling_industry_chemical_other_ccus: "Industrie overig"
+    external_coupling_industry_chemical_other_ccus: "Industrie chemie"
     external_coupling_industry_chemical_other_energetic: "Warmteproductie"
     external_coupling_industry_chemical_other_general: "Algemeen"
     external_coupling_industry_chemical_other_non_energetic: "Niet-energetisch gebruik"


### PR DESCRIPTION
The external coupling inputs for CCS in the chemical industry are currently described as follows in the front-end:

<img width="486" height="147" alt="Screenshot 2025-09-04 at 10 42 05" src="https://github.com/user-attachments/assets/fbd928df-e732-46e5-aa69-1030e103c612" />

This is confusing since it gives the impression that it concerns the other (non-specified) industry.

This PR makes changes to clarify the CCS section for external coupling.