### PR TITLE
Add hide_label option to chart series to suppress duplicate legends

### DIFF
--- a/app/assets/javascripts/lib/models/chart.coffee
+++ b/app/assets/javascripts/lib/models/chart.coffee
@@ -226,7 +226,7 @@ class @Chart extends Backbone.Model
 
   target_series: -> @series.select (s) -> s.get('is_target_line')
 
-  year_1990_series: -> @series.select (s) -> s.get('is_1990')
+  year_1990_series: -> @series.select (s) -> s.get('is_1990') && !s.get('is_target_line')
 
   format_value: (value) =>
     Metric.autoscale_value(value, @get('unit'), 2)

--- a/app/javascript/charts/Legend.js
+++ b/app/javascript/charts/Legend.js
@@ -81,6 +81,10 @@ class Legend extends Backbone.View {
     const clickable = this.options.clickable;
 
     for (const series of this.options.items) {
+      if (series.get('hide_label')) {
+        continue;
+      }
+
       this.el.append(
         new LegendItem({
           clickable,

--- a/app/javascript/charts/StackedBar.js
+++ b/app/javascript/charts/StackedBar.js
@@ -11,8 +11,11 @@ const stack = d3.stack().offset(d3.stackOffsetDiverging);
  * Determines the opacity with which a target line should be drawn.
  */
 const targetLineOpacity = (serie) => {
+  const position = serie.get('target_line_position');
   const value =
-    serie.get('target_line_position') === '1' ? serie.present_value() : serie.future_value();
+    position === '0' ? serie.present_value() :
+    position === '1' ? serie.present_value() :
+    serie.future_value();
 
   return value === null ? 0 : 1;
 };
@@ -129,7 +132,8 @@ class StackedBar extends D3Chart {
       .attr('height', 2)
       .attr('width', () => this.x.bandwidth() * 1.2)
       .attr('x', (s) => {
-        const year = s.get('target_line_position') === '1' ? this.startYear : this.endYear;
+        const position = s.get('target_line_position');
+        const year = position === '0' ? 1990 : position === '1' ? this.startYear : this.endYear;
         return this.x(year) - this.x.bandwidth() * 0.1;
       })
       .attr('y', 0);
@@ -174,8 +178,11 @@ class StackedBar extends D3Chart {
       .style('opacity', targetLineOpacity)
       .transition(transition)
       .attr('y', (d) => {
+        const position = d.get('target_line_position');
         const value =
-          d.get('target_line_position') === '1' ? d.safe_present_value() : d.safe_future_value();
+          position === '0' ? d.safe_present_value() :
+          position === '1' ? d.safe_present_value() :
+          d.safe_future_value();
 
         return this.y(value);
       });

--- a/app/models/output_element_serie.rb
+++ b/app/models/output_element_serie.rb
@@ -82,7 +82,8 @@ class OutputElementSerie < YModel::Base
       group_translated: group_translated, # used to display groups in mekkos's & horizontal_stacked_bar
       is_target_line: is_target_line,
       target_line_position: target_line_position,
-      is_1990: is_1990
+      is_1990: is_1990,
+      hide_label: hide_label
     }
   end
   # rubocop:enable Metrics/LineLength

--- a/config/interface/output_element_series/direct_emissions_per_sector.yml
+++ b/config/interface/output_element_series/direct_emissions_per_sector.yml
@@ -253,6 +253,20 @@
   output_element_key: direct_emissions_per_sector
   key: direct_emissions_per_sector_bunkers_1990
 
+# 1990 total GHG emissions target line
+- label: direct_emissions_total_ghg
+  color: "#FF0000"
+  order_by: 295
+  group: ''
+  show_at_first: false
+  is_target_line: true
+  target_line_position: '0'
+  gquery: direct_emissions_total_ghg_1990_for_direct_emissions_chart
+  is_1990: true
+  dependent_on:
+  output_element_key: direct_emissions_per_sector
+  key: direct_emissions_per_sector_total_ghg_1990
+
 # net total GHG emissions
 - label: direct_emissions_total_ghg
   color: "#FF0000"

--- a/config/interface/output_element_series/direct_emissions_per_sector.yml
+++ b/config/interface/output_element_series/direct_emissions_per_sector.yml
@@ -131,6 +131,7 @@
   target_line_position: ''
   gquery: direct_emissions_energy_total_ghg_1990_for_direct_emissions_chart
   is_1990: true
+  hide_label: true
   dependent_on:
   output_element_key: direct_emissions_per_sector
   key: direct_emissions_per_sector_energy_1990
@@ -143,6 +144,7 @@
   target_line_position: ''
   gquery: direct_emissions_industry_total_ghg_1990_for_direct_emissions_chart
   is_1990: true
+  hide_label: true
   dependent_on:
   output_element_key: direct_emissions_per_sector
   key: direct_emissions_per_sector_industry_1990
@@ -155,6 +157,7 @@
   target_line_position: ''
   gquery: direct_emissions_transport_total_ghg_1990_for_direct_emissions_chart
   is_1990: true
+  hide_label: true
   dependent_on:
   output_element_key: direct_emissions_per_sector
   key: direct_emissions_per_sector_transport_1990
@@ -167,6 +170,7 @@
   target_line_position: ''
   gquery: direct_emissions_buildings_total_ghg_1990_for_direct_emissions_chart
   is_1990: true
+  hide_label: true
   dependent_on:
   output_element_key: direct_emissions_per_sector
   key: direct_emissions_per_sector_buildings_1990
@@ -179,6 +183,7 @@
   target_line_position: ''
   gquery: direct_emissions_households_total_ghg_1990_for_direct_emissions_chart
   is_1990: true
+  hide_label: true
   dependent_on:
   output_element_key: direct_emissions_per_sector
   key: direct_emissions_per_sector_households_1990
@@ -191,6 +196,7 @@
   target_line_position: ''
   gquery: direct_emissions_agriculture_total_ghg_1990_for_direct_emissions_chart
   is_1990: true
+  hide_label: true
   dependent_on:
   output_element_key: direct_emissions_per_sector
   key: direct_emissions_per_sector_agriculture_1990
@@ -203,6 +209,7 @@
   target_line_position: ''
   gquery: direct_emissions_other_total_ghg_1990_for_direct_emissions_chart
   is_1990: true
+  hide_label: true
   dependent_on:
   output_element_key: direct_emissions_per_sector
   key: direct_emissions_per_sector_other_1990
@@ -215,6 +222,7 @@
   target_line_position: ''
   gquery: direct_emissions_lulucf_total_ghg_1990_for_direct_emissions_chart
   is_1990: true
+  hide_label: true
   dependent_on:
   output_element_key: direct_emissions_per_sector
   key: direct_emissions_per_sector_lulucf_1990
@@ -227,6 +235,7 @@
   target_line_position: ''
   gquery: direct_emissions_waste_total_ghg_1990_for_direct_emissions_chart
   is_1990: true
+  hide_label: true
   dependent_on:
   output_element_key: direct_emissions_per_sector
   key: direct_emissions_per_sector_waste_1990
@@ -239,6 +248,7 @@
   target_line_position: ''
   gquery: direct_emissions_bunkers_total_ghg_1990_for_direct_emissions_chart
   is_1990: true
+  hide_label: true
   dependent_on:
   output_element_key: direct_emissions_per_sector
   key: direct_emissions_per_sector_bunkers_1990

--- a/config/interface/output_element_series/direct_emissions_per_sector.yml
+++ b/config/interface/output_element_series/direct_emissions_per_sector.yml
@@ -253,10 +253,10 @@
   output_element_key: direct_emissions_per_sector
   key: direct_emissions_per_sector_bunkers_1990
 
-# 1990 total GHG emissions target line
+# 1990, present and future net total GHG emissions target line
 - label: direct_emissions_total_ghg
   color: "#FF0000"
-  order_by: 295
+  order_by: 300
   group: ''
   show_at_first: false
   is_target_line: true
@@ -266,11 +266,9 @@
   dependent_on:
   output_element_key: direct_emissions_per_sector
   key: direct_emissions_per_sector_total_ghg_1990
-
-# net total GHG emissions
 - label: direct_emissions_total_ghg
   color: "#FF0000"
-  order_by: 300
+  order_by: 310
   group: ''
   show_at_first: false
   is_target_line: true
@@ -282,7 +280,7 @@
   key: direct_emissions_per_sector_total_ghg_present
 - label: direct_emissions_total_ghg
   color: "#FF0000"
-  order_by: 310
+  order_by: 320
   group: ''
   show_at_first: false
   is_target_line: true

--- a/spec/models/output_element_serie_spec.rb
+++ b/spec/models/output_element_serie_spec.rb
@@ -23,11 +23,18 @@ describe OutputElementSerie do
     it { is_expected.to respond_to(:is_target_line) }
     it { is_expected.to respond_to(:target_line_position) }
     it { is_expected.to respond_to(:is_1990) }
+    it { is_expected.to respond_to(:hide_label) }
 
     # methods
     it { is_expected.to respond_to(:title_translated) }
     it { is_expected.to respond_to(:group_translated) }
     it { is_expected.to respond_to(:json_attributes) }
     it { is_expected.to respond_to(:url_in_etengine) }
+  end
+
+  describe '#json_attributes' do
+    subject { described_class.new(hide_label: true).json_attributes }
+
+    it { is_expected.to include(hide_label: true) }
   end
 end


### PR DESCRIPTION
#### Context
This PR adds a hide_label attribute to chart series to prevent 1990 reference lines from cluttering
the legend on the Direct GHG Emissions chart. The `hide_label` attribute is available generally, and applied only to the 1990 direct emissions chart currently.

Result: Reference lines remain visible on the chart but no longer create redundant legend entries.
#### Implemented changes
- Add hide_label boolean to OutputElementSerie model and JSON serialization
- Update Legend.js to skip rendering items where hide_label: true
- Apply hide_label: true to all 10 sector 1990 reference lines in the Direct Emissions chart config

## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review

Goes with [this documentation PR](https://github.com/quintel/documentation/pull/328)