### PR TITLE
Changed chart description

### DIFF
--- a/config/locales/interface/output_elements/en_emissions.yml
+++ b/config/locales/interface/output_elements/en_emissions.yml
@@ -51,6 +51,12 @@ en:
         This chart compares total GHG emissions per IPCC CRT category in 1990, the present and the
         future. The year 1990 is often used as a reference year in emission targets.
         <br/><br/>
+        The categories are not shown in numerical order, on purpose. Categories from the same ETM
+        sector are grouped together, so they can be compared to the
+        <a href="#" class="open_chart" data-chart-key="direct_emissions_per_sector"
+        data-chart-location="side">direct emissions chart</a>, which uses the other standard ETM
+        categories.
+        <br/><br/>
         <b>Note: the emissions are calculated based on direct emissions.</b> This emissions method
         is currently in beta release and is not yet completely available for regional (Dutch)
         datasets. Read more in the

--- a/config/locales/interface/output_elements/en_emissions.yml
+++ b/config/locales/interface/output_elements/en_emissions.yml
@@ -51,11 +51,11 @@ en:
         This chart compares total GHG emissions per IPCC CRT category in 1990, the present and the
         future. The year 1990 is often used as a reference year in emission targets.
         <br/><br/>
-        The categories are not shown in numerical order, on purpose. Categories from the same ETM
-        sector are grouped together, so they can be compared to the
+        The IPCC categories are intentionally shown in custom order. Certain categories
+        are grouped together so that the chart can be compared with the
         <a href="#" class="open_chart" data-chart-key="direct_emissions_per_sector"
-        data-chart-location="side">direct emissions chart</a>, which uses the other standard ETM
-        categories.
+        data-chart-location="side">direct emissions chart</a>, which uses the standard ETM
+        sectors.
         <br/><br/>
         <b>Note: the emissions are calculated based on direct emissions.</b> This emissions method
         is currently in beta release and is not yet completely available for regional (Dutch)

--- a/config/locales/interface/output_elements/nl_emissions.yml
+++ b/config/locales/interface/output_elements/nl_emissions.yml
@@ -50,6 +50,11 @@ nl:
         Deze grafiek vergelijkt de uitstoot van broeikasgassen per IPCC CRT categorie,
         in 1990, het heden en de toekomst. Het jaar 1990 wordt vaak als referentiejaar
         gebruikt in doelstellingen omtrent broeikasgasemissies.<br/><br/>
+        De categorieën staan bewust niet op numerieke volgorde. Categorieën uit
+        dezelfde ETM-sector staan bij elkaar, zodat ze vergeleken kunnen worden met de andere
+        <a href="#" class="open_chart" data-chart-key="direct_emissions_per_sector"
+        data-chart-location="side">directe emissies grafiek</a>, die de standaard
+        ETM-categorieën gebruikt.<br/><br/>
         <b>Let op: de emissies zijn berekend op basis van directe emissies.</b> Deze
         emissiemethode is momenteel in beta release en is nog niet volledig beschikbaar voor de
         regionale (Nederlandse) datasets. Lees hierover meer in de

--- a/config/locales/interface/output_elements/nl_emissions.yml
+++ b/config/locales/interface/output_elements/nl_emissions.yml
@@ -50,11 +50,11 @@ nl:
         Deze grafiek vergelijkt de uitstoot van broeikasgassen per IPCC CRT categorie,
         in 1990, het heden en de toekomst. Het jaar 1990 wordt vaak als referentiejaar
         gebruikt in doelstellingen omtrent broeikasgasemissies.<br/><br/>
-        De categorieën staan bewust niet op numerieke volgorde. Categorieën uit
-        dezelfde ETM-sector staan bij elkaar, zodat ze vergeleken kunnen worden met de andere
+        De IPCC categorieën staan bewust in aangepaste volgorde. Bepaalde categorieën zijn
+        gegroepeerd zodat de grafiek vergeleken kan worden met de andere
         <a href="#" class="open_chart" data-chart-key="direct_emissions_per_sector"
-        data-chart-location="side">directe emissies grafiek</a>, die de standaard
-        ETM-categorieën gebruikt.<br/><br/>
+        data-chart-location="side">directe emissies grafiek</a>, welke de standaard
+        ETM sectoren gebruikt.<br/><br/>
         <b>Let op: de emissies zijn berekend op basis van directe emissies.</b> Deze
         emissiemethode is momenteel in beta release en is nog niet volledig beschikbaar voor de
         regionale (Nederlandse) datasets. Lees hierover meer in de


### PR DESCRIPTION
#### Context
In the IPCC emissions chart the categories are not shown in order

#### Implemented changes
Changed chart description to refer to the other direct emissions chart and explain why the categories are not shown in ascending order

#### Related
Closes issue ...
Goes with pull requests ...

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
