### PR TITLE
Replace scenario report retirement banner by a friendly notice

### DIFF
--- a/app/assets/stylesheets/report.css.sass
+++ b/app/assets/stylesheets/report.css.sass
@@ -420,7 +420,7 @@ li
   grid-template-columns: 1fr 1fr
   gap: 2rem
   margin: 0 0 2rem
-  padding-top: 7rem
+  padding-top: 1rem
 
   .report-chart-col
     h2

--- a/app/assets/stylesheets/report.css.sass
+++ b/app/assets/stylesheets/report.css.sass
@@ -1,3 +1,5 @@
+@import font-awesome
+
 $font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"
 $body-font-family: $font-family
 
@@ -387,24 +389,28 @@ li
     margin-left: 5px
     white-space: nowrap
 
-// Retirement Banner
+// Retirement Notice
 // -----------------
 
-.retirement-banner
-  background: #fff3cd
-  border: 2px solid #e6ac00
-  border-radius: 4px
-  color: #5a4200
+.retirement-notice
+  align-items: flex-start
+  display: flex
   font-size: 1rem
+  gap: 1.5rem
   line-height: 1.6
   margin: 2rem 0
-  padding: 1rem 1.5rem
 
-  p
-    margin: 0
+  div p
+    font-size: 1.1rem
+    margin: 0 0 0.75rem
 
-  strong
-    font-weight: bold
+    &:last-child
+      margin-bottom: 0
+
+  .icon
+    color: $link-color
+    flex-shrink: 0
+    font-size: 3.2rem
 
 // Horizontal chart row
 // --------------------
@@ -413,7 +419,8 @@ li
   display: grid
   grid-template-columns: 1fr 1fr
   gap: 2rem
-  margin: 2rem 0
+  margin: 0 0 2rem
+  padding-top: 7rem
 
   .report-chart-col
     h2

--- a/config/reports/main.en.liquid
+++ b/config/reports/main.en.liquid
@@ -22,19 +22,13 @@
     <span class="icon fa fa-magic"></span>
     <div>
       <p>
-        The <u>Scenario report</u> and the
+        The original Scenario report and
         <a href="https://docs.energytransitionmodel.com/main/factsheet" target="_blank">
-          <u>Energy mix infographic</u>
-        </a>
-        are no longer supported by the Energy Transition Model (ETM).
-      </p>
-      <p>
-        The ETM offers many new visualizations that may better meet your needs.
-        Below you can find a few chart examples from the wide range of charts available across the ETM.
-      </p>
-      <p>
-        For questions or suggestions, please contact
-        <a href="mailto:info@energytransitionmodel.com">info@energytransitionmodel.com</a>.
+        Energy mix infographic</a>
+        are no longer supported. The ETM offers many other visualizations that may be useful.
+        Some examples are give below. For questions or suggestions, please
+        <a href="mailto:info@energytransitionmodel.com" target="_blank">
+        Contact us</a>.
       </p>
     </div>
   </div>

--- a/config/reports/main.en.liquid
+++ b/config/reports/main.en.liquid
@@ -1,6 +1,6 @@
 <header>
   <div class="inner">
-    <h1>Scenario results</h1>
+    <h1>Scenario report</h1>
     <p class="scenario-details">
       {% current_date %}
       <span class="bullet">&bull;</span>
@@ -18,13 +18,25 @@
 </header>
 
 <main>
-  <div class="retirement-banner">
-    <p>
-      <strong>Notice:</strong> the <u>Scenario report</u> and the <u>Energy mix infographic</u> are
-      no longer supported by the Energy Transition Model (ETM). The ETM offers many new
-      visualizations that may meet your needs. For questions or suggestions, please contact
-      <a href="mailto:info@energytransitionmodel.com">info@energytransitionmodel.com</a>.
-    </p>
+  <div class="retirement-notice">
+    <span class="icon fa fa-magic"></span>
+    <div>
+      <p>
+        The <u>Scenario report</u> and the
+        <a href="https://docs.energytransitionmodel.com/main/factsheet" target="_blank">
+          <u>Energy mix infographic</u>
+        </a>
+        are no longer supported by the Energy Transition Model (ETM).
+      </p>
+      <p>
+        The ETM offers many new visualizations that may better meet your needs.
+        Below you can find a few chart examples from the wide range of charts available across the ETM.
+      </p>
+      <p>
+        For questions or suggestions, please contact
+        <a href="mailto:info@energytransitionmodel.com">info@energytransitionmodel.com</a>.
+      </p>
+    </div>
   </div>
 
   <div class="report-charts-row">

--- a/config/reports/main.nl.liquid
+++ b/config/reports/main.nl.liquid
@@ -22,19 +22,13 @@
     <span class="icon fa fa-magic"></span>
     <div>
       <p>
