### PR TITLE
Add direct emissions method with data export

### DIFF
--- a/config/interface/slides/data_export.yml
+++ b/config/interface/slides/data_export.yml
@@ -11,6 +11,10 @@
   position: 105
   sidebar_item_key: data_export
   output_element_key: sankey_energy_overview
+- key: data_export_emissions
+  position: 107
+  sidebar_item_key: data_export
+  output_element_key: co2_emissions
 - key: data_export_molecule_flows
   position: 110
   sidebar_item_key: data_export

--- a/config/locales/interface/slides/en_data.yml
+++ b/config/locales/interface/slides/en_data.yml
@@ -147,10 +147,13 @@ en:
       description: |
         Download detailed data about the direct greenhouse gas emissions of a scenario for the
         present and future year. Read more about how direct emissions are calculated in the
-        documentation.<br/><br/>
+        <a href="https://docs.energytransitionmodel.com/main/direct-emissions#principles"
+        target=\"_blank\">documentation</a>.<br/><br/>
         <b>Note:</b> for regional (Dutch) datasets, this data export does not yet include the
         results for <a href="/scenario/emissions/other_emissions/overview">other greenhouse gas
-        emissions</a>. Read more about this in the documentation.
+        emissions</a>. Read more about this in the
+        <a href="https://docs.energytransitionmodel.com/main/direct-emissions#method-implementation"
+        target=\"_blank\">documentation</a>.
         <ul class="data-download">
           <li>
             <a href="/passthru/%{scenario_id}/direct_emissions_present.csv" target="_blank">

--- a/config/locales/interface/slides/en_data.yml
+++ b/config/locales/interface/slides/en_data.yml
@@ -142,19 +142,24 @@ en:
           </li>
         </ul>
     data_export_emissions:
-      title: Yearly emissions
+      title: Yearly direct greenhouse gas emissions
       short_description:
       description: |
-        Download emissions data for all nodes, one CSV for the present year and one for the future year.
+        Download detailed data about the direct greenhouse gas emissions of a scenario for the
+        present and future year. Read more about how direct emissions are calculated in the
+        documentation.<br/><br/>
+        <b>Note:</b> for regional (Dutch) datasets, this data export does not yet include the
+        results for <a href="/scenario/emissions/other_emissions/overview">other greenhouse gas
+        emissions</a>. Read more about this in the documentation.
         <ul class="data-download">
           <li>
             <a href="/passthru/%{scenario_id}/direct_emissions_present.csv" target="_blank">
-              <span class="name">Emissions (present)</span>
+              <span class="name">Direct emissions (present)</span>
               <span class="filetype">CSV</span></a>
           </li>
           <li>
             <a href="/passthru/%{scenario_id}/direct_emissions_future.csv" target="_blank">
-              <span class="name">Emissions (future)</span>
+              <span class="name">Direct emissions (future)</span>
               <span class="filetype">CSV</span></a>
           </li>
         </ul>

--- a/config/locales/interface/slides/en_data.yml
+++ b/config/locales/interface/slides/en_data.yml
@@ -151,9 +151,7 @@ en:
         target=\"_blank\">documentation</a>.<br/><br/>
         <b>Note:</b> for regional (Dutch) datasets, this data export does not yet include the
         results for <a href="/scenario/emissions/other_emissions/overview">other greenhouse gas
-        emissions</a>. Read more about this in the
-        <a href="https://docs.energytransitionmodel.com/main/direct-emissions#method-implementation"
-        target=\"_blank\">documentation</a>.
+        emissions</a>. Read more about this in the above-mentioned documentation.
         <ul class="data-download">
           <li>
             <a href="/passthru/%{scenario_id}/direct_emissions_present.csv" target="_blank">

--- a/config/locales/interface/slides/en_data.yml
+++ b/config/locales/interface/slides/en_data.yml
@@ -141,6 +141,23 @@ en:
             <span class="filetype">1MB CSV</span></a>
           </li>
         </ul>
+    data_export_emissions:
+      title: Yearly emissions
+      short_description:
+      description: |
+        Download emissions data for all nodes, one CSV for the present year and one for the future year.
+        <ul class="data-download">
+          <li>
+            <a href="/passthru/%{scenario_id}/direct_emissions_present.csv" target="_blank">
+              <span class="name">Emissions (present)</span>
+              <span class="filetype">CSV</span></a>
+          </li>
+          <li>
+            <a href="/passthru/%{scenario_id}/direct_emissions_future.csv" target="_blank">
+              <span class="name">Emissions (future)</span>
+              <span class="filetype">CSV</span></a>
+          </li>
+        </ul>
     data_export_heat_network:
       title: Hourly curves for heat networks
       short_description:

--- a/config/locales/interface/slides/nl_data.yml
+++ b/config/locales/interface/slides/nl_data.yml
@@ -149,10 +149,13 @@ nl:
       description: |
         Download gedetailleerde data over de directe broeikasgasemissies van een scenario voor het
         heden en het toekomstjaar. Lees meer over hoe directe emissies worden berekend in de
-        documentatie.<br/><br/>
+        <a href="https://docs.energytransitionmodel.com/main/direct-emissions#principles"
+        target=\"_blank\">documentatie</a>.<br/><br/>
         <b>Let op:</b> voor regionale (Nederlandse) datasets bevat deze data-export nog niet de
         resultaten voor <a href="/scenario/emissions/other_emissions/overview">overige
