### PR TITLE
Remove Sentry browser profiling

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -179,7 +179,6 @@ module ApplicationHelper
       if Settings.sentry_dsn
         json.sentry_dsn Settings.sentry_dsn
         json.sentry_traces Settings.sentry_traces
-        json.sentry_profiles Settings.sentry_profiles
       end
     end.html_safe
   end

--- a/app/javascript/sentry.ts
+++ b/app/javascript/sentry.ts
@@ -3,7 +3,6 @@ import * as Sentry from '@sentry/browser';
 declare const globals: {
   sentry_dsn?: string;
   sentry_traces?: number;
-  sentry_profiles?: number;
   release?: string;
   env?: string;
 };
@@ -17,16 +16,9 @@ if (globals && globals.sentry_dsn && enabledEnvs.includes(globals.env)) {
     environment: globals.env,
     integrations: [
       Sentry.browserTracingIntegration(),
-      Sentry.browserProfilingIntegration(),
     ],
 
     // Percentage of transactions to capture for tracing
     tracesSampleRate: globals.sentry_traces,
-
-    // Percentage of sampled transactions to profile
-    profileSessionSampleRate: globals.sentry_profiles,
-
-    // Automatically start/stop profiler based on tracing spans
-    profileLifecycle: 'trace',
   });
 }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -55,11 +55,10 @@ feedback_email: info@energytransitionmodel.com
 # Sentry
 # ------
 
-# Optionally send error messages and profiling data to the Sentry service by providing your
+# Optionally send error messages and tracing data to the Sentry service by providing your
 # Sentry details:
 sentry_dsn: <%= ENV['SENTRY_DSN'] %>
 sentry_traces: <%= ENV.fetch('SENTRY_TRACES', 0.1) %>
-sentry_profiles: <%= ENV.fetch('SENTRY_PROFILES', 0.1) %>
 
 # Mailchimp
 # ---------


### PR DESCRIPTION
#### Context

Sentry browser profiling was enabled but proved mostly unusable. The call tree was dominated by minified framework code even with source maps in place. We're paying for profiling hours with little actionable insight.

#### Implemented changes

- Removed `browserProfilingIntegration` from Sentry init
- Removed `profileSessionSampleRate` and `profileLifecycle` options
- Removed `sentry_profiles` from the globals passed to the frontend and from `settings.yml`

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
