### PR TITLE
Fix scenario collaboration on ETModel

### DIFF
--- a/app/models/saved_scenario.rb
+++ b/app/models/saved_scenario.rb
@@ -77,8 +77,8 @@ class SavedScenario < Dry::Struct
 
   def self.role_to_int(role)
     case role.to_s.downcase.strip
-    when "viewer" then 1
-    when "collaborator" then 2
+    when "scenario_viewer" then 1
+    when "scenario_collaborator" then 2
     when "scenario_owner" then 3
     else 0
     end

--- a/spec/models/saved_scenario_spec.rb
+++ b/spec/models/saved_scenario_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require 'dry-struct'
-require 'active_model'
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe SavedScenario do
   describe 'attributes' do
@@ -49,6 +47,201 @@ RSpec.describe SavedScenario do
       expect(scenario.area_code).to eq('nl')
       expect(scenario.end_year).to eq(2050)
       expect(scenario.scenario_id).to eq(1234)
+    end
+
+    context 'with saved_scenario_users' do
+      it 'converts role strings to integers' do
+        params = {
+          title: 'Test Scenario',
+          area_code: 'nl',
+          end_year: 2050,
+          scenario_id: 1234,
+          saved_scenario_users: [
+            { user_id: 1, role: 'scenario_collaborator' },
+            { user_id: 2, role: 'scenario_viewer' },
+            { user_id: 3, role: 'scenario_owner' }
+          ]
+        }
+
+        scenario = described_class.from_params(params)
+
+        expect(scenario.saved_scenario_users.length).to eq(3)
+        expect(scenario.saved_scenario_users[0].id).to eq(1)
+        expect(scenario.saved_scenario_users[0].role).to eq(2)
+        expect(scenario.saved_scenario_users[1].id).to eq(2)
+        expect(scenario.saved_scenario_users[1].role).to eq(1)
+        expect(scenario.saved_scenario_users[2].id).to eq(3)
+        expect(scenario.saved_scenario_users[2].role).to eq(3)
+      end
+
+      it 'returns role 0 for unknown role strings' do
+        params = {
+          title: 'Test Scenario',
+          area_code: 'nl',
+          end_year: 2050,
+          scenario_id: 1234,
+          saved_scenario_users: [
+            { user_id: 1, role: 'unknown_role' }
+          ]
+        }
+
+        scenario = described_class.from_params(params)
+
+        expect(scenario.saved_scenario_users[0].role).to eq(0)
+      end
+    end
+  end
+
+  describe '.role_to_int' do
+    it 'converts scenario_viewer to 1' do
+      expect(described_class.role_to_int('scenario_viewer')).to eq(1)
+    end
+
+    it 'converts scenario_collaborator to 2' do
+      expect(described_class.role_to_int('scenario_collaborator')).to eq(2)
+    end
+
+    it 'converts scenario_owner to 3' do
+      expect(described_class.role_to_int('scenario_owner')).to eq(3)
+    end
+
+    it 'returns 0 for unknown roles' do
+      expect(described_class.role_to_int('unknown')).to eq(0)
+    end
+
+    it 'returns 0 for non-prefixed role names' do
+      expect(described_class.role_to_int('viewer')).to eq(0)
+      expect(described_class.role_to_int('collaborator')).to eq(0)
+      expect(described_class.role_to_int('owner')).to eq(0)
+    end
+
+    it 'handles different casings' do
+      expect(described_class.role_to_int('SCENARIO_COLLABORATOR')).to eq(2)
+      expect(described_class.role_to_int('Scenario_Viewer')).to eq(1)
+    end
+
+    it 'handles whitespace' do
+      expect(described_class.role_to_int('  scenario_collaborator  ')).to eq(2)
+    end
+  end
+
+  describe '#collaborator?' do
+    let(:user) { double('User', id: 1) }
+
+    it 'returns true when user is a collaborator' do
+      scenario = described_class.from_params(
+        title: 'Test',
+        area_code: 'nl',
+        end_year: 2050,
+        scenario_id: 1234,
+        saved_scenario_users: [
+          { user_id: 1, role: 'scenario_collaborator' }
+        ]
+      )
+
+      expect(scenario.collaborator?(user)).to be true
+    end
+
+    it 'returns true when user is an owner' do
+      scenario = described_class.from_params(
+        title: 'Test',
+        area_code: 'nl',
+        end_year: 2050,
+        scenario_id: 1234,
+        saved_scenario_users: [
+          { user_id: 1, role: 'scenario_owner' }
+        ]
+      )
+
+      expect(scenario.collaborator?(user)).to be true
+    end
+
+    it 'returns false when user is only a viewer' do
+      scenario = described_class.from_params(
+        title: 'Test',
+        area_code: 'nl',
+        end_year: 2050,
+        scenario_id: 1234,
+        saved_scenario_users: [
+          { user_id: 1, role: 'scenario_viewer' }
+        ]
+      )
+
+      expect(scenario.collaborator?(user)).to be false
+    end
+
+    it 'returns false when user is not in the saved_scenario_users list' do
+      scenario = described_class.from_params(
+        title: 'Test',
+        area_code: 'nl',
+        end_year: 2050,
+        scenario_id: 1234,
+        saved_scenario_users: [
+          { user_id: 2, role: 'scenario_collaborator' }
+        ]
+      )
+
+      expect(scenario.collaborator?(user)).to be false
+    end
+  end
+
+  describe '#viewer?' do
+    let(:user) { double('User', id: 1) }
+
+    it 'returns true when user is a viewer' do
+      scenario = described_class.from_params(
+        title: 'Test',
+        area_code: 'nl',
+        end_year: 2050,
+        scenario_id: 1234,
+        saved_scenario_users: [
+          { user_id: 1, role: 'scenario_viewer' }
+        ]
+      )
+
+      expect(scenario.viewer?(user)).to be true
+    end
+
+    it 'returns true when user is a collaborator (has viewer permissions)' do
+      scenario = described_class.from_params(
+        title: 'Test',
+        area_code: 'nl',
+        end_year: 2050,
+        scenario_id: 1234,
+        saved_scenario_users: [
+          { user_id: 1, role: 'scenario_collaborator' }
+        ]
+      )
+
+      expect(scenario.viewer?(user)).to be true
+    end
+
+    it 'returns true when user is an owner (has viewer permissions)' do
+      scenario = described_class.from_params(
+        title: 'Test',
+        area_code: 'nl',
+        end_year: 2050,
+        scenario_id: 1234,
+        saved_scenario_users: [
+          { user_id: 1, role: 'scenario_owner' }
+        ]
+      )
+
+      expect(scenario.viewer?(user)).to be true
+    end
+
+    it 'returns false when user is not in the saved_scenario_users list' do
+      scenario = described_class.from_params(
+        title: 'Test',
+        area_code: 'nl',
+        end_year: 2050,
+        scenario_id: 1234,
+        saved_scenario_users: [
+          { user_id: 2, role: 'scenario_viewer' }
+        ]
+      )
+
+      expect(scenario.viewer?(user)).to be false
     end
   end
 


### PR DESCRIPTION
## Description
This PR updates viewer and collaborator roles to include the scenario_ prefix like in etengine and myetm. Specs were also updated to test this properly.

Note that as part of this investigation, [I also found an issue on the MyETM side](https://github.com/quintel/my-etm/pull/201). The fixes should be merged together.

@claudiavalkenier flagged this as an issue that a client was facing so I investigated. In short the issue was that a user listed as a collaborator of a scenario in MyETM would open a scenario and only have the option to 'Save As' rather than 'Save' that scenario. I saw that scenario_viewers and scenario_owners were not being set properly, and because the spec was just mocking the implementatio, this issue was not flagged. 

Tagging @claudiavalkenier for functional review and @noracato for code review.

## Type of change
- [x] Bug fix

## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review
