### PR TITLE
Updating lables in solar production chart

### DIFF
--- a/config/locales/interface/output_element_series/en_labels.yml
+++ b/config/locales/interface/output_element_series/en_labels.yml
@@ -316,7 +316,7 @@ en:
         buildings_roof_surface_area_available: "Available roof area (buildings)"
         buildings_solar_pv: 'Buildings'
         buildings_solar_pv_curtailed_electricity_output_curve: 'Curtailment buildings'
-        buildings_solar_pv_electricity_output_curve: 'Production buildings'
+        buildings_solar_pv_electricity_output_curve: 'Solar rooftop (buildings)'
         buildings_solar_pv_solar_radiation: 'Solar rooftop (buildings)'
         busses: "Buses"
         capaciteit_bezet_mva: "Capacity used - [MVA]"
@@ -829,7 +829,7 @@ en:
         households_heating_demand: "Heating households"
         households_solar_pv: 'Households'
         households_solar_pv_curtailed_electricity_output_curve: 'Curtailment households'
-        households_solar_pv_electricity_output_curve: 'Production households'
+        households_solar_pv_electricity_output_curve: 'Solar rooftop (households)'
         households_solar_pv_solar_radiation: 'Solar rooftop (households)'
         households_space_heater_coal: "Coal-fired heater"
         households_space_heater_combined_hydrogen: "Condensing combi boiler (hydrogen)"
@@ -935,10 +935,10 @@ en:
         energy_battery_wind_turbine_inland: "Wind onshore (battery)"
         energy_battery_solar_pv: "Solar on land (battery)"
         energy_power_solar_pv_curtailed_electricity_output_curve: "Curtailment solar on land"
-        energy_power_solar_pv_electricity_output_curve: "Production solar on land"
+        energy_power_solar_pv_electricity_output_curve: "Solar on land"
         energy_power_solar_pv_offshore_curtailed_electricity_output_curve: "Curtailment solar offshore"
-        energy_power_solar_pv_offshore_electricity_output_curve: "Production solar offshore"
-        energy_battery_solar_pv_electricity_output_curve: "Production solar on land (battery)"
+        energy_power_solar_pv_offshore_electricity_output_curve: "Solar offshore"
+        energy_battery_solar_pv_electricity_output_curve: "Solar on land (battery)"
         energy_battery_solar_pv_curtailed_electricity_output_curve: "Curtailment solar on land (battery)"
         greengas_price: "Green gas price"
         hydrogen_demand: "Hydrogen demand"

--- a/config/locales/interface/output_element_series/nl_labels.yml
+++ b/config/locales/interface/output_element_series/nl_labels.yml
@@ -302,7 +302,7 @@ nl:
         buildings_roof_surface_area_available: "Beschikbaar dakoppervlak (gebouwen)"
         buildings_solar_pv: 'Gebouwen'
         buildings_solar_pv_curtailed_electricity_output_curve: 'Productieverlaging gebouwen'
-        buildings_solar_pv_electricity_output_curve: 'Opwek gebouwen'
+        buildings_solar_pv_electricity_output_curve: 'Zon op dak (gebouwen)'
         buildings_solar_pv_solar_radiation: 'Zon op dak (gebouwen)'
         busses: "Bussen"
         capaciteit_bezet_mva: "Capaciteit - gebruikt [MVA]"
@@ -578,9 +578,9 @@ nl:
         energy_battery_wind_electricity: 'Wind op land (batterij)'
         energy_power_solar_pv_curtailed_electricity_output_curve: 'Productieverlaging zon op land'
         energy_power_solar_pv_offshore_curtailed_electricity_output_curve: 'Productieverlaging zon op zee'
-        energy_power_solar_pv_electricity_output_curve: 'Opwek zon op land'
-        energy_power_solar_pv_offshore_electricity_output_curve: 'Opwek zon op zee'
-        energy_battery_solar_pv_electricity_output_curve: 'Opwek zon op land (batterij)'
+        energy_power_solar_pv_electricity_output_curve: 'Zon op land'
+        energy_power_solar_pv_offshore_electricity_output_curve: 'Zon op zee'
+        energy_battery_solar_pv_electricity_output_curve: 'Zon op land (batterij)'
         energy_battery_solar_pv_curtailed_electricity_output_curve: 'Productieverlaging zon op land (batterij)'
         energy_power_solar_pv_solar_radiation: 'Zon op land'
         energy_power_offshore_solar_pv: 'Zon op zee'
@@ -837,7 +837,7 @@ nl:
         households_heating_demand: "Verwarming huishoudens"
         households_solar_pv: 'Huishoudens'
         households_solar_pv_curtailed_electricity_output_curve: 'Productieverlaging huishoudens'
-        households_solar_pv_electricity_output_curve: 'Opwek huishoudens'
+        households_solar_pv_electricity_output_curve: 'Zon op dak (huishoudens)'
         households_solar_pv_solar_radiation: 'Zon op dak (huishoudens)'
         households_space_heater_coal: "Kolenketel"
         households_space_heater_combined_hydrogen:  "HR combiketel (waterstof)"


### PR DESCRIPTION
## Description

This PR updates the chart labels for the chart "Solar PV production per hour".
Now the chart labels are in line with the solar production technologies. 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation

## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review


