### PR TITLE
Fix _.include TypeError by using native Array.includes

### DIFF
--- a/app/assets/javascripts/common_interface.coffee
+++ b/app/assets/javascripts/common_interface.coffee
@@ -29,7 +29,7 @@ class @CommonInterface
 
   setup_browser_tweaks: ->
     # TODO: check if this is still needed, was added for an old bug - PZ
-    if _.include(['iPad', 'iPhone', 'iPod'], navigator.platform)
+    if ['iPad', 'iPhone', 'iPod'].includes(navigator.platform)
       $("#footer").css("position", "static")
 
     if $.browser.msie

--- a/app/assets/javascripts/lib/models/input_element_balancer.js
+++ b/app/assets/javascripts/lib/models/input_element_balancer.js
@@ -385,7 +385,7 @@
 
     this.__runOnSubordinates(method);
 
-    if (method === 'resolve' && _.include(SEND_ENTIRE_GROUP, groupName)) {
+    if (method === 'resolve' && SEND_ENTIRE_GROUP.includes(groupName)) {
       // ETengine wants the whole group to be marked dirty.
       for (var i = 0, length = this.views.length; i < length; i++) {
         this.views[i].model.markDirty();


### PR DESCRIPTION
#### Context

The Sentry issue attributed this to a lodash upgrade dropping _.include, suggesting a rename to _.includes. However, investigation showed that _ at runtime in the Sprockets bundle is actually Underscore.js (1.3.3), and _.includes doesn't exist there.

#### Implemented changes

Rather than depending on whichever _ library happens to be in scope, we replaced both calls with native Array.prototype.includes, which is the idiomatic modern JS approach and removes the dependency on any utility library entirely.

#### Related

Closes #4688

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
