### PR TITLE
Inline inputs for collections MVP

### DIFF
--- a/app/models/slide_presenter.rb
+++ b/app/models/slide_presenter.rb
@@ -13,7 +13,7 @@ class SlidePresenter
     slides =
       slides.sort_by do |slide|
         [slide.sidebar_item.tab.position,
-         slide.sidebar_item.position,
+         SlidePresenter.sidebar_item_position(slide),
          slide.position]
       end
 
@@ -34,6 +34,15 @@ class SlidePresenter
     [translate_item(:tabs, @slide.sidebar_item.tab),
      translate_item(:sidebar_items, @slide.sidebar_item),
      translate_item(:slides, @slide)]
+  end
+
+  def self.sidebar_item_position(slide)
+    if parent_item = slide.sidebar_item.parent_key
+      SidebarItem.find_by_key(parent_item).position +
+        slide.sidebar_item.position / 10
+    else
+      slide.sidebar_item.position
+    end
   end
 
   def inputs

--- a/app/models/slide_presenter.rb
+++ b/app/models/slide_presenter.rb
@@ -30,11 +30,7 @@ class SlidePresenter
 
   private
 
-  def path
-    [translate_item(:tabs, @slide.sidebar_item.tab),
-     translate_item(:sidebar_items, @slide.sidebar_item),
-     translate_item(:slides, @slide)]
-  end
+
 
   def self.sidebar_item_position(slide)
     if parent_item = slide.sidebar_item.parent_key
@@ -43,6 +39,22 @@ class SlidePresenter
     else
       slide.sidebar_item.position
     end
+  end
+
+  def path
+    [translate_item(:tabs, @slide.sidebar_item.tab),
+     sidebar_item_translation,
+     translate_item(:slides, @slide)]
+  end
+
+  def sidebar_item_translation
+    translation = translate_item(:sidebar_items, @slide.sidebar_item)
+
+    prefix = if parent_item = @slide.sidebar_item.parent_key
+      translate_item(:sidebar_items, SidebarItem.find_by_key(parent_item))
+    end
+
+    prefix ? "#{prefix} - #{translation}" : translation
   end
 
   def inputs

--- a/app/models/slide_presenter.rb
+++ b/app/models/slide_presenter.rb
@@ -35,7 +35,7 @@ class SlidePresenter
   def self.sidebar_item_position(slide)
     if parent_item = slide.sidebar_item.parent_key
       SidebarItem.find_by_key(parent_item).position +
-        slide.sidebar_item.position / 10
+        slide.sidebar_item.position / 10.0
     else
       slide.sidebar_item.position
     end

--- a/config/interface/input_elements/demand_industry_steel.yml
+++ b/config/interface/input_elements/demand_industry_steel.yml
@@ -2,7 +2,7 @@
 - key: industry_steel_production
   step_value: 0.1
   unit: "%"
-  position: 100
+  position: 1
   slide_key: demand_industry_steel
 
 - key: industry_steel_blastfurnace_bof_share
@@ -10,7 +10,7 @@
   step_value: 0.1
   unit: "%"
   interface_group: production_route
-  position: 200
+  position: 2
   slide_key: demand_industry_steel
   related_node: industry_steel_blastfurnace_bof_production
 - key: industry_steel_dri_network_gas_share
@@ -18,7 +18,7 @@
   step_value: 0.1
   unit: "%"
   interface_group: production_route
-  position: 205
+  position: 3
   slide_key: demand_industry_steel
   related_node: industry_steel_dri_network_gas_production
 - key: industry_steel_dri_hydrogen_share
@@ -26,7 +26,7 @@
   step_value: 0.1
   unit: "%"
   interface_group: production_route
-  position: 210
+  position: 4
   slide_key: demand_industry_steel
   related_node: industry_steel_dri_hydrogen_production
 - key: industry_steel_cyclonefurnace_bof_share
@@ -34,7 +34,7 @@
   step_value: 0.1
   unit: "%"
   interface_group: production_route
-  position: 215
+  position: 5
   slide_key: demand_industry_steel
   related_node: industry_steel_cyclonefurnace_bof_production
 - key: industry_steel_scrap_hbi_eaf_share
@@ -42,14 +42,14 @@
   step_value: 0.1
   unit: "%"
   interface_group: production_route
-  position: 220
+  position: 6
   slide_key: demand_industry_steel
   related_node: industry_steel_scrap_hbi_eaf_production
 
 - key: industry_steel_cyclonefurnace_bof_wood_pellets_share
   step_value: 0.1
   unit: "%"
-  position: 300
+  position: 7
   interface_group: biomass_input
   slide_key: demand_industry_steel
   related_node: industry_steel_cyclonefurnace_bof_production


### PR DESCRIPTION
#### Context
This is part of the MVP for enhanced workflows for collections: inline editable inputs, and collection IDs in the collections app. Making it possible to edit inputs in Collections without opening ETModel.

Pending UI feedback and network use and cache enhancements in a follow up PR.

#### Implemented changes
Makes inputs inline editable, removing the need for the ETModel iframe.
Adds a cache for sessions, which is invalidated by a webhook originating from the engine, on session update. 
Use collection IDs instead of session IDs in the url

#### Related

Goes with pull requests 
myetm -> quintel/myetm#308
etengine -> quintel/etengine#1806
etmodel -> quintel/etmodel#4807
collections -> quintel/multi-year-charts#130

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review

