### PR TITLE
Remove applications data export

### DIFF
--- a/config/interface/slides/data_export.yml
+++ b/config/interface/slides/data_export.yml
@@ -15,10 +15,6 @@
   position: 110
   sidebar_item_key: data_export
   output_element_key: co2_emissions
-- key: data_export_application_demands
-  position: 120
-  sidebar_item_key: data_export
-  output_element_key: use_of_primary_energy
 - key: data_export_production
   position: 200
   sidebar_item_key: data_export

--- a/config/locales/interface/slides/en_data.yml
+++ b/config/locales/interface/slides/en_data.yml
@@ -32,14 +32,6 @@ en:
       subregion_description: |
         You can view the source data for your region in a clear
         and structured way in the ETM Dataset Manager, which can be visited by clicking on the button below.
-    data_export_application_demands:
-      title: Yearly energy demand per application
-      short_description:
-      description: |
-        Download information about the primary and final demands, and also the primary CO<sub>2</sub> emissions of applications (such as cooking, appliances, heating, transport, etc).
-        <ul class="data-download">
-          <li><a href="/passthru/%{scenario_id}/application_demands.csv" target="_blank"><span class="name">Application primary and final demands</span> <span class="filetype">40KB CSV</span></a></li>
-        </ul>
     data_export_inputs:
       title: Overview of slider settings
       short_description:

--- a/config/locales/interface/slides/nl_data.yml
+++ b/config/locales/interface/slides/nl_data.yml
@@ -31,14 +31,6 @@ nl:
       subregion_description: |
         Je kunt de brondata voor jouw regio op een heldere en overzichtelijke manier inzien met de ETM Dataset Manager,
         die je kan openen door op de onderstaande knop te klikken.
-    data_export_application_demands:
-      title: Jaarlijkse energievraag per toepassing
-      short_description:
-      description: |
-        Download informatie over de primaire en finale vraag – en de primaire CO<sub>2</sub>-uitstoot – van toepassingen van energie (zoals koken, apparaten, ruimterverwarming en transport).
-        <ul class="data-download">
-          <li><a href="/passthru/%{scenario_id}/application_demands.csv" target="_blank"><span class="name">Primaire en finale vraag per toepassing</span> <span class="filetype">40KB CSV</span></a></li>
-        </ul>
     data_export_inputs:
       title: Overzicht van schuifjesinstellingen
       short_description:


### PR DESCRIPTION
## Description

Following [this PR](https://github.com/quintel/etengine/pull/1695), the current PR completely removes the Applications data export and related files. 

Goes with:
- https://github.com/quintel/etengine/pull/1699
- https://github.com/quintel/etmodel/pull/4636
- https://github.com/quintel/documentation/pull/288

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation
- [x] Maintenance

## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review

## Related Issues

Closes #
