### PR TITLE
Change scenario report footer

### DIFF
--- a/app/assets/javascripts/lib/views/report_view.js
+++ b/app/assets/javascripts/lib/views/report_view.js
@@ -444,12 +444,10 @@
           self.$el.empty().append(nav).append(article);
 
           self.$el.append(
-            '<div id="credits"> ' +
-            '  &copy; Quintel Intelligence &bull;' +
-            ' ' + I18n.t('report.icons_by') +
-            '  <a href="http://www.flaticon.com/authors/freepik">Freepik</a>' +
-            '  &amp;' +
-            '  <a href="http://www.flaticon.com/authors/yannick">Yannick</a>' +
+            '<div id="credits">' +
+            '  <a href="/my_etm/terms">' + I18n.t('report.footer.terms') + '</a>' +
+            '  <a href="/my_etm/privacy">' + I18n.t('report.footer.privacy') + '</a>' +
+            '  <a href="/my_etm/contact">' + I18n.t('report.footer.contact_us') + '</a>' +
             '</div>'
           );
 

--- a/app/assets/stylesheets/report.css.sass
+++ b/app/assets/stylesheets/report.css.sass
@@ -167,10 +167,12 @@ li
 
   #credits
     color: lighten($grey, 20%)
+    display: flex
     font-size: 0.875rem
+    gap: 1.5rem
+    justify-content: center
     margin-top: 4rem
     margin-bottom: 2rem
-    text-align: center
     a
       color: lighten($grey, 20%)
       &:hover

--- a/config/locales/en_report.yml
+++ b/config/locales/en_report.yml
@@ -11,4 +11,7 @@ en:
       header: Sorry
       message: We weren't able to fetch the data in a timely manner.
       reload: Please try reloading the page.
-    icons_by: Icons by
+    footer:
+      terms: Terms
+      privacy: Privacy
+      contact_us: Contact Us

--- a/config/locales/nl_report.yml
+++ b/config/locales/nl_report.yml
@@ -11,4 +11,7 @@ nl:
       header: 'Sorry'
       message: Het duurde te lang om de data op te halen.
       reload: Probeer de pagina opnieuw te laden.
-    icons_by: Icoontjes van
+    footer:
+      terms: Voorwaarden
+      privacy: Privacy
+      contact_us: Contact


### PR DESCRIPTION
#### Context

The "Icon by" disclaimers in the Scenario Report are no longer needed. 

#### Implemented changes

In the footer we replaced both, the "Quintel intelligence" copyright and the icons disclaimer by the same links as in the landing page:
- Terms
- Privacy
- Contact Us

#### Related

Retire energy mix entirely and replace scenario report by retire notice. [(#4668)](https://github.com/quintel/etmodel/pull/4668)

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review