-        Het <u>Scenariorapport</u> en de
+        Het originele Scenariorapport en de
         <a href="https://docs.energytransitionmodel.com/main/factsheet" target="_blank">
-          <u>Energiemix infographic</u>
-        </a>
-        worden niet langer ondersteund door het Energietransitiemodel (ETM).
-      </p>
-      <p>
-        Het ETM biedt vele nieuwe visualisaties die mogelijk beter aan uw behoeften voldoen.
-        Hieronder vindt u een aantal grafiekvoorbeelden uit het brede aanbod van grafieken in het ETM.
-      </p>
-      <p>
-        Neem voor vragen of suggesties contact op met
-        <a href="mailto:info@energytransitionmodel.com">info@energytransitionmodel.com</a>.
+        Energiemix infographic</a>
+        worden niet langer ondersteund. Het ETM bevat vele andere visualisaties die nuttig kunnen zijn.
+        Hieronder worden een aantal voorbeelden getoond. Neem voor vragen of suggesties
+        <a href="mailto:info@energytransitionmodel.com" target="_blank">
+        Contact</a> op.
       </p>
     </div>
   </div>

--- a/config/reports/main.nl.liquid
+++ b/config/reports/main.nl.liquid
@@ -1,6 +1,6 @@
 <header>
   <div class="inner">
-    <h1>Scenarioresultaten</h1>
+    <h1>Scenariorapport</h1>
     <p class="scenario-details">
       {% current_date %}
       <span class="bullet">&bull;</span>
@@ -18,13 +18,25 @@
 </header>
 
 <main>
-  <div class="retirement-banner">
-    <p>
-      <strong>Melding:</strong> het <u>Scenariorapport</u> en de <u>Energiemix infographic</u>
-      worden niet langer ondersteund door het Energietransitiemodel (ETM). Het ETM biedt vele nieuwe
-      visualisaties die mogelijk aan uw behoeften voldoen. Neem voor vragen of suggesties contact op
-      met <a href="mailto:info@energytransitionmodel.com">info@energytransitionmodel.com</a>.
-    </p>
+  <div class="retirement-notice">
+    <span class="icon fa fa-magic"></span>
+    <div>
+      <p>
+        Het <u>Scenariorapport</u> en de
+        <a href="https://docs.energytransitionmodel.com/main/factsheet" target="_blank">
+          <u>Energiemix infographic</u>
+        </a>
+        worden niet langer ondersteund door het Energietransitiemodel (ETM).
+      </p>
+      <p>
+        Het ETM biedt vele nieuwe visualisaties die mogelijk beter aan uw behoeften voldoen.
+        Hieronder vindt u een aantal grafiekvoorbeelden uit het brede aanbod van grafieken in het ETM.
+      </p>
+      <p>
+        Neem voor vragen of suggesties contact op met
+        <a href="mailto:info@energytransitionmodel.com">info@energytransitionmodel.com</a>.
+      </p>
+    </div>
   </div>
 
   <div class="report-charts-row">

--- a/config/reports/regional.en.liquid
+++ b/config/reports/regional.en.liquid
@@ -22,19 +22,13 @@
     <span class="icon fa fa-magic"></span>
     <div>
       <p>
-        The <u>Scenario report</u> and the
+        The original Scenario report and
         <a href="https://docs.energytransitionmodel.com/main/factsheet" target="_blank">
-          <u>Energy mix infographic</u>
-        </a>
-        are no longer supported by the Energy Transition Model (ETM).
-      </p>
-      <p>
-        The ETM offers many new visualizations that may better meet your needs.
-        Below you can find a few chart examples from the wide range of charts available across the ETM.
-      </p>
-      <p>
-        For questions or suggestions, please contact
-        <a href="mailto:info@energytransitionmodel.com">info@energytransitionmodel.com</a>.
+        Energy mix infographic</a>
+        are no longer supported. The ETM offers many other visualizations that may be useful.
+        Some examples are give below. For questions or suggestions, please
+        <a href="mailto:info@energytransitionmodel.com" target="_blank">
+        Contact us</a>.
       </p>
     </div>
   </div>

--- a/config/reports/regional.en.liquid
+++ b/config/reports/regional.en.liquid
@@ -1,6 +1,6 @@
 <header>
   <div class="inner">
-    <h1>Scenario results</h1>
+    <h1>Scenario report</h1>
     <p class="scenario-details">
       {% current_date %}
       <span class="bullet">&bull;</span>
@@ -18,13 +18,25 @@
 </header>
 
 <main>
