### PR TITLE
Announcement banner

### DIFF
--- a/app/assets/stylesheets/_flash.sass
+++ b/app/assets/stylesheets/_flash.sass
@@ -1,3 +1,39 @@
+$announcement-height: 34px
+
+#announcement
+  background-color: #fffced
+  border-bottom: 1px solid #e2d278
+  box-sizing: border-box
+  height: $announcement-height
+  text-align: center
+
+  p
+    line-height: $announcement-height - 2px
+    margin: 0
+    overflow: hidden
+    padding: 0 10px
+    text-overflow: ellipsis
+    white-space: nowrap
+
+// The model page fixes its header and scenario nav to the viewport. A fixed child of a flex
+// container sits at the top of that container whatever precedes it, so the nav is drawn over the
+// banner. Pin the banner too, and move everything below it down by its height.
+body#model:not(.liteui)
+  #announcement
+    position: fixed
+    top: 57px
+    width: 100%
+    z-index: 99
+
+  #announcement ~ #scenario-nav
+    top: 57px + $announcement-height
+
+  #announcement ~ .flex-wrapper
+    padding-top: 41px + $announcement-height
+
+    #sidebar
+      height: calc(100% - 68px - 42px - 57px - #{$announcement-height})
+
 #flash
   background-color: #FFF1A8
   background-image: linear-gradient(#fffad7, #fff1a8)

--- a/app/assets/stylesheets/_liteui.sass
+++ b/app/assets/stylesheets/_liteui.sass
@@ -2,7 +2,7 @@
 // of the extraneous elements such that the tabs, slides, and sliders may be
 // shown in a small iframe.
 body.liteui
-  header#top, #scenario-nav, footer, #title .help
+  header#top, #announcement, #scenario-nav, footer, #title .help
     display: none !important
 
   #wrapper, #content

--- a/app/models/my_etm/announcement.rb
+++ b/app/models/my_etm/announcement.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module MyEtm
+  # Site-wide messages, such as planned maintenance notices, configured in the MyETM admin panel.
+  #
+  # The banner is never important enough to break a page, so a failure to reach MyETM is reported
+  # and treated as "no announcements".
+  class Announcement < ActiveResource::Base
+    self.site = "#{Settings.identity.issuer}/api/v1"
+
+    # Announcements are fetched while rendering a page, so a slow MyETM may not hold up the
+    # response.
+    self.timeout = 2
+
+    CACHE_TTL = 5.minutes
+
+    def self.all_active
+      Rails.cache.fetch(:announcements, expires_in: CACHE_TTL) { find(:all).to_a }
+    rescue StandardError => e
+      Sentry.capture_exception(e)
+      []
+    end
+
+    # The message in the given locale, falling back to the other language when it is untranslated.
+    def body(locale)
+      locale.to_s == 'nl' ? body_nl.presence || body_en : body_en.presence || body_nl
+    end
+  end
+end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -31,6 +31,7 @@
     #wrapper
       = render "layouts/etm/header"
       #content
+        = render "layouts/etm/announcements"
         - if content_for?(:flash)
           = yield :flash
         - else

--- a/app/views/layouts/etm/_announcements.html.haml
+++ b/app/views/layouts/etm/_announcements.html.haml
@@ -1,0 +1,6 @@
+- messages = MyEtm::Announcement.all_active.filter_map { |announcement| announcement.body(I18n.locale).presence }
+
+- if messages.any?
+  #announcement
+    - messages.each do |message|
+      %p{ title: message }= message


### PR DESCRIPTION
#### Context

When making infrastructure changes to the server or any other kind of maintenance we did not have a way to announce this, therefore the intention is to add a simple way to enable/disable a banner and change the text at any given time without having to cherry pick commits.

#### Implemented changes

- `app/models/my_etm/announcement.rb` — ActiveResource client mirroring `MyEtm::Version`. 5-minute cache, 2s timeout, failures reported to Sentry and treated as "no announcements" so a banner can never break a page. Picks the locale, falls back when untranslated.
- `app/views/layouts/etm/_announcements.html.haml` — renders the banner, skips blank messages
- `app/views/layouts/application.html.haml` — one line; covers the whole site, since `landing`, `etm`, `static_page` and `compare` all delegate to this layout
- `app/assets/stylesheets/_flash.sass` — banner styling + model-page offsets
- `app/assets/stylesheets/_liteui.sass` — hides the banner in the embedded iframe view

#### Related

- etmodel: https://github.com/quintel/etmodel/pull/4770 [This one]
- my-etm: https://github.com/quintel/my-etm/pull/289


## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
