### PR TITLE
Verify database set up or throw warning

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -30,6 +30,18 @@ FileUtils.chdir APP_ROOT do
   puts "\n== Preparing database =="
   system! "bin/rails db:prepare"
 
+  puts "\n== Verifying database setup =="
+  verify_cmd = <<~BASH
+    mysql -u root -e "SELECT COUNT(*) FROM sessions LIMIT 1;" etmodel_dev 2>&1 > /dev/null
+  BASH
+
+  if system(verify_cmd)
+    puts "✓ Database setup verified successfully"
+  else
+    puts "⚠ Warning: Database may not be fully set up. Tables might be missing."
+    puts "Try running: bin/rails db:drop db:create db:schema:load db:seed"
+  end
+
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
 


### PR DESCRIPTION
#### Context
Adds a warning when the databases do not set up properly using the databases instructions based on MyETM's readme.

#### Related
Goes with [this myetm PR](https://github.com/quintel/my-etm/pull/238)
Goes with [this etengine PR](https://github.com/quintel/etengine/pull/1733)

## Checklist
- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review