-  <div class="retirement-banner">
-    <p>
-      <strong>Notice:</strong> the <u>Scenario report</u> and the <u>Energy mix infographic</u> are
-      no longer supported by the Energy Transition Model (ETM). The ETM offers many new
-      visualizations that may meet your needs. For questions or suggestions, please contact
-      <a href="mailto:info@energytransitionmodel.com">info@energytransitionmodel.com</a>.
-    </p>
+  <div class="retirement-notice">
+    <span class="icon fa fa-magic"></span>
+    <div>
+      <p>
+        The <u>Scenario report</u> and the
+        <a href="https://docs.energytransitionmodel.com/main/factsheet" target="_blank">
+          <u>Energy mix infographic</u>
+        </a>
+        are no longer supported by the Energy Transition Model (ETM).
+      </p>
+      <p>
+        The ETM offers many new visualizations that may better meet your needs.
+        Below you can find a few chart examples from the wide range of charts available across the ETM.
+      </p>
+      <p>
+        For questions or suggestions, please contact
+        <a href="mailto:info@energytransitionmodel.com">info@energytransitionmodel.com</a>.
+      </p>
+    </div>
   </div>
 
   <div class="report-charts-row">

--- a/config/reports/regional.nl.liquid
+++ b/config/reports/regional.nl.liquid
@@ -22,19 +22,13 @@
     <span class="icon fa fa-magic"></span>
     <div>
       <p>
-        Het <u>Scenariorapport</u> en de
+        Het originele Scenariorapport en de
         <a href="https://docs.energytransitionmodel.com/main/factsheet" target="_blank">
-          <u>Energiemix infographic</u>
-        </a>
-        worden niet langer ondersteund door het Energietransitiemodel (ETM).
-      </p>
-      <p>
-        Het ETM biedt vele nieuwe visualisaties die mogelijk beter aan uw behoeften voldoen.
-        Hieronder vindt u een aantal grafiekvoorbeelden uit het brede aanbod van grafieken in het ETM.
-      </p>
-      <p>
-        Neem voor vragen of suggesties contact op met
-        <a href="mailto:info@energytransitionmodel.com">info@energytransitionmodel.com</a>.
+        Energiemix infographic</a>
+        worden niet langer ondersteund. Het ETM bevat vele andere visualisaties die nuttig kunnen zijn.
+        Hieronder worden een aantal voorbeelden getoond. Neem voor vragen of suggesties
+        <a href="mailto:info@energytransitionmodel.com" target="_blank">
+        Contact</a> op.
       </p>
     </div>
   </div>

--- a/config/reports/regional.nl.liquid
+++ b/config/reports/regional.nl.liquid
@@ -1,6 +1,6 @@
 <header>
   <div class="inner">
-    <h1>Scenarioresultaten</h1>
+    <h1>Scenariorapport</h1>
     <p class="scenario-details">
       {% current_date %}
       <span class="bullet">&bull;</span>
@@ -18,13 +18,25 @@
 </header>
 
 <main>
-  <div class="retirement-banner">
-    <p>
-      <strong>Melding:</strong> het <u>Scenariorapport</u> en de <u>Energiemix infographic</u>
-      worden niet langer ondersteund door het Energietransitiemodel (ETM). Het ETM biedt vele nieuwe
-      visualisaties die mogelijk aan uw behoeften voldoen. Neem voor vragen of suggesties contact op
-      met <a href="mailto:info@energytransitionmodel.com">info@energytransitionmodel.com</a>.
-    </p>
+  <div class="retirement-notice">
+    <span class="icon fa fa-magic"></span>
+    <div>
+      <p>
+        Het <u>Scenariorapport</u> en de
+        <a href="https://docs.energytransitionmodel.com/main/factsheet" target="_blank">
+          <u>Energiemix infographic</u>
+        </a>
+        worden niet langer ondersteund door het Energietransitiemodel (ETM).
+      </p>
+      <p>
+        Het ETM biedt vele nieuwe visualisaties die mogelijk beter aan uw behoeften voldoen.
+        Hieronder vindt u een aantal grafiekvoorbeelden uit het brede aanbod van grafieken in het ETM.
+      </p>
+      <p>
+        Neem voor vragen of suggesties contact op met
+        <a href="mailto:info@energytransitionmodel.com">info@energytransitionmodel.com</a>.
+      </p>
+    </div>
   </div>
 
   <div class="report-charts-row">


### PR DESCRIPTION
#### Context

We recently replace the scenario report by a notice explaining both Scenario Report and Energy Mix are retired but the message we wanted to convey of collaboration was lost.

#### Implemented changes

We replace the yellow banner by a friendlier notice paragraph and changed the spacing and wording to better convey the real situation in hopes people will actually read the content and not skip straight to the example charts.

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
