### PR TITLE
Add link to data export in the description of the hydrogen mekko

### DIFF
--- a/config/locales/interface/output_elements/en_supply.yml
+++ b/config/locales/interface/output_elements/en_supply.yml
@@ -263,8 +263,8 @@ en:
         If there are indicated storage losses, this represents the amount of unused hydrogen from
         storage.
         </br></br>
-        More detailed categories of the hydrogen supply and demand can be found in
-        <a href = "/scenario/data/data_export/hourly-curves-for-hydrogen"> data export</a>.
+        More detailed categories of hydrogen supply and demand can be found in the
+        <a href="/scenario/data/data_export/hourly-curves-for-hydrogen">data export</a>.
     hydrogen_production:
       title: Hydrogen production per hour
       short_description:

--- a/config/locales/interface/output_elements/en_supply.yml
+++ b/config/locales/interface/output_elements/en_supply.yml
@@ -264,7 +264,7 @@ en:
         storage.
         </br></br>
         More detailed categories of the hydrogen supply and demand can be found in
-        <a href = "https://energytransitionmodel.com/scenario/data/data_export/hourly-curves-for-hydrogen"> data export</a>.
+        <a href = "/scenario/data/data_export/hourly-curves-for-hydrogen"> data export</a>.
     hydrogen_production:
       title: Hydrogen production per hour
       short_description:

--- a/config/locales/interface/output_elements/en_supply.yml
+++ b/config/locales/interface/output_elements/en_supply.yml
@@ -262,6 +262,9 @@ en:
         </br></br>
         If there are indicated storage losses, this represents the amount of unused hydrogen from
         storage.
+        </br></br>
+        More detailed categories of the hydrogen supply and demand can be found in
+        <a href = "https://energytransitionmodel.com/scenario/data/data_export/hourly-curves-for-hydrogen"> data export</a>.
     hydrogen_production:
       title: Hydrogen production per hour
       short_description:

--- a/config/locales/interface/output_elements/nl_supply.yml
+++ b/config/locales/interface/output_elements/nl_supply.yml
@@ -264,6 +264,9 @@ nl:
         back-up. Er wordt waterstof geïmporteerd via de import back-up in geval van een tekort aan waterstof.
         </br></br>
         Indien er opslagverliezen zijn, gaat dit om de hoeveelheid ongebruikte waterstof uit opslag.
+        </br></br>
+        Meer gedetailleerde categorieën in de vraag en aanbod van het centrale waterstofnet zijn te vinden bij
+        <a href = "https://energytransitionmodel.com/scenario/data/data_export/hourly-curves-for-hydrogen"> data export</a>.
     hydrogen_production:
       title: Waterstofproductie per uur
       short_description:

--- a/config/locales/interface/output_elements/nl_supply.yml
+++ b/config/locales/interface/output_elements/nl_supply.yml
@@ -266,7 +266,7 @@ nl:
         Indien er opslagverliezen zijn, gaat dit om de hoeveelheid ongebruikte waterstof uit opslag.
         </br></br>
         Meer gedetailleerde categorieën in de vraag en aanbod van het centrale waterstofnet zijn te vinden bij
-        <a href = "https://energytransitionmodel.com/scenario/data/data_export/hourly-curves-for-hydrogen"> data export</a>.
+        <a href = "/scenario/data/data_export/hourly-curves-for-hydrogen"> data-export</a>.
     hydrogen_production:
       title: Waterstofproductie per uur
       short_description:

--- a/config/locales/interface/output_elements/nl_supply.yml
+++ b/config/locales/interface/output_elements/nl_supply.yml
@@ -265,8 +265,9 @@ nl:
         </br></br>
         Indien er opslagverliezen zijn, gaat dit om de hoeveelheid ongebruikte waterstof uit opslag.
         </br></br>
-        Meer gedetailleerde categorieën in de vraag en aanbod van het centrale waterstofnet zijn te vinden bij
-        <a href = "/scenario/data/data_export/hourly-curves-for-hydrogen"> data-export</a>.
+        Meer gedetailleerde categorieën in vraag en aanbod van het centrale waterstofnet zijn te
+        vinden in de
+        <a href ="/scenario/data/data_export/hourly-curves-for-hydrogen">data-export</a>.
     hydrogen_production:
       title: Waterstofproductie per uur
       short_description:


### PR DESCRIPTION
#### Context
The labels in the hydrogen supply and demand chart have been simplified and some have been aggregated. For a more detailed categories of the hydrogen supply and demand, a link to the export data should be added to the description of the chart.

#### Implemented changes
A link is added to the description of the "Hydrogen supply and demand" chart (in English and Dutch).

#### Related

Closes issue https://github.com/quintel/etmodel/issues/4670

Goes with pull requests https://github.com/quintel/etmodel/pull/4703

## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review