-        broeikasgasemissies</a>. Lees meer hierover in de documentatie.
+        broeikasgasemissies</a>. Lees meer hierover in de
+        <a href="https://docs.energytransitionmodel.com/main/direct-emissions#method-implementation"
+        target=\"_blank\">documentatie</a>.
         <ul class="data-download">
           <li>
             <a href="/passthru/%{scenario_id}/direct_emissions_present.csv" target="_blank">

--- a/config/locales/interface/slides/nl_data.yml
+++ b/config/locales/interface/slides/nl_data.yml
@@ -144,19 +144,24 @@ nl:
           </li>
         </ul>
     data_export_emissions:
-      title: Jaarlijkse emissies
+      title: Jaarlijkse directe broeikasgasemissies
       short_description:
       description: |
-        Download emissiedata voor alle nodes, één CSV voor het huidige jaar en één voor het toekomstjaar.
+        Download gedetailleerde data over de directe broeikasgasemissies van een scenario voor het
+        heden en het toekomstjaar. Lees meer over hoe directe emissies worden berekend in de
+        documentatie.<br/><br/>
+        <b>Let op:</b> voor regionale (Nederlandse) datasets bevat deze data-export nog niet de
+        resultaten voor <a href="/scenario/emissions/other_emissions/overview">overige
+        broeikasgasemissies</a>. Lees meer hierover in de documentatie.
         <ul class="data-download">
           <li>
             <a href="/passthru/%{scenario_id}/direct_emissions_present.csv" target="_blank">
-              <span class="name">Emissies (huidig)</span>
+              <span class="name">Directe emissies (heden)</span>
               <span class="filetype">CSV</span></a>
           </li>
           <li>
             <a href="/passthru/%{scenario_id}/direct_emissions_future.csv" target="_blank">
-              <span class="name">Emissies (toekomst)</span>
+              <span class="name">Directe emissies (toekomst)</span>
               <span class="filetype">CSV</span></a>
           </li>
         </ul>

--- a/config/locales/interface/slides/nl_data.yml
+++ b/config/locales/interface/slides/nl_data.yml
@@ -143,6 +143,23 @@ nl:
             </a>
           </li>
         </ul>
+    data_export_emissions:
+      title: Jaarlijkse emissies
+      short_description:
+      description: |
+        Download emissiedata voor alle nodes, één CSV voor het huidige jaar en één voor het toekomstjaar.
+        <ul class="data-download">
+          <li>
+            <a href="/passthru/%{scenario_id}/direct_emissions_present.csv" target="_blank">
+              <span class="name">Emissies (huidig)</span>
+              <span class="filetype">CSV</span></a>
+          </li>
+          <li>
+            <a href="/passthru/%{scenario_id}/direct_emissions_future.csv" target="_blank">
+              <span class="name">Emissies (toekomst)</span>
+              <span class="filetype">CSV</span></a>
+          </li>
+        </ul>
     data_export_heat_network:
       title: Uurlijkse profielen voor warmtenetten
       short_description:

--- a/config/locales/interface/slides/nl_data.yml
+++ b/config/locales/interface/slides/nl_data.yml
@@ -149,13 +149,11 @@ nl:
       description: |
         Download gedetailleerde data over de directe broeikasgasemissies van een scenario voor het
         heden en het toekomstjaar. Lees meer over hoe directe emissies worden berekend in de
-        <a href="https://docs.energytransitionmodel.com/main/direct-emissions#principles"
+        <a href="https://docs.energytransitionmodel.com/main/direct-emissions"
         target=\"_blank\">documentatie</a>.<br/><br/>
         <b>Let op:</b> voor regionale (Nederlandse) datasets bevat deze data-export nog niet de
         resultaten voor <a href="/scenario/emissions/other_emissions/overview">overige
-        broeikasgasemissies</a>. Lees meer hierover in de
-        <a href="https://docs.energytransitionmodel.com/main/direct-emissions#method-implementation"
-        target=\"_blank\">documentatie</a>.
+        broeikasgasemissies</a>. Lees meer hierover in de bovengenoemde documentatie.
         <ul class="data-download">
           <li>
             <a href="/passthru/%{scenario_id}/direct_emissions_present.csv" target="_blank">


### PR DESCRIPTION
#### Context

This PR adds a new direct emissions method to the model, together with a detailed data export containing all greenhouse gas emissions of a scenario. 

#### Implemented changes
- New engine methods and node attributes that calculate relevant direct emissions, based on presence of (molecule) node group `emissions`
- Data processing pipeline that generates start year emissions data for country datasets, based on reported emission data from UNFCCC. Start year data is added as `emissions.csv` file to ETSource using a rake task. 
- New molecule nodes that read static emission data from `emissions.csv`, specified for co2 and other_ghg
- Detailed data export containing relevant direct reporting emission results for all relevant nodes, and categorises these into ETM sector and subsector. 

#### Related

Goes with pull requests:
- https://github.com/quintel/etengine/pull/1754
- https://github.com/quintel/atlas/pull/189
- https://github.com/quintel/etsource/pull/3444
- https://github.com/quintel/etmodel/pull/4719
- https://github.com/quintel/etdataset/pull/1087
- https://github.com/quintel/etlocal/pull/695
- https://github.com/quintel/documentation/pull/321

## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review
