### PR TITLE
Add present year energy_flow data export

### DIFF
--- a/config/interface/slides/data_export.yml
+++ b/config/interface/slides/data_export.yml
@@ -10,7 +10,7 @@
 - key: data_export_energy_flows
   position: 105
   sidebar_item_key: data_export
-  output_element_key: final_energy_demand_per_sector_joule
+  output_element_key: sankey_energy_overview
 - key: data_export_molecule_flows
   position: 110
   sidebar_item_key: data_export

--- a/config/locales/interface/slides/en_data.yml
+++ b/config/locales/interface/slides/en_data.yml
@@ -120,24 +120,25 @@ en:
       title: Yearly energy flows
       short_description:
       description: |
-        The Energy Transition Model describes the energy flows in a scenario through several hundred uses and conversions.
-        The first CSV provides an overview of these flows in a format based on the energy flows chart.
-        The second CSV provides a complete list of all the energy flows in the model (inputs and outputs).
+        The model describes the energy system scenario through several hundred energy flows.
+        The first CSV provides an overview of these flows in a format based on the "Energy flows
+        overview" chart. The second and third CSVs provide a complete list of all the energy flows
+        in the model, one for the present and one for the future year.
         <ul class="data-download">
           <li>
             <a href="/passthru/%{scenario_id}/sankey.csv" target="_blank">
             <span class="name">Energy flows (overview)</span>
-            <span class="filetype">10KB CSV</span></a>
+            <span class="filetype">50KB CSV</span></a>
           </li>
           <li>
             <a href="/passthru/%{scenario_id}/energy_flow_present.csv" target="_blank">
               <span class="name">Energy flows (complete - present)</span>
-              <span class="filetype">500KB CSV</span></a>
+              <span class="filetype">1MB CSV</span></a>
           </li>
           <li>
             <a href="/passthru/%{scenario_id}/energy_flow.csv" target="_blank">
             <span class="name">Energy flows (complete - future)</span>
-            <span class="filetype">500KB CSV</span></a>
+            <span class="filetype">1MB CSV</span></a>
           </li>
         </ul>
     data_export_heat_network:

--- a/config/locales/interface/slides/nl_data.yml
+++ b/config/locales/interface/slides/nl_data.yml
@@ -120,27 +120,26 @@ nl:
       title: Jaarlijkse energiestromen
       short_description:
       description:  |
-        Het Energietransitiemodel beschrijft het energiesysteem als een verzameling van honderden
-        energie-omzetters (nodes) die verbonden zijn met energiestromen (edges).
-        De eerste CSV geeft een overzicht van deze stromen in een format dat gebaseerd is op de energiestromengrafiek.
-        De tweede CSV geeft een complete lijst van alle energiestromen in het model.
-
+        Het model beschrijft het energiesysteem als een verzameling van honderden energiestromen.
+        De eerste CSV geeft een overzicht van deze stromen in een format dat gebaseerd is op de
+        grafiek "Overzicht energiestromen". De tweede en derde CSVs geven een complete lijst van
+        alle energiestromen in het model, één voor het start- en één voor het eindjaar.
         <ul class="data-download">
           <li>
             <a href="/passthru/%{scenario_id}/sankey.csv" target="_blank">
             <span class="name">Energiestromen (overzicht)</span>
-            <span class="filetype">10KB CSV</span></a>
+            <span class="filetype">50KB CSV</span></a>
           </li>
           <li>
             <a href="/passthru/%{scenario_id}/energy_flow_present.csv" target="_blank">
               <span class="name">Energiestromen (compleet - heden)</span>
-              <span class="filetype">500KB CSV</span>
+              <span class="filetype">1MB CSV</span>
             </a>
           </li>
           <li>
             <a href="/passthru/%{scenario_id}/energy_flow.csv" target="_blank">
               <span class="name">Energiestromen (compleet - toekomst)</span>
-              <span class="filetype">500KB CSV</span>
+              <span class="filetype">1MB CSV</span>
             </a>
           </li>
         </ul>


### PR DESCRIPTION
## Description

Add present year energy_flow data export.

This change requires ETEngine and ETmodel changes so is part of a two PR offensive:
- ETEngine: https://github.com/quintel/etengine/pull/1706
- ETModel: https://github.com/quintel/etmodel/pull/4648 [this one]

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review

## Related Issues

Closes #4647
