### PR TITLE
Filter empty series from hourly_stacked_area chart legend.

### DIFF
--- a/app/javascript/charts/HourlyStackedArea.js
+++ b/app/javascript/charts/HourlyStackedArea.js
@@ -34,13 +34,18 @@ export default class HourlyStackedArea extends HourlyBase {
 
   draw() {
     super.draw();
-    this.drawLegend(this.series, 2);
+    this.drawLegend(this.getLegendSeries(), 2);
 
     // Add a "negative region" which shades area of the chart representing values below zero.
     const [negativeRect, updateNegativeRect] = negativeRegionRect(this.width, this.yScale);
 
     this.updateNegativeRegion = updateNegativeRect;
     this.svg.node().append(negativeRect);
+  }
+
+  getLegendSeries() {
+    // Filter series whose values are all zero.
+    return this.series.filter(serie => _.some(serie.future_value()));
   }
 
   /**


### PR DESCRIPTION
## Description

The `hourly_stacked_area` chart (coffescript route) now also filters any empty series from the legend, same as with the `merit_order_hourly_supply` (non-coffescript route).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review

## Related Issues

Closes #3839
