### PR TITLE
Remove flh input for offshore wind with hydrogen

### DIFF
--- a/app/assets/javascripts/lib/views/radio_collection_view.js
+++ b/app/assets/javascripts/lib/views/radio_collection_view.js
@@ -132,7 +132,6 @@
    */
   var WEATHER_CURVE_DEPENDENTS = [
     'flexibility_outdoor_temperature',
-    'flh_of_energy_hydrogen_wind_turbine_offshore',
     'flh_of_energy_power_wind_turbine_coastal',
     'flh_of_energy_power_wind_turbine_inland',
     'flh_of_energy_power_wind_turbine_offshore',

--- a/config/interface/input_elements/flexibility_weather_conditions_and_flh.yml
+++ b/config/interface/input_elements/flexibility_weather_conditions_and_flh.yml
@@ -26,12 +26,6 @@
   interface_group: full_load_hours
   position: 220
   slide_key: flexibility_temperature_and_flh
-- key: flh_of_energy_hydrogen_wind_turbine_offshore
-  step_value: 1.0
-  unit: "#"
-  interface_group: full_load_hours
-  position: 230
-  slide_key: flexibility_temperature_and_flh
 
 - key: flh_of_households_solar_pv_solar_radiation
   step_value: 1.0

--- a/config/locales/interface/input_elements/en_flexibility.yml
+++ b/config/locales/interface/input_elements/en_flexibility.yml
@@ -327,26 +327,15 @@ en:
     flh_of_energy_power_wind_turbine_offshore:
       title: Wind offshore
       short_description:
-      description: By increasing
-        the full load hours for this type of wind turbine, more electricity will be
-        produced. Both the full load hours of 'regular'
-        offshore wind turbines and hybrid offshore wind turbines will be updated.
-        The slider not only increases the number
-        of full load hours but also changes the shape of the hourly production profile
-        for this type of wind turbine. Typically, the peaks will become broader
-        with increasing full load hours as the turbine spends more time running
+      description: |
+        By increasing the full load hours for this type of wind turbine, more electricity will be
+        produced. This slider updates full load hours of 'regular' offshore wind turbines, offshore
+        wind turbines combined with electrolyser and hybrid offshore wind turbines.
+        The slider not only increases the number of full load hours but also changes the shape of
+        the hourly production profile for this type of wind turbine. Typically, the peaks will
+        become broader with increasing full load hours as the turbine spends more time running
         at higher capacity. Take a look at the ‘Electricity production per hour’-chart
         to see the effect of your changes on the offshore wind profile.
-    flh_of_energy_hydrogen_wind_turbine_offshore:
-      title: Wind offshore (with electrolyser)
-      short_description:
-      description: By increasing
-        the full load hours for this type of wind turbine, more electricity will be
-        produced with the same number of turbines. The slider not only increases the number
-        of full load hours but also changes the shape of the hourly production profile
-        for this type of wind turbine. Typically, the peaks will become broader
-        with increasing full load hours as the turbine spends more time running
-        at higher capacity.
     flh_of_households_solar_pv_solar_radiation:
       title: Solar rooftop (households)
       short_description:

--- a/config/locales/interface/input_elements/nl_flexibility.yml
+++ b/config/locales/interface/input_elements/nl_flexibility.yml
@@ -332,26 +332,14 @@ nl:
     flh_of_energy_power_wind_turbine_offshore:
       title: Wind op zee
       short_description:
-      description: Door de vollasturen te
-        verhogen voor dit type windmolen zal er meer elektriciteit geproduceerd worden
-        met hetzelfde aantal windmolens. De vollasturen van zowel de 'normale' windmolens
-        op zee als de hybride windmolens op zee worden hiermee aangepast.
-        Wanneer het aantal vollasturen wordt verhoogd met deze schuif,
-        verandert tegelijkertijd ook het productieprofiel per uur
-        voor dit type windmolen. Bij een toenemend aantal vollasturen zullen de pieken
-        breder worden doordat de windmolen vaker draait op hogere capaciteit.
-        Bekijk de 'Elektriciteitsproductie op uurbasis'-grafiek voor meer inzicht
-        in het effect van het aantal vollasturen op het windprofiel.
-    flh_of_energy_hydrogen_wind_turbine_offshore:
-      title: Wind op zee (met electrolyser)
-      short_description:
-      description: Door de vollasturen te
-        verhogen voor dit type windmolen zal er meer elektriciteit geproduceerd worden
-        met hetzelfde aantal windmolens.
-        Om dit mogelijk te maken neemt niet alleen het aantal vollasturen toe met
-        dit schuifje, maar verandert tegelijkertijd ook het productieprofiel per uur
-        voor dit type windmolen. Bij een toenemend aantal vollasturen zullen de pieken
-        breder worden doordat de windmolen vaker draait op hogere capaciteit.
+      description: |
+        Door de vollasturen te verhogen voor dit type windturbine zal er meer elektriciteit
+        geproduceerd worden met hetzelfde aantal windturbines. De vollasturen van zowel de 'normale'
+        windturbines op zee als windturbines op zee gecombineerd met elektrolyser en de hybride
+        windturbines op zee worden hiermee aangepast. Wanneer het aantal vollasturen wordt verhoogd
+        met dit schuifje, verandert tegelijkertijd ook het productieprofiel per uur
+        voor dit type windturbine. Bij een toenemend aantal vollasturen zullen de pieken
+        breder worden doordat de windturbine vaker draait op hogere capaciteit.
         Bekijk de 'Elektriciteitsproductie op uurbasis'-grafiek voor meer inzicht
         in het effect van het aantal vollasturen op het windprofiel.
     flh_of_households_solar_pv_solar_radiation:


### PR DESCRIPTION
## Description

This PR removes the FLH input for offshore wind electrolyser. The FLHs of this technology can now be set with the regular offshore wind FLH input. 

Goes with:
- https://github.com/quintel/etmodel/pull/4627
- https://github.com/quintel/etsource/pull/3411
- https://github.com/quintel/etengine/pull/1694
- https://github.com/quintel/etdataset/pull/1077

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation

## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review

## Related Issues

Closes https://github.com/quintel/etsource/issues/3196
