### PR TITLE
Fix sentry source maps not matching js files

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -49,6 +49,7 @@ ARG SECRET_KEY_BASE=fakekeyforassets
 ARG SENTRY_AUTH_TOKEN
 ARG SENTRY_RELEASE
 
+RUN echo "SENTRY_AUTH_TOKEN is: ${SENTRY_AUTH_TOKEN:+SET}" && echo "SENTRY_RELEASE is: $SENTRY_RELEASE"
 RUN RAILS_ENV=production DOCKER_BUILD=true SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN SENTRY_RELEASE=$SENTRY_RELEASE bundle exec rails assets:precompile
 
 CMD ["bundle", "exec", "--keep-file-descriptors", "puma", "-C", "config/puma.rb"]

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -19,6 +19,7 @@ if (process.env.SENTRY_AUTH_TOKEN) {
             project: 'etmodel',
             authToken: process.env.SENTRY_AUTH_TOKEN,
             sourcemaps: {
+                urlPrefix: '~/packs/js',
                 filesToDeleteAfterUpload: ['./**/*.map'],
             },
         }),


### PR DESCRIPTION
#### Context

The source maps uploaded to Sentry do not seem to be link to their corresponding JS files properly

#### Implemented changes

Provided the urlPrefix to upload the artifact without using debug ids.

#### Related

We are trying to fix this issue in two places:
- etmodel: https://github.com/quintel/etmodel/pull/4672 [THIS ONE]
- collections: https://github.com/quintel/multi-year-charts/pull/118


## Checklist

- [x] I have tested these changes (nothing breaks locally but merging is necessary to test results)
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
