### PR TITLE
Set network gas mekko as default chart for gasmix slide

### DIFF
--- a/config/interface/slides/biomass.yml
+++ b/config/interface/slides/biomass.yml
@@ -3,8 +3,8 @@
   key: supply_electricity_renewable_gas
   position: 3
   sidebar_item_key: biomass
-  alt_output_element_key: gas_network_mix
-  output_element_key: gas_network_mix
+  alt_output_element_key: biomass_sankey
+  output_element_key: mekko_of_network_gas_network
 - general_sub_header: share
   key: supply_biomass_bio_coal_bio_oil
   position: 6


### PR DESCRIPTION
## Description

This PR sets the network gas mekko chart as default for the Gas mix in gas network slide, replacing the Gasmix chart. 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review

## Related Issues

Closes https://github.com/quintel/etsource/issues/3376
