### PR TITLE
2025 internal docker network

### DIFF
--- a/.semaphore/deploy_production.yml
+++ b/.semaphore/deploy_production.yml
@@ -3,7 +3,7 @@ name: Deploy to production
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu2004
+    os_image: ubuntu2404
 blocks:
   - name: Docker
     task:

--- a/.semaphore/deploy_stable.yml
+++ b/.semaphore/deploy_stable.yml
@@ -3,7 +3,7 @@ name: Deploy to stable
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu2004
+    os_image: ubuntu2404
 blocks:
   - name: Docker
     task:

--- a/.semaphore/deploy_staging.yml
+++ b/.semaphore/deploy_staging.yml
@@ -3,7 +3,7 @@ name: Deploy to staging
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu2004
+    os_image: ubuntu2404
 blocks:
   - name: Docker
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,7 +3,7 @@ name: Test ETModel
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu2004
+    os_image: ubuntu2404
 blocks:
   - name: RSpec
     task:
@@ -21,7 +21,9 @@ blocks:
           commands:
             - checkout
             - sem-service start mysql 8
-            - sem-version node 16
+            - sudo apt-get update
+            - sudo apt-get install -y libmysqlclient-dev
+            - sem-version node 18
             - cache restore
             - bundle config set --local deployment 'true'
             - gem update --system

--- a/app/models/engine/area.rb
+++ b/app/models/engine/area.rb
@@ -12,7 +12,7 @@ class Engine::Area < ActiveResource::Base
     neighbourhood_be
   )
 
-  self.site = "#{Settings.ete_url}/api/v3"
+  self.site = "#{Settings.ete_internal_url.presence || Settings.ete_url}/api/v3"
 
   # This list of attributes is used in the forms where you can set the
   # area dependencies for an object, such as the input_elements

--- a/app/models/nasty_proxy.rb
+++ b/app/models/nasty_proxy.rb
@@ -11,5 +11,5 @@ require 'httparty'
 #
 class NastyProxy
   include HTTParty
-  base_uri Settings.ete_url
+  base_uri(Settings.ete_internal_url.presence || Settings.ete_url)
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -83,9 +83,16 @@ identity:
   client_id: <%= ENV['IDENTITY_CLIENT_ID'] %>
   client_secret: <%= ENV['IDENTITY_CLIENT_SECRET'] %>
   client_uri: <%= ENV.fetch('IDENTITY_CLIENT_URI', 'http://localhost:3001') %>
-  resource_uri: <%= ENV.fetch('ETE_URL', 'http://localhost:3000') %>
+  resource_uri: <%= ENV.fetch('ETE_INTERNAL_URL', ENV.fetch('ETE_URL', 'http://localhost:3000')) %>
 
 ete_url: <%= ENV.fetch('ETE_URL', 'http://localhost:3000') %>
+
+# Server-side-only base URL for ETEngine, for when both apps share an internal Docker network and
+# can skip the public vhost. Resolves only inside Docker and is not to be used in browser/client.
+# Blank where there is no such network, so read it with a fallback to the public url:
+#    `Settings.ete_internal_url.presence || Settings.ete_url`
+# Not defaulted here because per-environment files override ete_url after this file is parsed.
+ete_internal_url: <%= ENV['ETE_INTERNAL_URL'] %>
 
 # ESDL
 # ----

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -9,4 +9,4 @@ partners_url: https://energytransitionmodel.com
 identity:
   client_uri: <%= ENV.fetch('IDENTITY_CLIENT_URI', 'https://energytransitionmodel.com') %>
   issuer: <%= ENV.fetch('IDP_URL', 'https://my.energytransitionmodel.com') %>
-  resource_uri: <%= ENV.fetch('ETE_URL', 'https://engine.energytransitionmodel.com') %>
+  resource_uri: <%= ENV.fetch('ETE_INTERNAL_URL', ENV.fetch('ETE_URL', 'https://engine.energytransitionmodel.com')) %>

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -2,6 +2,10 @@
 #          have to be manually adapted (s. spec_helper.rb -> default_cassette_options -> :record) or re-recorded
 ete_url: https://beta-engine.energytransitionmodel.com
 
+# WARNING: Keep this key, and keep it blank. Stops an ETE_INTERNAL_URL exported in your
+#          shell from repointing Engine::Area / NastyProxy off the cassette host above.
+ete_internal_url:
+
 incoming_webhook_keys:
   mailchimp: abc
 
@@ -9,3 +13,4 @@ identity:
   client_id: client_id_123
   client_secret: client_secret_123
   client_uri: http://localhost:3000
+  resource_uri: http://localhost:3000


### PR DESCRIPTION
#### Context

Necessary changes to set 2025-01 also with a internal docker network.

#### Implemented changes

* Cherry-pick of fd219b2 form 2025-sso, so semaphore workflows stop failing
* Cherry-pick of 691bb6940 from master, so the stable image can read
`ETE_INTERNAL_URL` once the internal Docker bridge reaches the stable server:
  - `config/settings.yml` — new server-only `ete_internal_url` key; `identity.resource_uri` prefers it over `ETE_URL`
  - `config/settings/production.yml` — same fallback chain (this is the file stable uses)
  - `app/models/engine/area.rb`, `app/models/nasty_proxy.rb` — read `ete_internal_url.presence || ete_url`
  - `config/settings/test.yml` — pins the key blank so a shell-exported value can't move the specs off the cassette host

No behaviour change until ansible sets the variable: unset, everything falls back to `ETE_URL`.

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
