### PR TITLE
Update hourly electricity price chart margins

### DIFF
--- a/app/assets/javascripts/d3/merit_order_price_curve.coffee
+++ b/app/assets/javascripts/d3/merit_order_price_curve.coffee
@@ -6,7 +6,7 @@ D3.merit_order_price_curve =
     margins:
       top: 20
       bottom: 20
-      left: 70
+      left: 85
       right: 20
       label_left: 25
 


### PR DESCRIPTION
#### Context
For 100 euros or more the unit fell off the x-axis margin.

<img width="1282" height="980" alt="image" src="https://github.com/user-attachments/assets/556e1300-7d5c-4b6e-8632-f8d43f3e4779" />

#### Implemented changes
The margins have been changed to allow for larger number prices.

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
